### PR TITLE
signing_keys JSON

### DIFF
--- a/management/client.go
+++ b/management/client.go
@@ -46,7 +46,7 @@ type Client struct {
 	JWTConfiguration  *ClientJWTConfiguration `json:"jwt_configuration,omitempty"`
 
 	// Client signing keys
-	SigningKeys   []map[string]string `json:"-"`
+	SigningKeys   []map[string]string `json:"signing_keys,omitempty"`
 	EncryptionKey map[string]string   `json:"encryption_key,omitempty"`
 	SSO           *bool               `json:"sso,omitempty"`
 
@@ -86,6 +86,14 @@ type Client struct {
 func (c *Client) String() string {
 	b, _ := json.MarshalIndent(c, "", "  ")
 	return string(b)
+}
+
+// MarshalJSON encodes the client structure to JSON excluding the signing_keys field
+func (c *Client) MarshalJSON()([]byte, error) {
+	copy := *c
+	copy.SigningKeys = nil
+	// Marshal copy here, not &copy, to avoid recursion
+	return json.Marshal(copy)
 }
 
 type ClientJWTConfiguration struct {

--- a/management/client.go
+++ b/management/client.go
@@ -88,14 +88,6 @@ func (c *Client) String() string {
 	return string(b)
 }
 
-// MarshalJSON encodes the client structure to JSON excluding the signing_keys field
-func (c *Client) MarshalJSON()([]byte, error) {
-	copy := *c
-	copy.SigningKeys = nil
-	// Marshal copy here, not &copy, to avoid recursion
-	return json.Marshal(copy)
-}
-
 type ClientJWTConfiguration struct {
 	// The amount of seconds the JWT will be valid (affects exp claim)
 	LifetimeInSeconds *int `json:"lifetime_in_seconds,omitempty"`

--- a/management/client_test.go
+++ b/management/client_test.go
@@ -48,6 +48,7 @@ func TestClient(t *testing.T) {
 
 		c.ClientID = nil                       // read-only
 		c.JWTConfiguration.SecretEncoded = nil // read-only
+		c.SigningKeys = nil                    // read-only
 		c.Description = auth0.String(strings.Replace(auth0.StringValue(c.Description), "just", "more than", 1))
 
 		err = m.Client.Update(id, c)


### PR DESCRIPTION
While extending the yieldr auth0 terraform provider to add a new client data resource, I noticed that the auth0 client was ignoring the signing_keys part of the client response. This PR now respects signing_keys in the Auth0 response.

The Auth0 API insists that the field isn't present on submission, so I've written a custom marshaller which makes a copy of the structure and sets the signing_keys field to nil before marshalling.

I was in two (or more...) minds on how to do this.  The usual approach seems to be to duplicate the structure with the necessary json tags, but for such a large structure, that would be a pain to maintain.

Another approach could be to have two structs, one of which omits the field entirely, but that would constitute a breaking change:

```
type ClientPost struct {
 ... all fields except SigningKeys
}

type Client struct {
  SigningKeys []map...
  ClientPost
}
```