### PR TITLE
Add 'nickname' to user

### DIFF
--- a/management/user.go
+++ b/management/user.go
@@ -22,6 +22,9 @@ type User struct {
 	// The user's username. Only valid if the connection requires a username
 	Username *string `json:"username,omitempty"`
 
+	// The user's nickname
+	Nickname *string `json:"nickname,omitempty"`
+
 	// The user's password (mandatory for non SMS connections)
 	Password *string `json:"password,omitempty"`
 

--- a/management/user_test.go
+++ b/management/user_test.go
@@ -12,7 +12,7 @@ func TestUser(t *testing.T) {
 		Connection: auth0.String("Username-Password-Authentication"),
 		Email:      auth0.String("chuck@chucknorris.com"),
 		Password:   auth0.String("Passwords hide their Chuck"),
-        Nickname:   auth0.String("Chucky")
+		Nickname:   auth0.String("Chucky"),
 		UserMetadata: map[string]interface{}{
 			"favourite_attack": "roundhouse_kick",
 		},

--- a/management/user_test.go
+++ b/management/user_test.go
@@ -12,6 +12,7 @@ func TestUser(t *testing.T) {
 		Connection: auth0.String("Username-Password-Authentication"),
 		Email:      auth0.String("chuck@chucknorris.com"),
 		Password:   auth0.String("Passwords hide their Chuck"),
+        Nickname:   auth0.String("Chucky")
 		UserMetadata: map[string]interface{}{
 			"favourite_attack": "roundhouse_kick",
 		},


### PR DESCRIPTION
The Auth0 API v2 describes an optional `nickname` field in the `user` endpoint
https://auth0.com/docs/api/management/v2#!/Users/get_users