### PR TITLE
Support for Roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Following is a list of supported Auth0 resources.
 - [x] [Grants](https://auth0.com/docs/api/management/v2#!/Grants/get_grants)
 - [x] [Logs](https://auth0.com/docs/api/management/v2#!/Logs/get_logs)
 - [x] [Resource Servers (APIs)](https://auth0.com/docs/api/management/v2#!/Resource_Servers/get_resource_servers)
+- [x] [Roles](https://auth0.com/docs/api/management/v2#!/Roles)
 - [x] [Rules](https://auth0.com/docs/api/management/v2#!/Rules/get_rules)
 - [x] [Rules Configs](https://auth0.com/docs/api/management/v2#!/Rules_Configs/get_rules_configs)
 - [ ] [User Blocks](https://auth0.com/docs/api/management/v2#!/User_Blocks/get_user_blocks)

--- a/management/management.go
+++ b/management/management.go
@@ -41,6 +41,9 @@ type Management struct {
 	// Log reads Auth0 Logs.
 	Log *LogManager
 
+	// RoleManager manages Auth0 Roles.
+	Role *RoleManager
+
 	// RuleManager manages Auth0 Rules.
 	Rule *RuleManager
 
@@ -105,6 +108,7 @@ func New(domain, clientID, clientSecret string, options ...apiOption) (*Manageme
 	m.Grant = NewGrantManager(m)
 	m.Log = NewLogManager(m)
 	m.ResourceServer = NewResourceServerManager(m)
+	m.Role = NewRoleManager(m)
 	m.Rule = NewRuleManager(m)
 	m.RuleConfig = NewRuleConfigManager(m)
 	m.EmailTemplate = NewEmailTemplateManager(m)

--- a/management/role.go
+++ b/management/role.go
@@ -1,0 +1,98 @@
+package management
+
+import "encoding/json"
+
+type Role struct {
+	// A unique ID for the role.
+	ID *string `json:"id,omitempty"`
+
+	// The name of the role created.
+	Name *string `json:"name,omitempty"`
+
+	// A description of the role created.
+	Description *string `json:"description,omitempty"`
+}
+
+type Permission struct {
+	// The resource server that the permission is attached to.
+	ResourceServerIdentifier *string `json:"resource_server_identifier,omitempty"`
+
+	// The name of the resource server.
+	ResourceServerName *string `json:"resource_server_name,omitempty"`
+
+	// The name of the permission.
+	Name *string `json:"permission_name,omitempty"`
+
+	// The description of the permission.
+	Description *string `json:"description,omitempty"`
+}
+
+func (r *Role) String() string {
+	b, _ := json.MarshalIndent(r, "", "  ")
+	return string(b)
+}
+
+type RoleManager struct {
+	m *Management
+}
+
+func NewRoleManager(m *Management) *RoleManager {
+	return &RoleManager{m}
+}
+
+func (rm *RoleManager) Create(r *Role) error {
+	return rm.m.post(rm.m.uri("roles"), r)
+}
+
+func (rm *RoleManager) Read(id string, opts ...reqOption) (*Role, error) {
+	r := new(Role)
+	err := rm.m.get(rm.m.uri("roles", id)+rm.m.q(opts), r)
+	return r, err
+}
+
+func (rm *RoleManager) Update(id string, r *Role) (err error) {
+	return rm.m.patch(rm.m.uri("roles", id), r)
+}
+
+func (rm *RoleManager) Delete(id string) (err error) {
+	return rm.m.delete(rm.m.uri("roles", id))
+}
+
+func (rm *RoleManager) List(opts ...reqOption) ([]*Role, error) {
+	var r []*Role
+	err := rm.m.get(rm.m.uri("roles")+rm.m.q(opts), &r)
+	return r, err
+}
+
+func (rm *RoleManager) AssignUsers(id string, users ...*User) error {
+	u := make(map[string][]*string)
+	u["users"] = make([]*string, len(users))
+	for i, user := range users {
+		u["users"][i] = user.ID
+	}
+	return rm.m.post(rm.m.uri("roles", id, "users"), &u)
+}
+
+func (rm *RoleManager) Users(id string, opts ...reqOption) ([]*User, error) {
+	var u []*User
+	err := rm.m.get(rm.m.uri("roles", id, "users")+rm.m.q(opts), &u)
+	return u, err
+}
+
+func (rm *RoleManager) AssignPermissions(id string, permissions ...*Permission) error {
+	p := make(map[string][]*Permission)
+	p["permissions"] = permissions
+	return rm.m.post(rm.m.uri("roles", id, "permissions"), &p)
+}
+
+func (rm *RoleManager) Permissions(id string, opts ...reqOption) ([]*Permission, error) {
+	var p []*Permission
+	err := rm.m.get(rm.m.uri("roles", id, "permissions")+rm.m.q(opts), &p)
+	return p, err
+}
+
+func (rm *RoleManager) UnassignPermissions(id string, permissions ...*Permission) error {
+	p := make(map[string][]*Permission)
+	p["permissions"] = permissions
+	return rm.m.request("DELETE", rm.m.uri("roles", id, "permissions"), &p)
+}

--- a/management/role_test.go
+++ b/management/role_test.go
@@ -1,0 +1,142 @@
+package management
+
+import (
+	"testing"
+	"time"
+
+	"gopkg.in/auth0.v1"
+)
+
+func TestRole(t *testing.T) {
+
+	var err error
+
+	r := &Role{
+		Name:        auth0.String("admin"),
+		Description: auth0.String("Administrator"),
+	}
+
+	u := &User{
+		Connection: auth0.String("Username-Password-Authentication"),
+		Email:      auth0.String("chuck@chucknorris.com"),
+		Password:   auth0.String("Passwords hide their Chuck"),
+	}
+	err = m.User.Create(u)
+	if err != nil {
+		t.Error(err)
+	}
+	defer m.User.Delete(auth0.StringValue(u.ID))
+
+	s := &ResourceServer{
+		Name: auth0.Stringf("Test Role (%s)",
+			time.Now().Format(time.StampMilli)),
+		Identifier: auth0.String("https://api.example.com/role"),
+		Scopes: []*ResourceServerScope{
+			{
+				Value:       auth0.String("read:resource"),
+				Description: auth0.String("Read Resource"),
+			},
+			{
+				Value:       auth0.String("update:resource"),
+				Description: auth0.String("Update Resource"),
+			},
+		},
+	}
+	err = m.ResourceServer.Create(s)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer m.ResourceServer.Delete(auth0.StringValue(s.ID))
+
+	t.Run("Create", func(t *testing.T) {
+		err = m.Role.Create(r)
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Logf("%v\n", r)
+	})
+
+	t.Run("Read", func(t *testing.T) {
+		r, err = m.Role.Read(auth0.StringValue(r.ID))
+		if err != nil {
+			t.Error(err)
+		}
+		t.Logf("%v\n", r)
+	})
+
+	t.Run("Update", func(t *testing.T) {
+		id := auth0.StringValue(r.ID)
+
+		r.ID = nil // read-only
+		r.Description = auth0.String("The Administrator")
+
+		err = m.Role.Update(id, r)
+		if err != nil {
+			t.Error(err)
+		}
+		t.Logf("%v\n", r)
+	})
+
+	t.Run("List", func(t *testing.T) {
+		var rs []*Role
+		rs, err = m.Role.List()
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Logf("%v\n", rs)
+	})
+
+	t.Run("AssignUsers", func(t *testing.T) {
+		err = m.Role.AssignUsers(auth0.StringValue(r.ID), u)
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("Users", func(t *testing.T) {
+		var us []*User
+		us, err = m.Role.Users(auth0.StringValue(r.ID))
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Logf("%v\n", us)
+	})
+
+	t.Run("AssignPermissions", func(t *testing.T) {
+		ps := []*Permission{
+			{Name: auth0.String("read:resource"), ResourceServerIdentifier: auth0.String("https://api.example.com/role")},
+			{Name: auth0.String("update:resource"), ResourceServerIdentifier: auth0.String("https://api.example.com/role")},
+		}
+		err = m.Role.AssignPermissions(auth0.StringValue(r.ID), ps...)
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("Permissions", func(t *testing.T) {
+		var ps []*Permission
+		ps, err = m.Role.Permissions(auth0.StringValue(r.ID))
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Logf("%v\n", ps)
+	})
+
+	t.Run("UnassignPermissions", func(t *testing.T) {
+		ps := []*Permission{
+			{Name: auth0.String("read:resource"), ResourceServerIdentifier: auth0.String("https://api.example.com/role")},
+			{Name: auth0.String("update:resource"), ResourceServerIdentifier: auth0.String("https://api.example.com/role")},
+		}
+		err = m.Role.UnassignPermissions(auth0.StringValue(r.ID), ps...)
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("Delete", func(t *testing.T) {
+		err = m.Role.Delete(auth0.StringValue(r.ID))
+		if err != nil {
+			t.Error(err)
+		}
+	})
+}

--- a/management/user.go
+++ b/management/user.go
@@ -106,3 +106,30 @@ func (um *UserManager) List(opts ...reqOption) (us []*User, err error) {
 func (um *UserManager) Search(opts ...reqOption) (us []*User, err error) {
 	return um.List(opts...)
 }
+
+func (um *UserManager) GetRoles(id string, opts ...reqOption) (roles []*Role, err error) {
+	err = um.m.get(um.m.uri("users", id, "roles")+um.m.q(opts), &roles)
+	return roles, err
+}
+
+func (um *UserManager) AssignRoles(id string, roles ...*Role) error {
+	r := make(map[string][]*string)
+
+	r["roles"] = make([]*string, len(roles))
+	for i, role := range roles {
+		r["roles"][i] = role.ID
+	}
+
+	return um.m.post(um.m.uri("users", id, "roles"), &r)
+}
+
+func (um *UserManager) UnassignRoles(id string, roles ...*Role) error {
+	r := make(map[string][]*string)
+
+	r["roles"] = make([]*string, len(roles))
+	for i, role := range roles {
+		r["roles"][i] = role.ID
+	}
+
+	return um.m.request("DELETE", um.m.uri("users", id, "roles"), &r)
+}

--- a/management/user_test.go
+++ b/management/user_test.go
@@ -30,6 +30,27 @@ func TestUser(t *testing.T) {
 
 	var err error
 
+	r1 := &Role{
+		Name:        auth0.String("admin"),
+		Description: auth0.String("Administrator"),
+	}
+	err = m.Role.Create(r1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	r2 := &Role{
+		Name:        auth0.String("user"),
+		Description: auth0.String("User"),
+	}
+	err = m.Role.Create(r2)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer m.Role.Delete(auth0.StringValue(r1.ID))
+	defer m.Role.Delete(auth0.StringValue(r2.ID))
+
 	t.Run("Create", func(t *testing.T) {
 		err = m.User.Create(u)
 		if err != nil {
@@ -80,11 +101,33 @@ func TestUser(t *testing.T) {
 		t.Logf("%v\n", uu)
 	})
 
-	t.Run("Delete", func(t *testing.T) {
-		err = m.User.Delete(auth0.StringValue(u.ID))
+	t.Run("GetRoles", func(t *testing.T) {
+		var roles []*Role
+		roles, err = m.User.GetRoles(auth0.StringValue(u.ID))
 		if err != nil {
 			t.Error(err)
 		}
+		t.Logf("%v\n", roles)
+	})
+
+	t.Run("AssignRoles", func(t *testing.T) {
+		err = m.User.AssignRoles(auth0.StringValue(u.ID), r1, r2)
+		if err != nil {
+			t.Error(err)
+		}
+
+	})
+
+	t.Run("UnassignRoles", func(t *testing.T) {
+		roles := []*Role{r1, r2}
+		err = m.User.UnassignRoles(auth0.StringValue(u.ID), roles...)
+		if err != nil {
+			t.Error(err)
+		}
+	})
+
+	t.Run("Delete", func(t *testing.T) {
+		err = m.User.Delete(auth0.StringValue(u.ID))
 	})
 
 	t.Run("Search", func(t *testing.T) {


### PR DESCRIPTION
Resolves #35.

Added `Role` and `Permission` entities as well as a `RoleManager` which supports the following functionality:

- `Create`: Creates a role
- `Read`: Reads a role
- `Update`: Updates a role
- `List`: Lists all available roles within the current tenant
- `AssignUsers`: Assigns a user to a role
- `Users`: Lists all the users associated to this role.
- `AssignPermissions`: Assigns a permission to a role
- `Permissions`: Lists all the permissions associated to this role.
- `UnassignPermissions`: Unassigns a permission from a role
- `Delete`: Deletes a role