### PR TITLE
Remove omitempty from Client lists

### DIFF
--- a/management/client.go
+++ b/management/client.go
@@ -34,15 +34,15 @@ type Client struct {
 	OIDCConformant *bool `json:"oidc_conformant,omitempty"`
 
 	// The URLs that Auth0 can use to as a callback for the client
-	Callbacks      []interface{} `json:"callbacks,omitempty"`
-	AllowedOrigins []interface{} `json:"allowed_origins,omitempty"`
+	Callbacks      []interface{} `json:"callbacks"`
+	AllowedOrigins []interface{} `json:"allowed_origins"`
 
 	// A set of URLs that represents valid web origins for use with web message
 	// response mode
-	WebOrigins        []interface{}           `json:"web_origins,omitempty"`
-	ClientAliases     []interface{}           `json:"client_aliases,omitempty"`
-	AllowedClients    []interface{}           `json:"allowed_clients,omitempty"`
-	AllowedLogoutURLs []interface{}           `json:"allowed_logout_urls,omitempty"`
+	WebOrigins        []interface{}           `json:"web_origins"`
+	ClientAliases     []interface{}           `json:"client_aliases"`
+	AllowedClients    []interface{}           `json:"allowed_clients"`
+	AllowedLogoutURLs []interface{}           `json:"allowed_logout_urls"`
 	JWTConfiguration  *ClientJWTConfiguration `json:"jwt_configuration,omitempty"`
 
 	// Client signing keys


### PR DESCRIPTION
See alexkappa/terraform-provider-auth0#50

Auth0 requires you to explicitly specify the empty array