### PR TITLE
Add support for listing users by email

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Following is a list of supported Auth0 resources.
 - [x] [Rules Configs](https://auth0.com/docs/api/management/v2#!/Rules_Configs/get_rules_configs)
 - [ ] [User Blocks](https://auth0.com/docs/api/management/v2#!/User_Blocks/get_user_blocks)
 - [x] [Users](https://auth0.com/docs/api/management/v2#!/Users/get_users)
-- [ ] [Users By Email](https://auth0.com/docs/api/management/v2#!/Users_By_Email/get_users_by_email)
+- [x] [Users By Email](https://auth0.com/docs/api/management/v2#!/Users_By_Email/get_users_by_email)
 - [ ] [Blacklists](https://auth0.com/docs/api/management/v2#!/Blacklists/get_tokens)
 - [x] [Email Templates](https://auth0.com/docs/api/management/v2#!/Email_Templates/get_email_templates_by_templateName)
 - [x] [Emails](https://auth0.com/docs/api/management/v2#!/Emails/get_provider)

--- a/management/user.go
+++ b/management/user.go
@@ -107,6 +107,12 @@ func (um *UserManager) Search(opts ...reqOption) (us []*User, err error) {
 	return um.List(opts...)
 }
 
+func (um *UserManager) ListByEmail(email string, opts ...reqOption) (us []*User, err error) {
+	opts = append(opts, Parameter("email", email))
+	err = um.m.get(um.m.uri("users-by-email")+um.m.q(opts), &us)
+	return
+}
+
 func (um *UserManager) GetRoles(id string, opts ...reqOption) (roles []*Role, err error) {
 	err = um.m.get(um.m.uri("users", id, "roles")+um.m.q(opts), &roles)
 	return roles, err

--- a/management/user_test.go
+++ b/management/user_test.go
@@ -85,20 +85,20 @@ func TestUser(t *testing.T) {
 			t.Error(err)
 		}
 		t.Logf("%v\n", uu)
-	})
 
-	t.Run("Update App Metadata", func(t *testing.T) {
-		uu := &User{
-			Connection: auth0.String("Username-Password-Authentication"),
-			AppMetadata: map[string]interface{}{
-				"foo": "bar",
-			},
-		}
-		err = m.User.Update(auth0.StringValue(u.ID), uu)
-		if err != nil {
-			t.Error(err)
-		}
-		t.Logf("%v\n", uu)
+		t.Run("AppMetadata", func(t *testing.T) {
+			uu := &User{
+				Connection: auth0.String("Username-Password-Authentication"),
+				AppMetadata: map[string]interface{}{
+					"foo": "bar",
+				},
+			}
+			err = m.User.Update(auth0.StringValue(u.ID), uu)
+			if err != nil {
+				t.Error(err)
+			}
+			t.Logf("%v\n", uu)
+		})
 	})
 
 	t.Run("GetRoles", func(t *testing.T) {
@@ -130,34 +130,37 @@ func TestUser(t *testing.T) {
 		err = m.User.Delete(auth0.StringValue(u.ID))
 	})
 
-	t.Run("Search", func(t *testing.T) {
-
-		// Create some users we can search for
-		allUsers := []*User{
-			{
-				Email:      auth0.String("alice@example.com"),
-				Password:   auth0.String("5301111b-b31b-47c4-bf3d-0c26ea57bdf4"),
-				Connection: auth0.String("Username-Password-Authentication"),
-			},
-			{
-				Email:      auth0.String("bob@example.com"),
-				Password:   auth0.String("bcfc3bca-8cd3-4b74-a474-402420f34f85"),
-				Connection: auth0.String("Username-Password-Authentication"),
-			},
-			{
-				Email:      auth0.String("charlie@example.com"),
-				Password:   auth0.String("80140c2a-b5c1-490c-a4bf-b0623114d5fd"),
-				Connection: auth0.String("Username-Password-Authentication"),
-			},
+	// Create some users we can search for
+	allUsers := []*User{
+		{
+			Email:      auth0.String("alice@example.com"),
+			Password:   auth0.String("5301111b-b31b-47c4-bf3d-0c26ea57bdf4"),
+			Connection: auth0.String("Username-Password-Authentication"),
+		},
+		{
+			Email:      auth0.String("bob@example.com"),
+			Password:   auth0.String("bcfc3bca-8cd3-4b74-a474-402420f34f85"),
+			Connection: auth0.String("Username-Password-Authentication"),
+		},
+		{
+			Email:      auth0.String("charlie@example.com"),
+			Password:   auth0.String("80140c2a-b5c1-490c-a4bf-b0623114d5fd"),
+			Connection: auth0.String("Username-Password-Authentication"),
+		},
+	}
+	for _, user := range allUsers {
+		err = m.User.Create(user)
+		if err != nil {
+			t.Error(err)
 		}
+	}
+	defer func() {
 		for _, user := range allUsers {
-			err = m.User.Create(user)
-			if err != nil {
-				t.Error(err)
-			}
+			m.User.Delete(auth0.StringValue(user.ID))
 		}
+	}()
 
-		// Now search for one of those
+	t.Run("Search", func(t *testing.T) {
 		foundUsers, err := m.User.Search(
 			Parameter("q", `email:"alice@example.com"`),
 			Parameter("search_engine", "v3"))
@@ -169,10 +172,16 @@ func TestUser(t *testing.T) {
 			t.Error("unexpected number of users found")
 		}
 		t.Logf("%v\n", foundUsers)
+	})
 
-		// Finally clean up
-		for _, user := range allUsers {
-			m.User.Delete(auth0.StringValue(user.ID))
+	t.Run("ListByEmail", func(t *testing.T) {
+		foundUsers, err := m.User.ListByEmail("alice@example.com")
+		if err != nil {
+			t.Error(err)
 		}
+		if len(foundUsers) != 1 {
+			t.Error("unexpected number of users found")
+		}
+		t.Logf("%v\n", foundUsers)
 	})
 }


### PR DESCRIPTION
This PR adds support for [listing users by email](https://auth0.com/docs/api/management/v2#!/Users_By_Email/get_users_by_email).

Usage:

```go
users, err := m.User.ListByEmail("alice@example.com")
```