### PR TITLE
introduce Connection.List

### DIFF
--- a/management/connection.go
+++ b/management/connection.go
@@ -123,6 +123,12 @@ func (cm *ConnectionManager) Read(id string, opts ...reqOption) (*Connection, er
 	return c, err
 }
 
+func (cm *ConnectionManager) List(opts ...reqOption) ([]*Connection, error) {
+	var c []*Connection
+	err := cm.m.get(cm.m.uri("connections")+cm.m.q(opts), &c)
+	return c, err
+}
+
 func (cm *ConnectionManager) Update(id string, c *Connection) (err error) {
 	return cm.m.patch(cm.m.uri("connections", id), c)
 }

--- a/management/connection_test.go
+++ b/management/connection_test.go
@@ -32,6 +32,14 @@ func TestConnection(t *testing.T) {
 		t.Logf("%v\n", c)
 	})
 
+	t.Run("List", func(t *testing.T) {
+		cs, err := m.Connection.List()
+		if err != nil {
+			t.Error(err)
+		}
+		t.Logf("%v\n", cs)
+	})
+
 	t.Run("Update", func(t *testing.T) {
 
 		id := auth0.StringValue(c.ID)


### PR DESCRIPTION
This PR adds the `get connections` management API call as a Connection.List method.

More info https://auth0.com/docs/api/management/v2#!/Connections/get_connections

I haven't tested this - could you point me in the right direction on how I can fork/test with my changes locally? Thank you!