### PR TITLE
Added new options to allow custom connection type configurations

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module gopkg.in/auth0.v1
+module github.com/jordan-simonovski/auth0
 
 go 1.12
 

--- a/management/connection.go
+++ b/management/connection.go
@@ -117,6 +117,10 @@ type ConnectionOptions struct {
 
 	// Adfs
 	AdfsServer *string `json:"adfs_server,omitempty"`
+
+	// Options to add Custom Authorization type for OAuth2 Connections
+	AuthorizationURL    *string                `json:"authorizationURL,omitempty"`
+	TokenURL			*string                `json:"tokenURL,omitempty"`
 }
 
 type ConnectionManager struct {

--- a/management/connection.go
+++ b/management/connection.go
@@ -119,9 +119,9 @@ type ConnectionOptions struct {
 	AdfsServer *string `json:"adfs_server,omitempty"`
 
 	// Options to add Custom Authorization type for OAuth2 Connections
-	AuthorizationURL *string        `json:"authorizationURL,omitempty"`
-	TokenURL         *string        `json:"tokenURL,omitempty"`
-	Scope            *[]interface{} `json:"scope,omitempty"`
+	AuthorizationURL *string `json:"authorizationURL,omitempty"`
+	TokenURL         *string `json:"tokenURL,omitempty"`
+	Scope            *string `json:"scope,omitempty"`
 }
 
 type ConnectionManager struct {

--- a/management/connection.go
+++ b/management/connection.go
@@ -119,8 +119,9 @@ type ConnectionOptions struct {
 	AdfsServer *string `json:"adfs_server,omitempty"`
 
 	// Options to add Custom Authorization type for OAuth2 Connections
-	AuthorizationURL    *string                `json:"authorizationURL,omitempty"`
-	TokenURL			*string                `json:"tokenURL,omitempty"`
+	AuthorizationURL *string                 `json:"authorizationURL,omitempty"`
+	TokenURL         *string                 `json:"tokenURL,omitempty"`
+	Scope            *map[string]interface{} `json:"scope,omitempty"`
 }
 
 type ConnectionManager struct {

--- a/management/connection.go
+++ b/management/connection.go
@@ -119,9 +119,9 @@ type ConnectionOptions struct {
 	AdfsServer *string `json:"adfs_server,omitempty"`
 
 	// Options to add Custom Authorization type for OAuth2 Connections
-	AuthorizationURL *string                 `json:"authorizationURL,omitempty"`
-	TokenURL         *string                 `json:"tokenURL,omitempty"`
-	Scope            *map[string]interface{} `json:"scope,omitempty"`
+	AuthorizationURL *string        `json:"authorizationURL,omitempty"`
+	TokenURL         *string        `json:"tokenURL,omitempty"`
+	Scope            *[]interface{} `json:"scope,omitempty"`
 }
 
 type ConnectionManager struct {

--- a/management/connection.go
+++ b/management/connection.go
@@ -122,6 +122,11 @@ type ConnectionOptions struct {
 	AuthorizationURL *string `json:"authorizationURL,omitempty"`
 	TokenURL         *string `json:"tokenURL,omitempty"`
 	Scope            *string `json:"scope,omitempty"`
+	Script           *Script `json:"script,omitempty"`
+}
+
+type Script struct {
+	FetchUserProfile *string `json:"fetchUserProfile,omitempty"`
 }
 
 type ConnectionManager struct {


### PR DESCRIPTION
Adding in some more configuration items for Auth0 options to allow custom connection types, which in this case are OAuth2 related.
@alexkappa I'll be raising another PR for the terraform provider after this one :) Let me know if there's anything I'm missing.