### PR TITLE
User add family and given name

### DIFF
--- a/management/user.go
+++ b/management/user.go
@@ -26,6 +26,12 @@ type User struct {
 	// The users name
 	Name *string `json:"name,omitempty"`
 
+	// The users given name
+	GivenName *string `json:"given_name,omitempty"`
+
+	// The users family name
+	FamilyName *string `json:"family_name,omitempty"`
+
 	// The user's username. Only valid if the connection requires a username
 	Username *string `json:"username,omitempty"`
 

--- a/management/user_test.go
+++ b/management/user_test.go
@@ -13,6 +13,8 @@ func TestUser(t *testing.T) {
 		Email:      auth0.String("chuck@chucknorris.com"),
 		Password:   auth0.String("Passwords hide their Chuck"),
 		Username:   auth0.String("chucknorris"),
+		GivenName: auth0.String("Chuck"),
+		FamilyName: auth0.String("Norris"),
 		Nickname:   auth0.String("Chucky"),
 		UserMetadata: map[string]interface{}{
 			"favourite_attack": "roundhouse_kick",


### PR DESCRIPTION
As a user i want to have access to the full user profile.

Reading https://auth0.com/docs/users/references/user-profile-structure we should be able to retrieve given_name and family_name.