### PR TITLE
Fix domain related error

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -67,13 +67,25 @@ func WrapDebug(c *http.Client) *http.Client {
 	}
 }
 
-func OAuth2(domain, clientID, clientSecret string) *http.Client {
+func getTokenURL(u url.URL) string {
+	u.Path = "oauth/token"
+
+	return (&u).String()
+}
+
+func getAudience(u url.URL, apiPath string) string {
+	u.Path = apiPath
+
+	return (&u).String()
+}
+
+func OAuth2(u *url.URL, clientID, clientSecret string) *http.Client {
 	return (&clientcredentials.Config{
 		ClientID:     clientID,
 		ClientSecret: clientSecret,
-		TokenURL:     "https://" + domain + "/oauth/token",
+		TokenURL:     getTokenURL(*u),
 		EndpointParams: url.Values{
-			"audience": {"https://" + domain + "/api/v2/"},
+			"audience": {getAudience(*u, "api/v2/")},
 		},
 	}).Client(context.Background())
 }

--- a/management/management.go
+++ b/management/management.go
@@ -74,7 +74,7 @@ type Management struct {
 	// Branding settings such as company logo or primary color.
 	Branding *BrandingManager
 
-	domain   string
+	url      *url.URL
 	basePath string
 	timeout  time.Duration
 	debug    bool
@@ -85,9 +85,17 @@ type Management struct {
 // New creates a new Auth0 Management client by authenticating using the
 // supplied client id and secret.
 func New(domain, clientID, clientSecret string, options ...apiOption) (*Management, error) {
+	if !strings.HasPrefix(domain, "http://") && !strings.HasPrefix(domain, "https://") {
+		domain = "https://" + domain
+	}
+
+	u, err := url.Parse(domain)
+	if err != nil {
+		return nil, err
+	}
 
 	m := &Management{
-		domain:   domain,
+		url:      u,
 		basePath: "api/v2",
 		timeout:  1 * time.Minute,
 		debug:    false,
@@ -97,7 +105,7 @@ func New(domain, clientID, clientSecret string, options ...apiOption) (*Manageme
 		option(m)
 	}
 
-	m.http = client.OAuth2(domain, clientID, clientSecret)
+	m.http = client.OAuth2(m.url, clientID, clientSecret)
 	m.http = client.WrapUserAgent(m.http)
 	m.http = client.WrapRetry(m.http)
 	if m.debug {
@@ -128,8 +136,8 @@ func New(domain, clientID, clientSecret string, options ...apiOption) (*Manageme
 
 func (m *Management) uri(path ...string) string {
 	return (&url.URL{
-		Scheme: "https",
-		Host:   m.domain,
+		Scheme: m.url.Scheme,
+		Host:   m.url.Host,
 		Path:   m.basePath + "/" + strings.Join(path, "/"),
 	}).String()
 }
@@ -146,12 +154,11 @@ func (m *Management) q(options []reqOption) string {
 }
 
 func (m *Management) request(method, uri string, v interface{}) error {
-
 	var payload bytes.Buffer
 	if v != nil {
 		json.NewEncoder(&payload).Encode(v)
 	}
-	
+
 	req, err := http.NewRequest(method, uri, &payload)
 	if err != nil {
 		return err

--- a/management/management.go
+++ b/management/management.go
@@ -151,7 +151,12 @@ func (m *Management) request(method, uri string, v interface{}) error {
 	if v != nil {
 		json.NewEncoder(&payload).Encode(v)
 	}
-	req, _ := http.NewRequest(method, uri, &payload)
+	
+	req, err := http.NewRequest(method, uri, &payload)
+	if err != nil {
+		return err
+	}
+
 	req.Header.Add("Content-Type", "application/json")
 
 	ctx, cancel := context.WithTimeout(context.Background(), m.timeout)


### PR DESCRIPTION
This fixes a silent error we were getting when passing the auth0 domain with included web protocol (`https://tenant.auth0.com`)

Changes:
- The code should be now more resilient to this case, but it should still work with the case where the protocol is not specified.
- If an error arises when making a request to auth0, it is no longer silently ignored.