### PR TITLE
Stabilize job test

### DIFF
--- a/management/connection.go
+++ b/management/connection.go
@@ -1,6 +1,9 @@
 package management
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"errors"
+)
 
 type Connection struct {
 	// A generated string identifying the connection.
@@ -124,8 +127,8 @@ type ConnectionManager struct {
 }
 
 type ConnectionOptionsTotp struct {
-	TimeStep *int `json:time_step,omitempty`
-	Length   *int `json:length,omitempty`
+	TimeStep *int `json:"time_step,omitempty"`
+	Length   *int `json:"length,omitempty"`
 }
 
 func NewConnectionManager(m *Management) *ConnectionManager {
@@ -154,4 +157,14 @@ func (cm *ConnectionManager) Update(id string, c *Connection) (err error) {
 
 func (cm *ConnectionManager) Delete(id string) (err error) {
 	return cm.m.delete(cm.m.uri("connections", id))
+}
+
+func (cm *ConnectionManager) GetConnectionID(connectionName string) (*string, error) {
+	connections, err := cm.m.Connection.List(Parameter("name", connectionName), Parameter("fields", "id"))
+	if len(connections) == 1 {
+		return connections[0].ID, nil
+	} else if err == nil {
+		err = errors.New(connectionName + " connection does not exist.")
+	}
+	return nil, err
 }

--- a/management/connection_test.go
+++ b/management/connection_test.go
@@ -89,4 +89,12 @@ func TestConnection(t *testing.T) {
 			t.Error(err)
 		}
 	})
+
+	t.Run("GetConnectionID", func(t *testing.T) {
+		cs, err := m.Connection.GetConnectionID("Username-Password-Authentication")
+		if err != nil {
+			t.Error(err)
+		}
+		t.Logf("%v\n", cs)
+	})
 }

--- a/management/job_test.go
+++ b/management/job_test.go
@@ -10,6 +10,8 @@ func TestJob(t *testing.T) {
 
 	var err error
 
+	connectionID, _ := m.Connection.GetConnectionID("Username-Password-Authentication")
+
 	u := &User{
 		Connection: auth0.String("Username-Password-Authentication"),
 		Email:      auth0.String("example@example.com"),
@@ -54,7 +56,7 @@ func TestJob(t *testing.T) {
 
 	t.Run("ExportUsers", func(t *testing.T) {
 		job := &Job{
-			ConnectionID: auth0.String("con_C2Imdps0x50qqvYF"),
+			ConnectionID: connectionID,
 			Format:       auth0.String("json"),
 			Limit:        auth0.Int(5),
 			Fields: []map[string]interface{}{
@@ -72,7 +74,7 @@ func TestJob(t *testing.T) {
 
 	t.Run("ImportUsers", func(t *testing.T) {
 		job := &Job{
-			ConnectionID:        auth0.String("con_C2Imdps0x50qqvYF"),
+			ConnectionID:        connectionID,
 			Upsert:              auth0.Bool(true),
 			SendCompletionEmail: auth0.Bool(false),
 			Users: []map[string]interface{}{


### PR DESCRIPTION
The connectionID is hardcoded in Job test.
This fails when another contributor want to execute this on his own tenant.

