### PR TITLE
fix: check error when creating http.Request

### DIFF
--- a/management/job.go
+++ b/management/job.go
@@ -120,7 +120,10 @@ func (jm *JobManager) ImportUsers(j *Job) error {
 	}
 	mp.Close()
 
-	req, _ := http.NewRequest("POST", jm.m.uri("jobs/users-imports"), &payload)
+	req, err := http.NewRequest("POST", jm.m.uri("jobs/users-imports"), &payload)
+	if err != nil {
+		return err
+	}
 	req.Header.Add("Content-Type", mp.FormDataContentType())
 
 	ctx, cancel := context.WithTimeout(context.Background(), jm.m.timeout)

--- a/management/management.go
+++ b/management/management.go
@@ -151,7 +151,10 @@ func (m *Management) request(method, uri string, v interface{}) error {
 	if v != nil {
 		json.NewEncoder(&payload).Encode(v)
 	}
-	req, _ := http.NewRequest(method, uri, &payload)
+	req, err := http.NewRequest(method, uri, &payload)
+	if err != nil {
+		return err
+	}
 	req.Header.Add("Content-Type", "application/json")
 
 	ctx, cancel := context.WithTimeout(context.Background(), m.timeout)


### PR DESCRIPTION
Check error when creating new http.Request. Otherwise, when terraform apply command fails because of an issue with creating of request, you will get panic instead of nice error. This will instead print actual error so you can see what happened.