### PR TITLE
[FEATURE] Add parameter missing to use salesforce community connection

### DIFF
--- a/management/connection.go
+++ b/management/connection.go
@@ -122,7 +122,7 @@ type ConnectionOptions struct {
 	AdfsServer *string `json:"adfs_server,omitempty"`
 
 	// Salesforce community
-	CommunityBaseURL    *string       `json:"community_base_url"`
+	CommunityBaseURL *string `json:"community_base_url"`
 }
 
 type ConnectionManager struct {

--- a/management/connection.go
+++ b/management/connection.go
@@ -120,6 +120,9 @@ type ConnectionOptions struct {
 
 	// Adfs
 	AdfsServer *string `json:"adfs_server,omitempty"`
+
+	// Salesforce community
+	CommunityBaseURL    *string       `json:"community_base_url"`
 }
 
 type ConnectionManager struct {


### PR DESCRIPTION
Currently blocks this PR from being merged: https://github.com/alexkappa/terraform-provider-auth0/pull/130

This updates the auth0 module to support this extra option for the Terraform `auth0_connection` resource.

cc @alexkappa 