### PR TITLE
Add Guardian Factor support

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,8 @@ The following Auth0 resources are supported:
 - [ ] [Blacklists](https://auth0.com/docs/api/management/v2#!/Blacklists/get_tokens)
 - [x] [Email Templates](https://auth0.com/docs/api/management/v2#!/Email_Templates/get_email_templates_by_templateName)
 - [x] [Emails](https://auth0.com/docs/api/management/v2#!/Emails/get_provider)
-- [ ] [Guardian](https://auth0.com/docs/api/management/v2#!/Guardian/get_factors)
+- [x] [Guardian](https://auth0.com/docs/api/management/v2#!/Guardian/get_factors)
+	- Only Guardian Factors; Enrollment endpoints not implemented
 - [x] [Jobs](https://auth0.com/docs/api/management/v2#!/Jobs/get_jobs_by_id)
 - [x] [Stats](https://auth0.com/docs/api/management/v2#!/Stats/get_active_users)
 - [x] [Tenants](https://auth0.com/docs/api/management/v2#!/Tenants/get_settings)

--- a/management/guardian.go
+++ b/management/guardian.go
@@ -26,7 +26,7 @@ type GuardianFactorStatus struct {
 	TrialExpired *bool `json:"trial_expired,omitempty"`
 }
 
-type GuardianTemplate struct {
+type GuardianSmsTemplate struct {
 	// Message sent to the user when they are invited to enroll with a phone number
 	EnrollmentMessage *string `json:"enrollment_message,omitempty"`
 
@@ -34,7 +34,7 @@ type GuardianTemplate struct {
 	VerificationMessage *string `json:"verification_message,omitempty"`
 }
 
-type GuardianFactorPushNotificationSnsConfig struct {
+type GuardianPushNotificationSnsConfig struct {
 	// AWS Access Key ID
 	AwsAccessKeyID *string `json:"aws_access_key_id,omitempty"`
 
@@ -51,7 +51,7 @@ type GuardianFactorPushNotificationSnsConfig struct {
 	SnsGcmPlatformApplicationArn *string `json:"sns_gcm_platform_application_arn,omitempty"`
 }
 
-type GuardianFactorSmsTwilioConfig struct {
+type GuardianSmsTwilioConfig struct {
 	// From number
 	From *string `json:"from,omitempty"`
 
@@ -73,7 +73,7 @@ func NewGuardianManager(m *Management) *GuardianManager {
 	return &GuardianManager{m}
 }
 
-func (gm *GuardianManager) ListFactorsAndStatuses() ([]*GuardianFactorStatus, error) {
+func (gm *GuardianManager) ListFactors() ([]*GuardianFactorStatus, error) {
 	var gf []*GuardianFactorStatus
 	err := gm.m.get(gm.m.uri("guardian/factors"), &gf)
 	return gf, err
@@ -83,32 +83,32 @@ func (gm *GuardianManager) UpdateFactor(name GuardianFactorType, gf *GuardianFac
 	return gm.m.put(gm.m.uri("guardian/factors", string(name)), gf)
 }
 
-func (gm *GuardianManager) GetTemplate() (*GuardianTemplate, error) {
-	gt := new(GuardianTemplate)
-	err := gm.m.get(gm.m.uri("guardian/factors/sms/templates"), gt)
-	return gt, err
+func (gm *GuardianManager) GetSmsTemplate() (*GuardianSmsTemplate, error) {
+	st := new(GuardianSmsTemplate)
+	err := gm.m.get(gm.m.uri("guardian/factors/sms/templates"), st)
+	return st, err
 }
 
-func (gm *GuardianManager) UpdateTemplate(gt *GuardianTemplate) error {
-	return gm.m.put(gm.m.uri("guardian/factors/sms/templates"), gt)
+func (gm *GuardianManager) UpdateSmsTemplate(st *GuardianSmsTemplate) error {
+	return gm.m.put(gm.m.uri("guardian/factors/sms/templates"), st)
 }
 
-func (gm *GuardianManager) GetFactorPushNotificationSnsConfig() (*GuardianFactorPushNotificationSnsConfig, error) {
-	sc := new(GuardianFactorPushNotificationSnsConfig)
+func (gm *GuardianManager) GetPushNotificationSnsConfig() (*GuardianPushNotificationSnsConfig, error) {
+	sc := new(GuardianPushNotificationSnsConfig)
 	err := gm.m.get(gm.m.uri("guardian/factors/push-notification/providers/sns"), sc)
 	return sc, err
 }
 
-func (gm *GuardianManager) UpdateFactorPushNotificationSnsConfig(sc *GuardianFactorPushNotificationSnsConfig) error {
+func (gm *GuardianManager) UpdatePushNotificationSnsConfig(sc *GuardianPushNotificationSnsConfig) error {
 	return gm.m.put(gm.m.uri("guardian/factors/push-notification/providers/sns"), sc)
 }
 
-func (gm *GuardianManager) GetFactorSmsTwilioConfig() (*GuardianFactorSmsTwilioConfig, error) {
-	tc := new(GuardianFactorSmsTwilioConfig)
+func (gm *GuardianManager) GetSmsTwilioConfig() (*GuardianSmsTwilioConfig, error) {
+	tc := new(GuardianSmsTwilioConfig)
 	err := gm.m.get(gm.m.uri("guardian/factors/sms/providers/twilio"), tc)
 	return tc, err
 }
 
-func (gm *GuardianManager) UpdateFactorSmsTwilioConfig(tc *GuardianFactorSmsTwilioConfig) error {
+func (gm *GuardianManager) UpdateSmsTwilioConfig(tc *GuardianSmsTwilioConfig) error {
 	return gm.m.put(gm.m.uri("guardian/factors/sms/providers/twilio"), tc)
 }

--- a/management/guardian.go
+++ b/management/guardian.go
@@ -1,0 +1,93 @@
+package management
+
+const (
+	DuoGuardianFactor              GuardianFactorType = "duo"
+	EmailGuardianFactor            GuardianFactorType = "email"
+	OtpGuardianFactor              GuardianFactorType = "otp"
+	PushNotificationGuardianFactor GuardianFactorType = "push-notification"
+	SmsGuardianFactor              GuardianFactorType = "sms"
+)
+
+type GuardianFactorType string
+
+type GuardianFactor struct {
+	// States if this factor is enabled
+	Enabled *bool `json:"enabled,omitempty"`
+}
+
+type GuardianFactorStatus struct {
+	// States if this factor is enabled
+	Enabled *bool `json:"enabled,omitempty"`
+
+	// Guardian Factor name
+	Name *string `json:"name,omitempty"`
+
+	// For factors with trial limits (e.g. SMS) states if those limits have been exceeded
+	TrialExpired *bool `json:"trial_expired,omitempty"`
+}
+
+type GuardianFactorPushNotificationSnsConfig struct {
+	// AWS Access Key ID
+	AwsAccessKeyID *string `json:"aws_access_key_id,omitempty"`
+
+	// AWS Secret Access Key ID
+	AwsSecretAccessKeyID *string `json:"aws_secret_access_key,omitempty"`
+
+	// AWS Region
+	AwsRegion *string `json:"aws_region,omitempty"`
+
+	// SNS APNS Platform Application ARN
+	SnsApnsPlatformApplicationArn *string `json:"sns_apns_platform_application_arn,omitempty"`
+
+	// SNS GCM Platform Application ARN
+	SnsGcmPlatformApplicationArn *string `json:"sns_gcm_platform_application_arn,omitempty"`
+}
+
+type GuardianFactorSmsTwilioConfig struct {
+	// From number
+	From *string `json:"from,omitempty"`
+
+	// Copilot SID
+	MessagingServiceSid *string `json:"messaging_service_sid,omitempty"`
+
+	// Twilio Authentication token
+	AuthToken *string `json:"auth_token,omitempty"`
+
+	// Twilio SID
+	Sid *string `json:"sid,omitempty"`
+}
+
+type GuardianManager struct {
+	m *Management
+}
+
+func NewGuardianManager(m *Management) *GuardianManager {
+	return &GuardianManager{m}
+}
+
+func (gm *GuardianManager) ListFactorsAndStatuses() (gf []*GuardianFactorStatus, err error) {
+	err = gm.m.get(gm.m.uri("guardian/factors"), gf)
+	return
+}
+
+func (gm *GuardianManager) UpdateFactor(name GuardianFactorType, gf *GuardianFactor) error {
+	return gm.m.put(gm.m.uri("guardian/factors", string(name)), gf)
+}
+
+func (gm *GuardianManager) GetFactorPushNotificationSnsConfig() (sc *GuardianFactorPushNotificationSnsConfig, err error) {
+	err = gm.m.get(gm.m.uri("guardian/factors/push-notification/providers/sns"), sc)
+	return
+}
+
+func (gm *GuardianManager) UpdateFactorPushNotificationSnsConfig(sc *GuardianFactorPushNotificationSnsConfig) error {
+	return gm.m.put(gm.m.uri("guardian/factors/push-notification/providers/sns"), sc)
+}
+
+func (gm *GuardianManager) GetFactorSmsTwilioConfig() (tc *GuardianFactorSmsTwilioConfig, err error) {
+	err = gm.m.get(gm.m.uri("guardian/factors/sms/providers/twilio"), tc)
+	return
+}
+
+func (gm *GuardianManager) UpdateFactorSmsTwilioConfig(tc *GuardianFactorSmsTwilioConfig) error {
+	return gm.m.put(gm.m.uri("guardian/factors/sms/providers/twilio"), tc)
+}

--- a/management/guardian.go
+++ b/management/guardian.go
@@ -26,6 +26,14 @@ type GuardianFactorStatus struct {
 	TrialExpired *bool `json:"trial_expired,omitempty"`
 }
 
+type GuardianTemplate struct {
+	// Message sent to the user when they are invited to enroll with a phone number
+	EnrollmentMessage *string `json:"enrollment_message,omitempty"`
+
+	// Message sent to the user when they are prompted to verify their account
+	VerificationMessage *string `json:"verification_message,omitempty"`
+}
+
 type GuardianFactorPushNotificationSnsConfig struct {
 	// AWS Access Key ID
 	AwsAccessKeyID *string `json:"aws_access_key_id,omitempty"`
@@ -73,6 +81,16 @@ func (gm *GuardianManager) ListFactorsAndStatuses() ([]*GuardianFactorStatus, er
 
 func (gm *GuardianManager) UpdateFactor(name GuardianFactorType, gf *GuardianFactor) error {
 	return gm.m.put(gm.m.uri("guardian/factors", string(name)), gf)
+}
+
+func (gm *GuardianManager) GetTemplate() (*GuardianTemplate, error) {
+	gt := new(GuardianTemplate)
+	err := gm.m.get(gm.m.uri("guardian/factors/sms/templates"), gt)
+	return gt, err
+}
+
+func (gm *GuardianManager) UpdateTemplate(gt *GuardianTemplate) error {
+	return gm.m.put(gm.m.uri("guardian/factors/sms/templates"), gt)
 }
 
 func (gm *GuardianManager) GetFactorPushNotificationSnsConfig() (*GuardianFactorPushNotificationSnsConfig, error) {

--- a/management/guardian.go
+++ b/management/guardian.go
@@ -65,27 +65,30 @@ func NewGuardianManager(m *Management) *GuardianManager {
 	return &GuardianManager{m}
 }
 
-func (gm *GuardianManager) ListFactorsAndStatuses() (gf []*GuardianFactorStatus, err error) {
-	err = gm.m.get(gm.m.uri("guardian/factors"), gf)
-	return
+func (gm *GuardianManager) ListFactorsAndStatuses() ([]*GuardianFactorStatus, error) {
+	var gf []*GuardianFactorStatus
+	err := gm.m.get(gm.m.uri("guardian/factors"), &gf)
+	return gf, err
 }
 
 func (gm *GuardianManager) UpdateFactor(name GuardianFactorType, gf *GuardianFactor) error {
 	return gm.m.put(gm.m.uri("guardian/factors", string(name)), gf)
 }
 
-func (gm *GuardianManager) GetFactorPushNotificationSnsConfig() (sc *GuardianFactorPushNotificationSnsConfig, err error) {
-	err = gm.m.get(gm.m.uri("guardian/factors/push-notification/providers/sns"), sc)
-	return
+func (gm *GuardianManager) GetFactorPushNotificationSnsConfig() (*GuardianFactorPushNotificationSnsConfig, error) {
+	sc := new(GuardianFactorPushNotificationSnsConfig)
+	err := gm.m.get(gm.m.uri("guardian/factors/push-notification/providers/sns"), sc)
+	return sc, err
 }
 
 func (gm *GuardianManager) UpdateFactorPushNotificationSnsConfig(sc *GuardianFactorPushNotificationSnsConfig) error {
 	return gm.m.put(gm.m.uri("guardian/factors/push-notification/providers/sns"), sc)
 }
 
-func (gm *GuardianManager) GetFactorSmsTwilioConfig() (tc *GuardianFactorSmsTwilioConfig, err error) {
-	err = gm.m.get(gm.m.uri("guardian/factors/sms/providers/twilio"), tc)
-	return
+func (gm *GuardianManager) GetFactorSmsTwilioConfig() (*GuardianFactorSmsTwilioConfig, error) {
+	tc := new(GuardianFactorSmsTwilioConfig)
+	err := gm.m.get(gm.m.uri("guardian/factors/sms/providers/twilio"), tc)
+	return tc, err
 }
 
 func (gm *GuardianManager) UpdateFactorSmsTwilioConfig(tc *GuardianFactorSmsTwilioConfig) error {

--- a/management/guardian_test.go
+++ b/management/guardian_test.go
@@ -15,8 +15,8 @@ func TestGuardian(t *testing.T) {
 			Enabled: auth0.Bool(false),
 		})
 		m.Guardian.UpdateSmsTemplate(&GuardianSmsTemplate{
-			EnrollmentMessage:   auth0.String("{{code}} is your verification code for {{tenant.friendly_name}}. Please enter this code to verify your enrollment."),
-			VerificationMessage: auth0.String("{{code}} is your verification code for {{tenant.friendly_name}}"),
+			EnrollmentMessage:   &emptyString,
+			VerificationMessage: &emptyString,
 		})
 		m.Guardian.UpdatePushNotificationSnsConfig(&GuardianPushNotificationSnsConfig{
 			AwsAccessKeyID:                &emptyString,

--- a/management/guardian_test.go
+++ b/management/guardian_test.go
@@ -14,6 +14,10 @@ func TestGuardian(t *testing.T) {
 		m.Guardian.UpdateFactor(testFactor, &GuardianFactor{
 			Enabled: auth0.Bool(false),
 		})
+		m.Guardian.UpdateTemplate(&GuardianTemplate{
+			EnrollmentMessage:   auth0.String("{{code}} is your verification code for {{tenant.friendly_name}}. Please enter this code to verify your enrollment."),
+			VerificationMessage: auth0.String("{{code}} is your verification code for {{tenant.friendly_name}}"),
+		})
 		m.Guardian.UpdateFactorPushNotificationSnsConfig(&GuardianFactorPushNotificationSnsConfig{
 			AwsAccessKeyID:                &emptyString,
 			AwsSecretAccessKeyID:          &emptyString,
@@ -46,6 +50,26 @@ func TestGuardian(t *testing.T) {
 		}
 		gf, _ := m.Guardian.ListFactorsAndStatuses()
 		t.Logf("%v\n", gf)
+	})
+
+	t.Run("GetTemplate", func(t *testing.T) {
+		gt, err := m.Guardian.GetTemplate()
+		if err != nil {
+			t.Error(err)
+		}
+		t.Logf("%v\n", gt)
+	})
+
+	t.Run("UpdateTemplate", func(t *testing.T) {
+		err := m.Guardian.UpdateTemplate(&GuardianTemplate{
+			EnrollmentMessage:   auth0.String("Test {{code}} for {{tenant.friendly_name}}"),
+			VerificationMessage: auth0.String("Test {{code}} for {{tenant.friendly_name}}"),
+		})
+		if err != nil {
+			t.Error(err)
+		}
+		gt, _ := m.Guardian.GetTemplate()
+		t.Logf("%v\n", gt)
 	})
 
 	t.Run("GetFactorPushNotificationSnsConfig", func(t *testing.T) {

--- a/management/guardian_test.go
+++ b/management/guardian_test.go
@@ -14,18 +14,18 @@ func TestGuardian(t *testing.T) {
 		m.Guardian.UpdateFactor(testFactor, &GuardianFactor{
 			Enabled: auth0.Bool(false),
 		})
-		m.Guardian.UpdateTemplate(&GuardianTemplate{
+		m.Guardian.UpdateSmsTemplate(&GuardianSmsTemplate{
 			EnrollmentMessage:   auth0.String("{{code}} is your verification code for {{tenant.friendly_name}}. Please enter this code to verify your enrollment."),
 			VerificationMessage: auth0.String("{{code}} is your verification code for {{tenant.friendly_name}}"),
 		})
-		m.Guardian.UpdateFactorPushNotificationSnsConfig(&GuardianFactorPushNotificationSnsConfig{
+		m.Guardian.UpdatePushNotificationSnsConfig(&GuardianPushNotificationSnsConfig{
 			AwsAccessKeyID:                &emptyString,
 			AwsSecretAccessKeyID:          &emptyString,
 			AwsRegion:                     &emptyString,
 			SnsApnsPlatformApplicationArn: &emptyString,
 			SnsGcmPlatformApplicationArn:  &emptyString,
 		})
-		m.Guardian.UpdateFactorSmsTwilioConfig(&GuardianFactorSmsTwilioConfig{
+		m.Guardian.UpdateSmsTwilioConfig(&GuardianSmsTwilioConfig{
 			From:                &emptyString,
 			MessagingServiceSid: &emptyString,
 			AuthToken:           &emptyString,
@@ -33,8 +33,8 @@ func TestGuardian(t *testing.T) {
 		})
 	}()
 
-	t.Run("ListFactorsAndStatuses", func(t *testing.T) {
-		gf, err := m.Guardian.ListFactorsAndStatuses()
+	t.Run("ListFactors", func(t *testing.T) {
+		gf, err := m.Guardian.ListFactors()
 		if err != nil {
 			t.Error(err)
 		}
@@ -48,40 +48,40 @@ func TestGuardian(t *testing.T) {
 		if err != nil {
 			t.Error(err)
 		}
-		gf, _ := m.Guardian.ListFactorsAndStatuses()
+		gf, _ := m.Guardian.ListFactors()
 		t.Logf("%v\n", gf)
 	})
 
-	t.Run("GetTemplate", func(t *testing.T) {
-		gt, err := m.Guardian.GetTemplate()
+	t.Run("GetSmsTemplate", func(t *testing.T) {
+		st, err := m.Guardian.GetSmsTemplate()
 		if err != nil {
 			t.Error(err)
 		}
-		t.Logf("%v\n", gt)
+		t.Logf("%v\n", st)
 	})
 
-	t.Run("UpdateTemplate", func(t *testing.T) {
-		err := m.Guardian.UpdateTemplate(&GuardianTemplate{
+	t.Run("UpdateSmsTemplate", func(t *testing.T) {
+		err := m.Guardian.UpdateSmsTemplate(&GuardianSmsTemplate{
 			EnrollmentMessage:   auth0.String("Test {{code}} for {{tenant.friendly_name}}"),
 			VerificationMessage: auth0.String("Test {{code}} for {{tenant.friendly_name}}"),
 		})
 		if err != nil {
 			t.Error(err)
 		}
-		gt, _ := m.Guardian.GetTemplate()
-		t.Logf("%v\n", gt)
+		st, _ := m.Guardian.GetSmsTemplate()
+		t.Logf("%v\n", st)
 	})
 
-	t.Run("GetFactorPushNotificationSnsConfig", func(t *testing.T) {
-		sc, err := m.Guardian.GetFactorPushNotificationSnsConfig()
+	t.Run("GetPushNotificationSnsConfig", func(t *testing.T) {
+		sc, err := m.Guardian.GetPushNotificationSnsConfig()
 		if err != nil {
 			t.Error(err)
 		}
 		t.Logf("%v\n", sc)
 	})
 
-	t.Run("UpdateFactorPushNotificationSnsConfig", func(t *testing.T) {
-		err := m.Guardian.UpdateFactorPushNotificationSnsConfig(&GuardianFactorPushNotificationSnsConfig{
+	t.Run("UpdatePushNotificationSnsConfig", func(t *testing.T) {
+		err := m.Guardian.UpdatePushNotificationSnsConfig(&GuardianPushNotificationSnsConfig{
 			AwsAccessKeyID:                auth0.String("test"),
 			AwsSecretAccessKeyID:          auth0.String("test_secret"),
 			AwsRegion:                     auth0.String("us-west-1"),
@@ -91,20 +91,20 @@ func TestGuardian(t *testing.T) {
 		if err != nil {
 			t.Error(err)
 		}
-		sc, _ := m.Guardian.GetFactorPushNotificationSnsConfig()
+		sc, _ := m.Guardian.GetPushNotificationSnsConfig()
 		t.Logf("%v\n", sc)
 	})
 
-	t.Run("GetFactorSmsTwilioConfig", func(t *testing.T) {
-		tc, err := m.Guardian.GetFactorSmsTwilioConfig()
+	t.Run("GetSmsTwilioConfig", func(t *testing.T) {
+		tc, err := m.Guardian.GetSmsTwilioConfig()
 		if err != nil {
 			t.Error(err)
 		}
 		t.Logf("%v\n", tc)
 	})
 
-	t.Run("UpdateFactorSmsTwilioConfig", func(t *testing.T) {
-		err := m.Guardian.UpdateFactorSmsTwilioConfig(&GuardianFactorSmsTwilioConfig{
+	t.Run("UpdateSmsTwilioConfig", func(t *testing.T) {
+		err := m.Guardian.UpdateSmsTwilioConfig(&GuardianSmsTwilioConfig{
 			From:      auth0.String("123456789"),
 			AuthToken: auth0.String("test_token"),
 			Sid:       auth0.String("test_sid"),
@@ -112,7 +112,7 @@ func TestGuardian(t *testing.T) {
 		if err != nil {
 			t.Error(err)
 		}
-		tc, _ := m.Guardian.GetFactorSmsTwilioConfig()
+		tc, _ := m.Guardian.GetSmsTwilioConfig()
 		t.Logf("%v\n", tc)
 	})
 }

--- a/management/guardian_test.go
+++ b/management/guardian_test.go
@@ -60,7 +60,7 @@ func TestGuardian(t *testing.T) {
 		err := m.Guardian.UpdateFactorPushNotificationSnsConfig(&GuardianFactorPushNotificationSnsConfig{
 			AwsAccessKeyID:                auth0.String("test"),
 			AwsSecretAccessKeyID:          auth0.String("test_secret"),
-			AwsRegion:                     auth0.String("test_region"),
+			AwsRegion:                     auth0.String("us-west-1"),
 			SnsApnsPlatformApplicationArn: auth0.String("test_arn"),
 			SnsGcmPlatformApplicationArn:  auth0.String("test_arn"),
 		})
@@ -81,10 +81,9 @@ func TestGuardian(t *testing.T) {
 
 	t.Run("UpdateFactorSmsTwilioConfig", func(t *testing.T) {
 		err := m.Guardian.UpdateFactorSmsTwilioConfig(&GuardianFactorSmsTwilioConfig{
-			From:                auth0.String("123456789"),
-			MessagingServiceSid: auth0.String("test_sid"),
-			AuthToken:           auth0.String("test_token"),
-			Sid:                 auth0.String("test_sid"),
+			From:      auth0.String("123456789"),
+			AuthToken: auth0.String("test_token"),
+			Sid:       auth0.String("test_sid"),
 		})
 		if err != nil {
 			t.Error(err)

--- a/management/guardian_test.go
+++ b/management/guardian_test.go
@@ -1,0 +1,95 @@
+package management
+
+import (
+	"testing"
+
+	"gopkg.in/auth0.v1"
+)
+
+func TestGuardian(t *testing.T) {
+	testFactor := OtpGuardianFactor
+
+	defer func() {
+		emptyString := ""
+		m.Guardian.UpdateFactor(testFactor, &GuardianFactor{
+			Enabled: auth0.Bool(false),
+		})
+		m.Guardian.UpdateFactorPushNotificationSnsConfig(&GuardianFactorPushNotificationSnsConfig{
+			AwsAccessKeyID:                &emptyString,
+			AwsSecretAccessKeyID:          &emptyString,
+			AwsRegion:                     &emptyString,
+			SnsApnsPlatformApplicationArn: &emptyString,
+			SnsGcmPlatformApplicationArn:  &emptyString,
+		})
+		m.Guardian.UpdateFactorSmsTwilioConfig(&GuardianFactorSmsTwilioConfig{
+			From:                &emptyString,
+			MessagingServiceSid: &emptyString,
+			AuthToken:           &emptyString,
+			Sid:                 &emptyString,
+		})
+	}()
+
+	t.Run("ListFactorsAndStatuses", func(t *testing.T) {
+		gf, err := m.Guardian.ListFactorsAndStatuses()
+		if err != nil {
+			t.Error(err)
+		}
+		t.Logf("%v\n", gf)
+	})
+
+	t.Run("UpdateFactor", func(t *testing.T) {
+		err := m.Guardian.UpdateFactor(testFactor, &GuardianFactor{
+			Enabled: auth0.Bool(true),
+		})
+		if err != nil {
+			t.Error(err)
+		}
+		gf, _ := m.Guardian.ListFactorsAndStatuses()
+		t.Logf("%v\n", gf)
+	})
+
+	t.Run("GetFactorPushNotificationSnsConfig", func(t *testing.T) {
+		sc, err := m.Guardian.GetFactorPushNotificationSnsConfig()
+		if err != nil {
+			t.Error(err)
+		}
+		t.Logf("%v\n", sc)
+	})
+
+	t.Run("UpdateFactorPushNotificationSnsConfig", func(t *testing.T) {
+		err := m.Guardian.UpdateFactorPushNotificationSnsConfig(&GuardianFactorPushNotificationSnsConfig{
+			AwsAccessKeyID:                auth0.String("test"),
+			AwsSecretAccessKeyID:          auth0.String("test_secret"),
+			AwsRegion:                     auth0.String("test_region"),
+			SnsApnsPlatformApplicationArn: auth0.String("test_arn"),
+			SnsGcmPlatformApplicationArn:  auth0.String("test_arn"),
+		})
+		if err != nil {
+			t.Error(err)
+		}
+		sc, _ := m.Guardian.GetFactorPushNotificationSnsConfig()
+		t.Logf("%v\n", sc)
+	})
+
+	t.Run("GetFactorSmsTwilioConfig", func(t *testing.T) {
+		tc, err := m.Guardian.GetFactorSmsTwilioConfig()
+		if err != nil {
+			t.Error(err)
+		}
+		t.Logf("%v\n", tc)
+	})
+
+	t.Run("UpdateFactorSmsTwilioConfig", func(t *testing.T) {
+		err := m.Guardian.UpdateFactorSmsTwilioConfig(&GuardianFactorSmsTwilioConfig{
+			From:                auth0.String("123456789"),
+			MessagingServiceSid: auth0.String("test_sid"),
+			AuthToken:           auth0.String("test_token"),
+			Sid:                 auth0.String("test_sid"),
+		})
+		if err != nil {
+			t.Error(err)
+		}
+		tc, _ := m.Guardian.GetFactorSmsTwilioConfig()
+		t.Logf("%v\n", tc)
+	})
+}

--- a/management/management.go
+++ b/management/management.go
@@ -74,6 +74,9 @@ type Management struct {
 	// Branding settings such as company logo or primary color.
 	Branding *BrandingManager
 
+	// Guardian manages your Auth0 Guardian settings
+	Guardian *GuardianManager
+
 	url      *url.URL
 	basePath string
 	timeout  time.Duration
@@ -134,6 +137,7 @@ func New(domain, clientID, clientSecret string, options ...apiOption) (*Manageme
 	m.Ticket = NewTicketManager(m)
 	m.Stat = NewStatManager(m)
 	m.Branding = NewBrandingManager(m)
+	m.Guardian = NewGuardianManager(m)
 
 	return m, nil
 }


### PR DESCRIPTION
Add support for Guardian Factor:

* GET /api/v2/guardian/factors https://auth0.com/docs/api/management/v2#!/Guardian/get_factors
* PUT /api/v2/guardian/factors/{name} https://auth0.com/docs/api/management/v2#!/Guardian/put_factors_by_name
* GET /api/v2/guardian/factors/sms/templates  https://auth0.com/docs/api/management/v2#!/Guardian/get_templates
* PUT  /api/v2/guardian/factors/sms/templates  https://auth0.com/docs/api/management/v2#!/Guardian/put_templates
* GET /api/v2/guardian/factors/push-notification/providers/sns  https://auth0.com/docs/api/management/v2#!/Guardian/get_sns
* PUT /api/v2/guardian/factors/push-notification/providers/sns  https://auth0.com/docs/api/management/v2#!/Guardian/put_sns
* GET /api/v2/guardian/factors/sms/providers/twilio  https://auth0.com/docs/api/management/v2#!/Guardian/get_twilio
* PUT /api/v2/guardian/factors/sms/providers/twilio  https://auth0.com/docs/api/management/v2#!/Guardian/put_twilio