### PR TITLE
Add prompt support

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ The following Auth0 resources are supported:
 - [x] [Tenants](https://auth0.com/docs/api/management/v2#!/Tenants/get_settings)
 - [x] [Tickets](https://auth0.com/docs/api/management/v2#!/Tickets/post_email_verification)
 - [x] [Branding](https://auth0.com/docs/api/management/v2/#!/Branding/get_branding)
+- [x] [Prompts](https://auth0.com/docs/api/management/v2#!/Prompts/get_prompts)
 
 ## What is Auth0?
 

--- a/management/management.go
+++ b/management/management.go
@@ -74,6 +74,9 @@ type Management struct {
 	// Branding settings such as company logo or primary color.
 	Branding *BrandingManager
 
+	// Prompt manages your prompt settings.
+	Prompt *PromptManager
+
 	url      *url.URL
 	basePath string
 	timeout  time.Duration
@@ -134,6 +137,7 @@ func New(domain, clientID, clientSecret string, options ...apiOption) (*Manageme
 	m.Ticket = NewTicketManager(m)
 	m.Stat = NewStatManager(m)
 	m.Branding = NewBrandingManager(m)
+	m.Prompt = NewPromptManager(m)
 
 	return m, nil
 }

--- a/management/prompt.go
+++ b/management/prompt.go
@@ -1,0 +1,24 @@
+package management
+
+type PromptSettings struct {
+	// Which login experience to use. Can be `new` or `classic`.
+	UniversalLoginExperience string `json:"universal_login_experience,omitempty"`
+}
+
+type PromptManager struct {
+	m *Management
+}
+
+func NewPromptManager(m *Management) *PromptManager {
+	return &PromptManager{m}
+}
+
+func (pm *PromptManager) GetSettings() (*PromptSettings, error) {
+	ps := new(PromptSettings)
+	err := pm.m.get(pm.m.uri("prompts"), ps)
+	return ps, err
+}
+
+func (pm *PromptManager) UpdateSettings(ps *PromptSettings) error {
+	return pm.m.patch(pm.m.uri("prompts"), ps)
+}

--- a/management/prompt_test.go
+++ b/management/prompt_test.go
@@ -31,7 +31,7 @@ func TestPrompt(t *testing.T) {
 		if err != nil {
 			t.Error(err)
 		}
-		if ps.UniversalLoginExperience != "new" {
+		if ps.UniversalLoginExperience != expected {
 			t.Errorf("unexpected output. have %v, expected %v", ps.UniversalLoginExperience, expected)
 		}
 		t.Logf("%v\n", ps)

--- a/management/prompt_test.go
+++ b/management/prompt_test.go
@@ -1,0 +1,39 @@
+package management
+
+import (
+	"testing"
+)
+
+func TestPrompt(t *testing.T) {
+	defer func() {
+		m.Prompt.UpdateSettings(&PromptSettings{
+			UniversalLoginExperience: "classic",
+		})
+	}()
+
+	t.Run("GetSettings", func(t *testing.T) {
+		ps, err := m.Prompt.GetSettings()
+		if err != nil {
+			t.Error(err)
+		}
+		t.Logf("%v\n", ps)
+	})
+
+	t.Run("UpdateSettings", func(t *testing.T) {
+		expected := "new"
+		err := m.Prompt.UpdateSettings(&PromptSettings{
+			UniversalLoginExperience: expected,
+		})
+		if err != nil {
+			t.Error(err)
+		}
+		ps, err := m.Prompt.GetSettings()
+		if err != nil {
+			t.Error(err)
+		}
+		if ps.UniversalLoginExperience != "new" {
+			t.Errorf("unexpected output. have %v, expected %v", ps.UniversalLoginExperience, expected)
+		}
+		t.Logf("%v\n", ps)
+	})
+}


### PR DESCRIPTION
Adds the Prompt endpoints:
* GET /api/v2/prompts: https://auth0.com/docs/api/management/v2/#!/Prompts/get_prompts
* PATCH	/api/v2/prompts: https://auth0.com/docs/api/management/v2/#!/Prompts/patch_prompts