### PR TITLE
Tickets: Mark as verified

### DIFF
--- a/management/ticket.go
+++ b/management/ticket.go
@@ -31,6 +31,10 @@ type Ticket struct {
 
 	// The URL that represents the ticket
 	Ticket *string `json:"ticket,omitempty"`
+
+	// Whether to set the email_verified attribute to true (true) or whether it
+	// should not be updated
+	MarkEmailAsVerified *bool `json:"mark_email_as_verified,omitempty"`
 }
 
 func (t *Ticket) String() string {

--- a/management/ticket_test.go
+++ b/management/ticket_test.go
@@ -41,9 +41,10 @@ func TestTicket(t *testing.T) {
 	t.Run("ChangePassword", func(t *testing.T) {
 
 		v := &Ticket{
-			ResultURL: auth0.String("https://example.com/change-password"),
-			UserID:    auth0.String(userID),
-			TTLSec:    auth0.Int(3600),
+			ResultURL:           auth0.String("https://example.com/change-password"),
+			UserID:              auth0.String(userID),
+			TTLSec:              auth0.Int(3600),
+			MarkEmailAsVerified: auth0.Bool(true),
 		}
 
 		v, err = m.Ticket.ChangePassword(v)


### PR DESCRIPTION
Adds `mark_email_as_verified` to the `Ticket` struct allowing generation of password reset tickets to ultimately flag the users email as verified.

As per docs: https://auth0.com/docs/api/management/v2#!/Tickets/post_password_change