### PR TITLE
Make reqOption public to allow users of the library to mock it

### DIFF
--- a/management/branding.go
+++ b/management/branding.go
@@ -40,7 +40,7 @@ func NewBrandingManager(m *Management) *BrandingManager {
 // Retrieve various settings related to branding.
 //
 // See: https://auth0.com/docs/api/management/v2#!/Branding/get_branding
-func (bm *BrandingManager) Read(opts ...reqOption) (*Branding, error) {
+func (bm *BrandingManager) Read(opts ...ReqOption) (*Branding, error) {
 	branding := new(Branding)
 	err := bm.m.get(bm.m.uri("branding")+bm.m.q(opts), branding)
 	return branding, err

--- a/management/client.go
+++ b/management/client.go
@@ -117,7 +117,7 @@ func (cm *ClientManager) Create(c *Client) (err error) {
 // Retrieves a client by its id.
 //
 // See: https://auth0.com/docs/api/management/v2#!/Clients/get_clients_by_id
-func (cm *ClientManager) Read(id string, opts ...reqOption) (*Client, error) {
+func (cm *ClientManager) Read(id string, opts ...ReqOption) (*Client, error) {
 	c := new(Client)
 	err := cm.m.get(cm.m.uri("clients", id)+cm.m.q(opts), c)
 	return c, err
@@ -126,7 +126,7 @@ func (cm *ClientManager) Read(id string, opts ...reqOption) (*Client, error) {
 // Retrieves a list of all client applications.
 //
 // See: https://auth0.com/docs/api/management/v2#!/Clients/get_clients
-func (cm *ClientManager) List(opts ...reqOption) ([]*Client, error) {
+func (cm *ClientManager) List(opts ...ReqOption) ([]*Client, error) {
 	var c []*Client
 	err := cm.m.get(cm.m.uri("clients")+cm.m.q(opts), &c)
 	return c, err

--- a/management/client_grant.go
+++ b/management/client_grant.go
@@ -74,7 +74,7 @@ func (cg *ClientGrantManager) Delete(id string) (err error) {
 // Retrieve client grants.
 //
 // See: https://auth0.com/docs/api/management/v2#!/Client_Grants/get_client_grants
-func (cg *ClientGrantManager) List(opts ...reqOption) (gs []*ClientGrant, err error) {
+func (cg *ClientGrantManager) List(opts ...ReqOption) (gs []*ClientGrant, err error) {
 	err = cg.m.get(cg.m.uri("client-grants")+cg.m.q(opts), &gs)
 	return
 }

--- a/management/connection.go
+++ b/management/connection.go
@@ -145,7 +145,7 @@ func (cm *ConnectionManager) Create(c *Connection) error {
 // Retrieves a connection by its id.
 //
 // See: https://auth0.com/docs/api/management/v2#!/Connections/get_connections_by_id
-func (cm *ConnectionManager) Read(id string, opts ...reqOption) (*Connection, error) {
+func (cm *ConnectionManager) Read(id string, opts ...ReqOption) (*Connection, error) {
 	c := new(Connection)
 	err := cm.m.get(cm.m.uri("connections", id)+cm.m.q(opts), c)
 	return c, err
@@ -154,7 +154,7 @@ func (cm *ConnectionManager) Read(id string, opts ...reqOption) (*Connection, er
 // Retrieves every connection matching the specified strategy.
 //
 // See: https://auth0.com/docs/api/management/v2#!/Connections/get_connections
-func (cm *ConnectionManager) List(opts ...reqOption) ([]*Connection, error) {
+func (cm *ConnectionManager) List(opts ...ReqOption) ([]*Connection, error) {
 	var c []*Connection
 	err := cm.m.get(cm.m.uri("connections")+cm.m.q(opts), &c)
 	return c, err
@@ -179,7 +179,7 @@ func (cm *ConnectionManager) Delete(id string) (err error) {
 
 // Retrieves a connection by its name. This is a helper method when a connection
 // id is not readily available.
-func (cm *ConnectionManager) ReadByName(name string, opts ...reqOption) (*Connection, error) {
+func (cm *ConnectionManager) ReadByName(name string, opts ...ReqOption) (*Connection, error) {
 	opts = append(opts, Parameter("name", name))
 	c, err := cm.List(opts...)
 	if err != nil {

--- a/management/custom_domain.go
+++ b/management/custom_domain.go
@@ -57,7 +57,7 @@ func (cm *CustomDomainManager) Create(c *CustomDomain) (err error) {
 // Retrieve a custom domain configuration and status.
 //
 // See: https://auth0.com/docs/api/management/v2#!/Custom_Domains/get_custom_domains_by_id
-func (cm *CustomDomainManager) Read(id string, opts ...reqOption) (*CustomDomain, error) {
+func (cm *CustomDomainManager) Read(id string, opts ...ReqOption) (*CustomDomain, error) {
 	c := new(CustomDomain)
 	err := cm.m.get(cm.m.uri("custom-domains", id)+cm.m.q(opts), c)
 	return c, err
@@ -82,7 +82,7 @@ func (cm *CustomDomainManager) Delete(id string) (err error) {
 // Retrieve a list of custom domains.
 //
 // See: https://auth0.com/docs/api/management/v2#!/Custom_Domains/get_custom_domains
-func (cm *CustomDomainManager) List(opts ...reqOption) ([]*CustomDomain, error) {
+func (cm *CustomDomainManager) List(opts ...ReqOption) ([]*CustomDomain, error) {
 	var c []*CustomDomain
 	err := cm.m.get(cm.m.uri("custom-domains")+cm.m.q(opts), &c)
 	return c, err

--- a/management/email.go
+++ b/management/email.go
@@ -77,7 +77,7 @@ func (em *EmailManager) Create(e *Email) error {
 // Retrieve email provider details.
 //
 // See: https://auth0.com/docs/api/management/v2#!/Emails/get_provider
-func (em *EmailManager) Read(opts ...reqOption) (*Email, error) {
+func (em *EmailManager) Read(opts ...ReqOption) (*Email, error) {
 	e := new(Email)
 	err := em.m.get(em.m.uri("emails", "provider")+em.m.q(opts), e)
 	return e, err

--- a/management/email_template.go
+++ b/management/email_template.go
@@ -59,7 +59,7 @@ func (em *EmailTemplateManager) Create(e *EmailTemplate) error {
 // legacy scenarios.
 //
 // See: https://auth0.com/docs/api/management/v2#!/Email_Templates/get_email_templates_by_templateName
-func (em *EmailTemplateManager) Read(template string, opts ...reqOption) (*EmailTemplate, error) {
+func (em *EmailTemplateManager) Read(template string, opts ...ReqOption) (*EmailTemplate, error) {
 	e := new(EmailTemplate)
 	err := em.m.get(em.m.uri("email-templates", template)+em.m.q(opts), e)
 	return e, err

--- a/management/grant.go
+++ b/management/grant.go
@@ -32,7 +32,7 @@ func NewGrantManager(m *Management) *GrantManager {
 // List the grants associated with your account.
 //
 // See: https://auth0.com/docs/api/management/v2#!/Grants/get_grants
-func (gm *GrantManager) List(opts ...reqOption) ([]*Grant, error) {
+func (gm *GrantManager) List(opts ...ReqOption) ([]*Grant, error) {
 	var g []*Grant
 	err := gm.m.get(gm.m.uri("grants")+gm.m.q(opts), &g)
 	return g, err

--- a/management/guardian.go
+++ b/management/guardian.go
@@ -101,7 +101,7 @@ type MultiFactorManager struct {
 // Retrieves all factors.
 //
 // See: https://auth0.com/docs/api/management/v2#!/Guardian/get_factors
-func (mfm *MultiFactorManager) List(opts ...reqOption) ([]*MultiFactor, error) {
+func (mfm *MultiFactorManager) List(opts ...ReqOption) ([]*MultiFactor, error) {
 	var mf []*MultiFactor
 	err := mfm.m.get(mfm.m.uri("guardian", "factors")+mfm.m.q(opts), &mf)
 	return mf, err

--- a/management/job.go
+++ b/management/job.go
@@ -77,7 +77,7 @@ func (jm *JobManager) VerifyEmail(j *Job) error {
 // Retrieves a job. Useful to check its status.
 //
 // See: https://auth0.com/docs/api/management/v2#!/Jobs/get_jobs_by_id
-func (jm *JobManager) Read(id string, opts ...reqOption) (*Job, error) {
+func (jm *JobManager) Read(id string, opts ...ReqOption) (*Job, error) {
 	j := new(Job)
 	err := jm.m.get(jm.m.uri("jobs", id)+jm.m.q(opts), j)
 	return j, err

--- a/management/log.go
+++ b/management/log.go
@@ -110,7 +110,7 @@ func NewLogManager(m *Management) *LogManager {
 // single log entry representation as specified in the schema.
 //
 // See: https://auth0.com/docs/api/management/v2#!/Logs/get_logs_by_id
-func (lm *LogManager) Read(id string, opts ...reqOption) (*Log, error) {
+func (lm *LogManager) Read(id string, opts ...ReqOption) (*Log, error) {
 	l := new(Log)
 	err := lm.m.get(lm.m.uri("logs", id), l)
 	return l, err
@@ -124,13 +124,13 @@ func (lm *LogManager) Read(id string, opts ...reqOption) (*Log, error) {
 // and descriptions, Log Data Event Listing.
 //
 // See: https://auth0.com/docs/api/management/v2#!/Logs/get_logs
-func (lm *LogManager) List(opts ...reqOption) ([]*Log, error) {
+func (lm *LogManager) List(opts ...ReqOption) ([]*Log, error) {
 	var l []*Log
 	err := lm.m.get(lm.m.uri("logs")+lm.m.q(opts), &l)
 	return l, err
 }
 
 // Search is an alias for List
-func (lm *LogManager) Search(opts ...reqOption) ([]*Log, error) {
+func (lm *LogManager) Search(opts ...ReqOption) ([]*Log, error) {
 	return lm.List(opts...)
 }

--- a/management/management.go
+++ b/management/management.go
@@ -167,7 +167,7 @@ func (m *Management) uri(path ...string) string {
 	}).String()
 }
 
-func (m *Management) q(options []reqOption) string {
+func (m *Management) q(options []ReqOption) string {
 	if len(options) == 0 {
 		return ""
 	}
@@ -299,12 +299,12 @@ func (m *managementError) Status() int {
 	return m.StatusCode
 }
 
-// reqOption configures a call (typically to retrieve a resource) to Auth0 with
+// ReqOption configures a call (typically to retrieve a resource) to Auth0 with
 // query parameters.
-type reqOption func(url.Values)
+type ReqOption func(url.Values)
 
 // WithFields configures a call to include the desired fields.
-func WithFields(fields ...string) reqOption {
+func WithFields(fields ...string) ReqOption {
 	return func(v url.Values) {
 		v.Set("fields", strings.Join(fields, ","))
 		v.Set("include_fields", "true")
@@ -312,7 +312,7 @@ func WithFields(fields ...string) reqOption {
 }
 
 // WithoutFields configures a call to exclude the desired fields.
-func WithoutFields(fields ...string) reqOption {
+func WithoutFields(fields ...string) ReqOption {
 	return func(v url.Values) {
 		v.Set("fields", strings.Join(fields, ","))
 		v.Set("include_fields", "false")
@@ -321,21 +321,21 @@ func WithoutFields(fields ...string) reqOption {
 
 // Page configures a call to receive a specific page, if the results where
 // concatenated.
-func Page(page int) reqOption {
+func Page(page int) ReqOption {
 	return func(v url.Values) {
 		v.Set("page", strconv.FormatInt(int64(page), 10))
 	}
 }
 
 // PerPage configures a call to limit the amount of items in the result.
-func PerPage(items int) reqOption {
+func PerPage(items int) ReqOption {
 	return func(v url.Values) {
 		v.Set("per_page", strconv.FormatInt(int64(items), 10))
 	}
 }
 
 // IncludeTotals configures a call to include totals.
-func IncludeTotals(include bool) reqOption {
+func IncludeTotals(include bool) ReqOption {
 	return func(v url.Values) {
 		v.Set("include_totals", strconv.FormatBool(include))
 	}
@@ -343,7 +343,7 @@ func IncludeTotals(include bool) reqOption {
 
 // Parameter is a generic configuration to add arbitrary query parameters to
 // calls made to Auth0.
-func Parameter(key, value string) reqOption {
+func Parameter(key, value string) ReqOption {
 	return func(v url.Values) {
 		v.Set(key, value)
 	}

--- a/management/resource_server.go
+++ b/management/resource_server.go
@@ -80,7 +80,7 @@ func (r *ResourceServerManager) Create(rs *ResourceServer) (err error) {
 // Retrieves a resource server by its id or audience.
 //
 // See: https://auth0.com/docs/api/management/v2#!/Resource_Servers/get_resource_servers_by_id
-func (r *ResourceServerManager) Read(id string, opts ...reqOption) (*ResourceServer, error) {
+func (r *ResourceServerManager) Read(id string, opts ...ReqOption) (*ResourceServer, error) {
 	rs := new(ResourceServer)
 	err := r.m.get(r.m.uri("resource-servers", id)+r.m.q(opts), rs)
 	return rs, err

--- a/management/role.go
+++ b/management/role.go
@@ -47,7 +47,7 @@ func (rm *RoleManager) Create(r *Role) error {
 // Retrieve a role.
 //
 // See: https://auth0.com/docs/api/management/v2#!/Roles/get_roles_by_id
-func (rm *RoleManager) Read(id string, opts ...reqOption) (*Role, error) {
+func (rm *RoleManager) Read(id string, opts ...ReqOption) (*Role, error) {
 	r := new(Role)
 	err := rm.m.get(rm.m.uri("roles", id)+rm.m.q(opts), r)
 	return r, err
@@ -70,7 +70,7 @@ func (rm *RoleManager) Delete(id string) (err error) {
 // Retrieve a list of roles that can be assigned to users or groups.
 //
 // See: https://auth0.com/docs/api/management/v2#!/Roles/get_roles
-func (rm *RoleManager) List(opts ...reqOption) ([]*Role, error) {
+func (rm *RoleManager) List(opts ...ReqOption) ([]*Role, error) {
 	var r []*Role
 	err := rm.m.get(rm.m.uri("roles")+rm.m.q(opts), &r)
 	return r, err
@@ -91,7 +91,7 @@ func (rm *RoleManager) AssignUsers(id string, users ...*User) error {
 // Retrieve users associated with a role.
 //
 // See: https://auth0.com/docs/api/management/v2#!/Roles/get_role_user
-func (rm *RoleManager) Users(id string, opts ...reqOption) ([]*User, error) {
+func (rm *RoleManager) Users(id string, opts ...ReqOption) ([]*User, error) {
 	var u []*User
 	err := rm.m.get(rm.m.uri("roles", id, "users")+rm.m.q(opts), &u)
 	return u, err
@@ -109,7 +109,7 @@ func (rm *RoleManager) AssociatePermissions(id string, permissions ...*Permissio
 // Retrieve list of permissions granted by a role.
 //
 // See: https://auth0.com/docs/api/management/v2#!/Roles/get_role_permission
-func (rm *RoleManager) Permissions(id string, opts ...reqOption) ([]*Permission, error) {
+func (rm *RoleManager) Permissions(id string, opts ...ReqOption) ([]*Permission, error) {
 	var p []*Permission
 	err := rm.m.get(rm.m.uri("roles", id, "permissions")+rm.m.q(opts), &p)
 	return p, err

--- a/management/rule.go
+++ b/management/rule.go
@@ -46,7 +46,7 @@ func (rm *RuleManager) Create(r *Rule) error {
 // Retrieve rule details. Accepts a list of fields to include or exclude in the result.
 //
 // See: https://auth0.com/docs/api/management/v2#!/Rules/get_rules_by_id
-func (rm *RuleManager) Read(id string, opts ...reqOption) (*Rule, error) {
+func (rm *RuleManager) Read(id string, opts ...ReqOption) (*Rule, error) {
 	r := new(Rule)
 	err := rm.m.get(rm.m.uri("rules", id)+rm.m.q(opts), r)
 	return r, err

--- a/management/stat.go
+++ b/management/stat.go
@@ -36,7 +36,7 @@ func (d *DailyStat) String() string {
 // (subscription required) that occurred each day within a specified date range.
 //
 // See: https://auth0.com/docs/api/management/v2#!/Stats/get_daily
-func (sm *StatManager) Daily(opts ...reqOption) ([]*DailyStat, error) {
+func (sm *StatManager) Daily(opts ...ReqOption) ([]*DailyStat, error) {
 	var ds []*DailyStat
 	err := sm.m.get(sm.m.uri("stats/daily")+sm.m.q(opts), &ds)
 	return ds, err

--- a/management/tenant.go
+++ b/management/tenant.go
@@ -167,7 +167,7 @@ func NewTenantManager(m *Management) *TenantManager {
 // specified.
 //
 // See: https://auth0.com/docs/api/management/v2#!/Tenants/get_settings
-func (tm *TenantManager) Read(opts ...reqOption) (*Tenant, error) {
+func (tm *TenantManager) Read(opts ...ReqOption) (*Tenant, error) {
 	t := new(Tenant)
 	err := tm.m.get(tm.m.uri("tenants/settings")+tm.m.q(opts), t)
 	return t, err

--- a/management/user.go
+++ b/management/user.go
@@ -112,7 +112,7 @@ func (um *UserManager) Create(u *User) error {
 // This endpoint can be used to retrieve user details given the user_id.
 //
 // See: https://auth0.com/docs/api/management/v2#!/Users/get_users_by_id
-func (um *UserManager) Read(id string, opts ...reqOption) (*User, error) {
+func (um *UserManager) Read(id string, opts ...ReqOption) (*User, error) {
 	u := new(User)
 	err := um.m.get(um.m.uri("users", id)+um.m.q(opts), u)
 	return u, err
@@ -153,13 +153,13 @@ func (um *UserManager) Delete(id string) (err error) {
 // This endpoint can be used to retrieve a list of users.
 //
 // See: https://auth0.com/docs/api/management/v2#!/Users/get_users
-func (um *UserManager) List(opts ...reqOption) (us []*User, err error) {
+func (um *UserManager) List(opts ...ReqOption) (us []*User, err error) {
 	err = um.m.get(um.m.uri("users")+um.m.q(opts), &us)
 	return
 }
 
 // Search is an alias for List.
-func (um *UserManager) Search(opts ...reqOption) (us []*User, err error) {
+func (um *UserManager) Search(opts ...ReqOption) (us []*User, err error) {
 	return um.List(opts...)
 }
 
@@ -175,7 +175,7 @@ func (um *UserManager) Search(opts ...reqOption) (us []*User, err error) {
 // email addresses using the correct case.
 //
 // See: https://auth0.com/docs/api/management/v2#!/Users_By_Email/get_users_by_email
-func (um *UserManager) ListByEmail(email string, opts ...reqOption) (us []*User, err error) {
+func (um *UserManager) ListByEmail(email string, opts ...ReqOption) (us []*User, err error) {
 	opts = append(opts, Parameter("email", email))
 	err = um.m.get(um.m.uri("users-by-email")+um.m.q(opts), &us)
 	return
@@ -184,7 +184,7 @@ func (um *UserManager) ListByEmail(email string, opts ...reqOption) (us []*User,
 // List the the roles associated with a user.
 //
 // See: https://auth0.com/docs/api/management/v2#!/Users/get_user_roles
-func (um *UserManager) GetRoles(id string, opts ...reqOption) (roles []*Role, err error) {
+func (um *UserManager) GetRoles(id string, opts ...ReqOption) (roles []*Role, err error) {
 	err = um.m.get(um.m.uri("users", id, "roles")+um.m.q(opts), &roles)
 	return roles, err
 }
@@ -216,7 +216,7 @@ func (um *UserManager) RemoveRoles(id string, roles ...*Role) error {
 // List the permissions associated to the user.
 //
 // See: https://auth0.com/docs/api/management/v2#!/Users/get_permissions
-func (um *UserManager) Permissions(id string, opts ...reqOption) (permissions []*Permission, err error) {
+func (um *UserManager) Permissions(id string, opts ...ReqOption) (permissions []*Permission, err error) {
 	err = um.m.get(um.m.uri("users", id, "permissions")+um.m.q(opts), &permissions)
 	return permissions, err
 }


### PR DESCRIPTION
Currently, the library can _almost_ be mocked for testing: all of the concrete types used in its interface are data structures, with the exception of reqOption.