### PR TITLE
Add support for user blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ The following Auth0 resources are supported:
 - [x] [Roles](https://auth0.com/docs/api/management/v2#!/Roles)
 - [x] [Rules](https://auth0.com/docs/api/management/v2#!/Rules/get_rules)
 - [x] [Rules Configs](https://auth0.com/docs/api/management/v2#!/Rules_Configs/get_rules_configs)
-- [ ] [User Blocks](https://auth0.com/docs/api/management/v2#!/User_Blocks/get_user_blocks)
+- [x] [User Blocks](https://auth0.com/docs/api/management/v2#!/User_Blocks/get_user_blocks)
 - [x] [Users](https://auth0.com/docs/api/management/v2#!/Users/get_users)
 - [x] [Users By Email](https://auth0.com/docs/api/management/v2#!/Users_By_Email/get_users_by_email)
 - [x] [Blacklists](https://auth0.com/docs/api/management/v2#!/Blacklists/get_tokens)

--- a/management/user.go
+++ b/management/user.go
@@ -89,6 +89,15 @@ type UserIdentity struct {
 	IsSocial   *bool   `json:"isSocial,omitempty"`
 }
 
+type userBlock struct {
+	BlockedFor []*UserBlock `json:"blocked_for,omitempty"`
+}
+
+type UserBlock struct {
+	Identifier *string `json:"identifier,omitempty"`
+	IP         *string `json:"ip,omitempty"`
+}
+
 // UserList is an envelope struct which is used when calling List() or Search()
 // methods.
 //
@@ -195,10 +204,10 @@ func (m *UserManager) ListByEmail(email string, opts ...ListOption) (us []*User,
 	return
 }
 
-// GetRoles lists all roles associated with a user.
+// Roles lists all roles associated with a user.
 //
 // See: https://auth0.com/docs/api/management/v2#!/Users/get_user_roles
-func (m *UserManager) GetRoles(id string, opts ...ListOption) (roles []*Role, err error) {
+func (m *UserManager) Roles(id string, opts ...ListOption) (roles []*Role, err error) {
 	err = m.get(m.uri("users", id, "roles")+m.q(opts), &roles)
 	return roles, err
 }
@@ -251,4 +260,23 @@ func (m *UserManager) RemovePermissions(id string, permissions ...*Permission) e
 	p := make(map[string][]*Permission)
 	p["permissions"] = permissions
 	return m.request("DELETE", m.uri("users", id, "permissions"), &p)
+}
+
+// Blocks retrieves a list of blocked IP addresses of a particular user.
+//
+// See: https://auth0.com/docs/api/management/v2#!/User_Blocks/get_user_blocks_by_id
+func (m *UserManager) Blocks(id string) ([]*UserBlock, error) {
+	b := new(userBlock)
+	err := m.get(m.uri("user-blocks", id), &b)
+	return b.BlockedFor, err
+}
+
+// Unblock a user that was blocked due to an excessive amount of incorrectly
+// provided credentials.
+//
+// Note: This endpoint does not unblock users that were blocked by admins.
+//
+// See: https://auth0.com/docs/api/management/v2#!/User_Blocks/delete_user_blocks_by_id
+func (m *UserManager) Unblock(id string) error {
+	return m.delete(m.uri("user-blocks", id))
 }

--- a/management/user_test.go
+++ b/management/user_test.go
@@ -128,9 +128,9 @@ func TestUser(t *testing.T) {
 		})
 	})
 
-	t.Run("GetRoles", func(t *testing.T) {
+	t.Run("Roles", func(t *testing.T) {
 		var roles []*Role
-		roles, err = m.User.GetRoles(auth0.StringValue(u.ID))
+		roles, err = m.User.Roles(auth0.StringValue(u.ID))
 		if err != nil {
 			t.Error(err)
 		}
@@ -184,8 +184,26 @@ func TestUser(t *testing.T) {
 		}
 	})
 
+	t.Run("Blocks", func(t *testing.T) {
+		b, err := m.User.Blocks(u.GetID())
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Logf("%v\n", b)
+	})
+
+	t.Run("Blocks", func(t *testing.T) {
+		err := m.User.Unblock(u.GetID())
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+
 	t.Run("Delete", func(t *testing.T) {
-		err = m.User.Delete(auth0.StringValue(u.ID))
+		err = m.User.Delete(u.GetID())
+		if err != nil {
+			t.Fatal(err)
+		}
 	})
 
 	// Create some users we can search for


### PR DESCRIPTION
This change adds support for retrieving a users blocks and unblocking a user. Only the user id variants are implemented, in that at the moment you cannot retrieve blocks by identifier (email, phone number).

See: https://auth0.com/docs/api/management/v2#!/User_Blocks/get_user_blocks