### PR TITLE
bugfix: user identity field user_id is a number in some id providers

### DIFF
--- a/management/user.go
+++ b/management/user.go
@@ -96,10 +96,11 @@ type UserIdentity struct {
 }
 
 // Used to avoid recursion in UnmarshalJSON below.
-type IdentityAlias UserIdentity
+type identityAlias UserIdentity
 
+// UnmarshalJSON - Override regular JSON unmarshal to handle identity providers with Number user_id field.
 func (u *UserIdentity) UnmarshalJSON(b []byte) error {
-	var identityAlias IdentityAlias
+	var identityAlias identityAlias
 	if err := json.Unmarshal(b, &identityAlias); err != nil {
 		return err
 	}

--- a/management/user.go
+++ b/management/user.go
@@ -89,9 +89,10 @@ type User struct {
 
 type UserIdentity struct {
 	Connection *string `json:"connection,omitempty"`
-	UserID     *string `json:"user_id,omitempty"`
-	Provider   *string `json:"provider,omitempty"`
-	IsSocial   *bool   `json:"isSocial,omitempty"`
+	// user_id should be String but it's a Number sometimes
+	UserID   *string `json:"-"`
+	Provider *string `json:"provider,omitempty"`
+	IsSocial *bool   `json:"isSocial,omitempty"`
 }
 
 // Used to avoid recursion in UnmarshalJSON below.


### PR DESCRIPTION
When the auth0 identity provider is Github, the user field might a number and not a "string"
This causes the Unmarshal JSON() func to fail with error:

```cannot unmarshal number into Go struct field UserIdentity.user_id of type string```

example:
```json
{
            "provider": "github",
            "user_id": 123123123,
            "connection": "github",
            "isSocial": true
}
```