### PR TITLE
Workaround for UserIdentity.UserID being a number

### DIFF
--- a/management/user.go
+++ b/management/user.go
@@ -117,8 +117,8 @@ func (i *UserIdentity) UnmarshalJSON(data []byte) error {
 	i.Provider = ambiguousIdentity.Provider
 	i.IsSocial = ambiguousIdentity.IsSocial
 
-	userId := fmt.Sprintf("%v", ambiguousIdentity.UserID)
-	i.UserID = &userId
+	userID := fmt.Sprintf("%v", ambiguousIdentity.UserID)
+	i.UserID = &userID
 
 	return nil
 }

--- a/management/user.go
+++ b/management/user.go
@@ -1,6 +1,10 @@
 package management
 
-import "time"
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+)
 
 // User represents an Auth0 user resource
 //
@@ -87,6 +91,36 @@ type UserIdentity struct {
 	UserID     *string `json:"user_id,omitempty"`
 	Provider   *string `json:"provider,omitempty"`
 	IsSocial   *bool   `json:"isSocial,omitempty"`
+}
+
+// ambiguousUserIdentity is an exact copy of UserIdentity type but with a UserID being
+// an interface. This allows us to unmarshal Auth0 response no mater what type of data
+// Auth0 returns for a `user_id` key.
+type ambiguousUserIdentity struct {
+	Connection *string     `json:"connection,omitempty"`
+	UserID     interface{} `json:"user_id,omitempty"`
+	Provider   *string     `json:"provider,omitempty"`
+	IsSocial   *bool       `json:"isSocial,omitempty"`
+}
+
+// UnmarshalJSON is a custom deserializer for the UserIdentity type.
+// We have to use a custom one due to a bug in Auth0 - for requests to /users/<user-id>
+// Auth0 might return a number for `user_id` instead of a string.
+// See https://community.auth0.com/t/users-user-id-returns-inconsistent-type-for-identities-user-id/39236
+func (i *UserIdentity) UnmarshalJSON(data []byte) error {
+	ambiguousIdentity := ambiguousUserIdentity{}
+	if err := json.Unmarshal(data, &ambiguousIdentity); err != nil {
+		return err
+	}
+
+	i.Connection = ambiguousIdentity.Connection
+	i.Provider = ambiguousIdentity.Provider
+	i.IsSocial = ambiguousIdentity.IsSocial
+
+	userId := fmt.Sprintf("%v", ambiguousIdentity.UserID)
+	i.UserID = &userId
+
+	return nil
 }
 
 type userBlock struct {

--- a/management/user_test.go
+++ b/management/user_test.go
@@ -1,6 +1,7 @@
 package management
 
 import (
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -259,5 +260,43 @@ func TestUser(t *testing.T) {
 			t.Error("unexpected number of users found")
 		}
 		t.Logf("%v\n", us)
+	})
+}
+
+func TestUserIdentityUnmarshalling(t *testing.T) {
+	t.Run("user_id as a string", func(t *testing.T) {
+		identityJson := `
+{
+	"connection": "github",
+	"provider": "github",
+	"user_id": "123456",
+	"is_social": true
+}`
+		identity := UserIdentity{}
+		if err := json.Unmarshal([]byte(identityJson), &identity); err != nil {
+			t.Error(err)
+		}
+
+		if *identity.UserID != "123456" {
+			t.Errorf("incorret UserID")
+		}
+	})
+
+	t.Run("user_id as an int", func(t *testing.T) {
+		identityJson := `
+{
+	"connection": "github",
+	"provider": "github",
+	"user_id": 123456,
+	"is_social": true
+}`
+		identity := UserIdentity{}
+		if err := json.Unmarshal([]byte(identityJson), &identity); err != nil {
+			t.Error(err)
+		}
+
+		if *identity.UserID != "123456" {
+			t.Errorf("incorret UserID: %s", *identity.UserID)
+		}
 	})
 }


### PR DESCRIPTION
Auth0 API has a bug - in some cases it might return `identity.user_id` as a number. Particularly for GitHub identities for requests to the `/users/<user_id` endpoint. In this case JSON unmarshalling will fail with an error: 
`"json: cannot unmarshal number into Go struct field UserIdentity.identities.user_id of type string"`

I created a report in Auth0 community: https://community.auth0.com/t/users-user-id-returns-inconsistent-type-for-identities-user-id/39236
Meanwhile this PR should allow to work around this problem.