### PR TITLE
Make ConnectionOptions "polymorphic"

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -33,4 +33,4 @@ jobs:
       with:
         codeclimate-test-reporter-id: ${{ secrets.CC_TEST_REPORTER_ID }}
         codeclimate-test-reporter-version: latest
-        command: after-build --prefix gopkg.in/auth0.v3
+        command: after-build --prefix gopkg.in/auth0.v4

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Auth0 Go SDK
 
-[![GoDoc](https://godoc.org/gopkg.in/auth0.v3?status.svg)](https://godoc.org/gopkg.in/auth0.v3)
+[![GoDoc](https://godoc.org/gopkg.in/auth0.v4?status.svg)](https://godoc.org/gopkg.in/auth0.v4)
 [![build status](https://img.shields.io/github/workflow/status/go-auth0/auth0/Go)](https://github.com/go-auth0/auth0/actions?query=workflow%3ABuild+branch%3Amaster)
 [![Maintainability](https://img.shields.io/codeclimate/maintainability/go-auth0/auth0)](https://codeclimate.com/github/go-auth0/auth0/maintainability)
 [![Test Coverage](https://img.shields.io/codeclimate/coverage/go-auth0/auth0)](https://codeclimate.com/github/go-auth0/auth0/test_coverage)
@@ -17,8 +17,8 @@ The Auth0 Management API is meant to be used by back-end servers or trusted part
 
 ```go
 import (
-	gopkg.in/auth0.v3
-	gopkg.in/auth0.v3/management
+	gopkg.in/auth0.v4
+	gopkg.in/auth0.v4/management
 )
 ```
 

--- a/doc.go
+++ b/doc.go
@@ -4,8 +4,8 @@ Package auth0 provides a client for using the Auth0 Management API.
 Usage
 
     import (
-        gopkg.in/auth0.v3
-        gopkg.in/auth0.v3/management
+        gopkg.in/auth0.v4
+        gopkg.in/auth0.v4/management
     )
 
 Initialize a new client using a domain, client ID and secret.

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module gopkg.in/auth0.v3
+module gopkg.in/auth0.v4
 
 go 1.12
 

--- a/internal/tag/tag.go
+++ b/internal/tag/tag.go
@@ -1,0 +1,67 @@
+package tag
+
+import (
+	"reflect"
+)
+
+func Scopes(v interface{}) (scopes []string) {
+
+	val := reflect.ValueOf(v)
+	if val.Kind() == reflect.Ptr {
+		val = val.Elem()
+
+	}
+	typ := val.Type()
+
+	for i := 0; i < typ.NumField(); i++ {
+
+		if scope, ok := typ.Field(i).Tag.Lookup("scope"); ok {
+			if scope != "" {
+				field := val.Field(i)
+				if field.Kind() == reflect.Ptr {
+					field = field.Elem()
+				}
+				if field.Bool() {
+					scopes = append(scopes, scope)
+				}
+			}
+		}
+	}
+
+	return
+}
+
+func SetScopes(v interface{}, enable bool, scopes ...string) {
+
+	val := reflect.ValueOf(v)
+	if val.Kind() == reflect.Ptr {
+		val = val.Elem()
+
+	}
+	typ := val.Type()
+
+	in := func(scope string, scopes []string) bool {
+		for _, s := range scopes {
+			if s == scope {
+				return true
+			}
+		}
+		return false
+	}
+
+	for i := 0; i < typ.NumField(); i++ {
+
+		if scope, ok := typ.Field(i).Tag.Lookup("scope"); ok {
+			if in(scope, scopes) {
+				field := val.Field(i)
+				v := reflect.ValueOf(enable)
+				if field.Kind() == reflect.Ptr {
+					v = reflect.ValueOf(&enable)
+				}
+				if field.CanSet() {
+					field.Set(v)
+				}
+			}
+		}
+	}
+}

--- a/internal/tag/tag.go
+++ b/internal/tag/tag.go
@@ -21,7 +21,7 @@ func Scopes(v interface{}) (scopes []string) {
 				if field.Kind() == reflect.Ptr {
 					field = field.Elem()
 				}
-				if field.Bool() {
+				if field.CanAddr() && field.Bool() {
 					scopes = append(scopes, scope)
 				}
 			}

--- a/internal/tag/tag_test.go
+++ b/internal/tag/tag_test.go
@@ -3,7 +3,7 @@ package tag
 import (
 	"testing"
 
-	"gopkg.in/auth0.v3/internal/testing/expect"
+	"gopkg.in/auth0.v4/internal/testing/expect"
 )
 
 type test struct {

--- a/internal/tag/tag_test.go
+++ b/internal/tag/tag_test.go
@@ -10,6 +10,7 @@ type test struct {
 	Foo bool  `scope:"foo"`
 	Bar *bool `scope:"bar"`
 	Baz *bool `scope:"baz"`
+	Bam *bool `scope:"bam"`
 }
 
 func TestScopes(t *testing.T) {

--- a/internal/tag/tag_test.go
+++ b/internal/tag/tag_test.go
@@ -1,0 +1,29 @@
+package tag
+
+import (
+	"testing"
+
+	"gopkg.in/auth0.v3/internal/testing/expect"
+)
+
+type test struct {
+	Foo bool  `scope:"foo"`
+	Bar *bool `scope:"bar"`
+	Baz *bool `scope:"baz"`
+}
+
+func TestScopes(t *testing.T) {
+	c := &test{
+		Foo: true,
+		Bar: func(b bool) *bool { return &b }(true),
+		Baz: func(b bool) *bool { return &b }(false),
+	}
+	expect.Expect(t, Scopes(c), []string{"foo", "bar"})
+}
+
+func TestSetScopes(t *testing.T) {
+	c := &test{}
+	SetScopes(c, true, "foo", "bar")
+	expect.Expect(t, c.Foo, true)
+	expect.Expect(t, c.Bar, func(b bool) *bool { return &b }(true))
+}

--- a/management/blacklist_test.go
+++ b/management/blacklist_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"gopkg.in/auth0.v3"
+	"gopkg.in/auth0.v4"
 )
 
 func TestBlacklist(t *testing.T) {

--- a/management/branding_test.go
+++ b/management/branding_test.go
@@ -3,7 +3,7 @@ package management
 import (
 	"testing"
 
-	"gopkg.in/auth0.v3"
+	"gopkg.in/auth0.v4"
 )
 
 func TestBranding(t *testing.T) {

--- a/management/client_grant_test.go
+++ b/management/client_grant_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"gopkg.in/auth0.v3"
+	"gopkg.in/auth0.v4"
 )
 
 func TestClientGrant(t *testing.T) {

--- a/management/client_test.go
+++ b/management/client_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"gopkg.in/auth0.v3"
+	"gopkg.in/auth0.v4"
 )
 
 func TestClient(t *testing.T) {

--- a/management/connection.go
+++ b/management/connection.go
@@ -498,9 +498,9 @@ type ConnectionOptionsAD struct {
 	LogoURL       *string       `json:"icon_url,omitempty"`
 	IPs           []interface{} `json:"ips"`
 
-	CertAuth             *bool `json:"certAuth"`
-	Kerberos             *bool `json:"kerberos"`
-	DisableCache         *bool `json:"disable_cache"`
+	CertAuth             *bool `json:"certAuth,omitempty"`
+	Kerberos             *bool `json:"kerberos,omitempty"`
+	DisableCache         *bool `json:"disable_cache,omitempty"`
 	BruteForceProtection *bool `json:"brute_force_protection,omitempty"`
 
 	SetUserAttributes *string `json:"set_user_root_attributes,omitempty"`

--- a/management/connection.go
+++ b/management/connection.go
@@ -6,6 +6,24 @@ import (
 	"gopkg.in/auth0.v3/internal/tag"
 )
 
+const (
+	ConnectionStrategyAuth0               = "auth0"
+	ConnectionStrategyGoogleOAuth2        = "google-oauth2"
+	ConnectionStrategyFacebook            = "facebook"
+	ConnectionStrategyApple               = "apple"
+	ConnectionStrategyLinkedin            = "linkedin"
+	ConnectionStrategyGitHub              = "github"
+	ConnectionStrategyWindowsLive         = "windowslive"
+	ConnectionStrategySalesforce          = "salesforce"
+	ConnectionStrategySalesforceCommunity = "salesforce-community"
+	ConnectionStrategySalesforceSandbox   = "salesforce-sandbox"
+	ConnectionStrategyEmail               = "email"
+	ConnectionStrategySMS                 = "sms"
+	ConnectionStrategyOIDC                = "oidc"
+	ConnectionStrategyAD                  = "ad"
+	ConnectionStrategyAzureAD             = "waad"
+)
+
 type Connection struct {
 	// A generated string identifying the connection.
 	ID *string `json:"id,omitempty"`
@@ -102,6 +120,8 @@ func (c *Connection) UnmarshalJSON(b []byte) error {
 			v = &ConnectionOptionsSMS{}
 		case "oidc":
 			v = &ConnectionOptionsOIDC{}
+		case "ad":
+			v = &ConnectionOptionsAD{}
 		case "waad":
 			v = &ConnectionOptionsAzureAD{}
 		default:
@@ -468,6 +488,20 @@ type ConnectionOptionsOIDC struct {
 	TokenEndpoint         *string `json:"token_endpoint"`
 
 	Scope *string `json:"scope,omitempty"`
+}
+
+type ConnectionOptionsAD struct {
+	TenantDomain  *string       `json:"tenant_domain,omitempty"`
+	DomainAliases []interface{} `json:"domain_aliases,omitempty"`
+	LogoURL       *string       `json:"icon_url,omitempty"`
+	IPs           []interface{} `json:"ips"`
+
+	CertAuth             *bool `json:"certAuth"`
+	Kerberos             *bool `json:"kerberos"`
+	DisableCache         *bool `json:"disable_cache"`
+	BruteForceProtection *bool `json:"brute_force_protection,omitempty"`
+
+	SetUserAttributes *string `json:"set_user_root_attributes,omitempty"`
 }
 
 type ConnectionOptionsAzureAD struct {

--- a/management/connection.go
+++ b/management/connection.go
@@ -381,7 +381,6 @@ type ConnectionOptionsWindowsLive struct {
 	SetUserAttributes *string `json:"set_user_root_attributes,omitempty"`
 }
 
-// Salesforce
 type ConnectionOptionsSalesforce struct {
 	ClientID     *string `json:"client_id,omitempty"`
 	ClientSecret *string `json:"client_secret,omitempty"`
@@ -411,22 +410,6 @@ type ConnectionOptionsOIDC struct {
 	TokenEndpoint         *string `json:"token_endpoint"`
 
 	Scope *string `json:"scope,omitempty"`
-
-	// "scope": "openid profile email",
-	// "icon_url": "https://alexkappa.com/logo.png",
-	// "discovery_url": "https://alexkappa.eu.auth0.com",
-	// "authorization_endpoint": "https://alexkappa.eu.auth0.com/authorize",
-	// "issuer": "https://alexkappa.eu.auth0.com/",
-	// "jwks_uri": "https://alexkappa.eu.auth0.com/.well-known/jwks.json",
-	// "type": "front_channel",
-	// "userinfo_endpoint": "https://alexkappa.eu.auth0.com/userinfo",
-	// "token_endpoint": null,
-	// "client_id": "foo",
-	// "domain_aliases": [
-	// 	"alexkappa.com",
-	// 	"api.alexkappa.com"
-	// ],
-	// "tenant_domain": "alexkappa.com"
 }
 
 // Azure AD

--- a/management/connection.go
+++ b/management/connection.go
@@ -98,31 +98,33 @@ func (c *Connection) UnmarshalJSON(b []byte) error {
 		var v interface{}
 
 		switch *c.Strategy {
-		case "auth0":
+		case ConnectionStrategyAuth0:
 			v = &ConnectionOptions{}
-		case "google-oauth2":
+		case ConnectionStrategyGoogleOAuth2:
 			v = &ConnectionOptionsGoogleOAuth2{}
-		case "facebook":
+		case ConnectionStrategyFacebook:
 			v = &ConnectionOptionsFacebook{}
-		case "apple":
+		case ConnectionStrategyApple:
 			v = &ConnectionOptionsApple{}
-		case "linkedin":
+		case ConnectionStrategyLinkedin:
 			v = &ConnectionOptionsLinkedin{}
-		case "github":
+		case ConnectionStrategyGitHub:
 			v = &ConnectionOptionsGitHub{}
-		case "windowslive":
+		case ConnectionStrategyWindowsLive:
 			v = &ConnectionOptionsWindowsLive{}
-		case "salesforce":
+		case ConnectionStrategySalesforce,
+			ConnectionStrategySalesforceCommunity,
+			ConnectionStrategySalesforceSandbox:
 			v = &ConnectionOptionsSalesforce{}
-		case "email":
+		case ConnectionStrategyEmail:
 			v = &ConnectionOptionsEmail{}
-		case "sms":
+		case ConnectionStrategySMS:
 			v = &ConnectionOptionsSMS{}
-		case "oidc":
+		case ConnectionStrategyOIDC:
 			v = &ConnectionOptionsOIDC{}
-		case "ad":
+		case ConnectionStrategyAD:
 			v = &ConnectionOptionsAD{}
-		case "waad":
+		case ConnectionStrategyAzureAD:
 			v = &ConnectionOptionsAzureAD{}
 		default:
 			v = make(map[string]interface{})

--- a/management/connection.go
+++ b/management/connection.go
@@ -82,7 +82,7 @@ func (c *Connection) UnmarshalJSON(b []byte) error {
 		case "auth0":
 			v = &ConnectionOptions{}
 		case "google-oauth2":
-			v = &ConnectionOptionsGooleOAuth2{}
+			v = &ConnectionOptionsGoogleOAuth2{}
 		case "facebook":
 			v = &ConnectionOptionsFacebook{}
 		case "apple":
@@ -162,7 +162,7 @@ type ConnectionOptions struct {
 	StrategyVersion *int `json:"strategy_version"`
 }
 
-type ConnectionOptionsGooleOAuth2 struct {
+type ConnectionOptionsGoogleOAuth2 struct {
 	ClientID     *string `json:"client_id,omitempty"`
 	ClientSecret *string `json:"client_secret,omitempty"`
 

--- a/management/connection.go
+++ b/management/connection.go
@@ -2,6 +2,8 @@ package management
 
 import (
 	"encoding/json"
+
+	"gopkg.in/auth0.v3/internal/tag"
 )
 
 type Connection struct {
@@ -167,88 +169,105 @@ type ConnectionOptionsGoogleOAuth2 struct {
 
 	AllowedAudiences []interface{} `json:"allowed_audiences,omitempty"`
 
-	Email                  *bool `json:"email,omitempty"`
-	Profile                *bool `json:"profile,omitempty"`
-	Contacts               *bool `json:"contacts,omitempty"`
-	Blogger                *bool `json:"blogger,omitempty"`
-	Calendar               *bool `json:"calendar,omitempty"`
-	Gmail                  *bool `json:"gmail,omitempty"`
-	GooglePlus             *bool `json:"google_plus,omitempty"`
-	Orkut                  *bool `json:"orkut,omitempty"`
-	PicasaWeb              *bool `json:"picasa_web,omitempty"`
-	Tasks                  *bool `json:"tasks,omitempty"`
-	Youtube                *bool `json:"youtube,omitempty"`
-	AdsenseManagement      *bool `json:"adsense_management,omitempty"`
-	GoogleAffiliateNetwork *bool `json:"google_affiliate_network,omitempty"`
-	Analytics              *bool `json:"analytics,omitempty"`
-	GoogleBooks            *bool `json:"google_books,omitempty"`
-	GoogleCloudStorage     *bool `json:"google_cloud_storage,omitempty"`
-	ContentAPIForShopping  *bool `json:"content_api_for_shopping,omitempty"`
-	ChromeWebStore         *bool `json:"chrome_web_store,omitempty"`
-	DocumentList           *bool `json:"document_list,omitempty"`
-	GoogleDrive            *bool `json:"google_drive,omitempty"`
-	GoogleDriveFiles       *bool `json:"google_drive_files,omitempty"`
-	LatitudeBest           *bool `json:"latitude_best,omitempty"`
-	LatitudeCity           *bool `json:"latitude_city,omitempty"`
-	Moderator              *bool `json:"moderator,omitempty"`
-	Sites                  *bool `json:"sites,omitempty"`
-	Spreadsheets           *bool `json:"spreadsheets,omitempty"`
-	URLShortener           *bool `json:"url_shortener,omitempty"`
-	WebmasterTools         *bool `json:"webmaster_tools,omitempty"`
-	Coordinate             *bool `json:"coordinate,omitempty"`
-	CoordinateReadonly     *bool `json:"coordinate_readonly,omitempty"`
+	Email                  *bool `json:"email,omitempty" scope:"email"`
+	Profile                *bool `json:"profile,omitempty" scope:"profile"`
+	Contacts               *bool `json:"contacts,omitempty" scope:"contacts"`
+	Blogger                *bool `json:"blogger,omitempty" scope:"blogger"`
+	Calendar               *bool `json:"calendar,omitempty" scope:"calendar"`
+	Gmail                  *bool `json:"gmail,omitempty" scope:"gmail"`
+	GooglePlus             *bool `json:"google_plus,omitempty" scope:"google_plus"`
+	Orkut                  *bool `json:"orkut,omitempty" scope:"orkut"`
+	PicasaWeb              *bool `json:"picasa_web,omitempty" scope:"picasa_web"`
+	Tasks                  *bool `json:"tasks,omitempty" scope:"tasks"`
+	Youtube                *bool `json:"youtube,omitempty" scope:"youtube"`
+	AdsenseManagement      *bool `json:"adsense_management,omitempty" scope:"adsense_management"`
+	GoogleAffiliateNetwork *bool `json:"google_affiliate_network,omitempty" scope:"google_affiliate_network"`
+	Analytics              *bool `json:"analytics,omitempty" scope:"analytics"`
+	GoogleBooks            *bool `json:"google_books,omitempty" scope:"google_books"`
+	GoogleCloudStorage     *bool `json:"google_cloud_storage,omitempty" scope:"google_cloud_storage"`
+	ContentAPIForShopping  *bool `json:"content_api_for_shopping,omitempty" scope:"content_api_for_shopping"`
+	ChromeWebStore         *bool `json:"chrome_web_store,omitempty" scope:"chrome_web_store"`
+	DocumentList           *bool `json:"document_list,omitempty" scope:"document_list"`
+	GoogleDrive            *bool `json:"google_drive,omitempty" scope:"google_drive"`
+	GoogleDriveFiles       *bool `json:"google_drive_files,omitempty" scope:"google_drive_files"`
+	LatitudeBest           *bool `json:"latitude_best,omitempty" scope:"latitude_best"`
+	LatitudeCity           *bool `json:"latitude_city,omitempty" scope:"latitude_city"`
+	Moderator              *bool `json:"moderator,omitempty" scope:"moderator"`
+	Sites                  *bool `json:"sites,omitempty" scope:"sites"`
+	Spreadsheets           *bool `json:"spreadsheets,omitempty" scope:"spreadsheets"`
+	URLShortener           *bool `json:"url_shortener,omitempty" scope:"url_shortener"`
+	WebmasterTools         *bool `json:"webmaster_tools,omitempty" scope:"webmaster_tools"`
+	Coordinate             *bool `json:"coordinate,omitempty" scope:"coordinate"`
+	CoordinateReadonly     *bool `json:"coordinate_readonly,omitempty" scope:"coordinate_readonly"`
 
 	Scope []interface{} `json:"scope,omitempty"`
+}
+
+func (c *ConnectionOptionsGoogleOAuth2) Scopes() []string {
+	return tag.Scopes(c)
+}
+
+func (c *ConnectionOptionsGoogleOAuth2) SetScopes(enable bool, scopes ...string) {
+	tag.SetScopes(c, true, scopes...)
 }
 
 type ConnectionOptionsFacebook struct {
 	ClientID     *string `json:"client_id,omitempty"`
 	ClientSecret *string `json:"client_secret,omitempty"`
 
-	Email                       *bool `json:"email,omitempty"`
-	GroupsAccessMemberInfo      *bool `json:"groups_access_member_info,omitempty"`
-	PublishToGroups             *bool `json:"publish_to_groups,omitempty"`
-	UserAgeRange                *bool `json:"user_age_range,omitempty"`
-	UserBirthday                *bool `json:"user_birthday,omitempty"`
-	AdsManagement               *bool `json:"ads_management,omitempty"`
-	AdsRead                     *bool `json:"ads_read,omitempty"`
-	ReadAudienceNetworkInsights *bool `json:"read_audience_network_insights,omitempty"`
-	ReadInsights                *bool `json:"read_insights,omitempty"`
-	ManageNotifications         *bool `json:"manage_notifications,omitempty"`
-	PublishActions              *bool `json:"publish_actions,omitempty"`
-	ReadMailbox                 *bool `json:"read_mailbox,omitempty"`
-	PublicProfile               *bool `json:"public_profile,omitempty"`
-	UserEvents                  *bool `json:"user_events,omitempty"`
-	UserFriends                 *bool `json:"user_friends,omitempty"`
-	UserGender                  *bool `json:"user_gender,omitempty"`
-	UserHometown                *bool `json:"user_hometown,omitempty"`
-	UserLikes                   *bool `json:"user_likes,omitempty"`
-	UserLink                    *bool `json:"user_link,omitempty"`
-	UserLocation                *bool `json:"user_location,omitempty"`
-	UserPhotos                  *bool `json:"user_photos,omitempty"`
-	UserPosts                   *bool `json:"user_posts,omitempty"`
-	UserTaggedPlaces            *bool `json:"user_tagged_places,omitempty"`
-	UserVideos                  *bool `json:"user_videos,omitempty"`
-	BusinessManagement          *bool `json:"business_management,omitempty"`
-	LeadsRetrieval              *bool `json:"leads_retrieval,omitempty"`
-	ManagePages                 *bool `json:"manage_pages,omitempty"`
-	PagesManageCTA              *bool `json:"pages_manage_cta,omitempty"`
-	PagesManageInstantArticles  *bool `json:"pages_manage_instant_articles,omitempty"`
-	PagesShowList               *bool `json:"pages_show_list,omitempty"`
-	PagesMessaging              *bool `json:"pages_messaging,omitempty"`
-	PagesMessagingPhoneNumber   *bool `json:"pages_messaging_phone_number,omitempty"`
-	PagesMessagingSubscriptions *bool `json:"pages_messaging_subscriptions,omitempty"`
-	PublishPages                *bool `json:"publish_pages,omitempty"`
-	PublishVideo                *bool `json:"publish_video,omitempty"`
-	ReadPageMailboxes           *bool `json:"read_page_mailboxes,omitempty"`
-	ReadStream                  *bool `json:"read_stream,omitempty"`
-	UserGroups                  *bool `json:"user_groups,omitempty"`
-	UserManagedGroups           *bool `json:"user_managed_groups,omitempty"`
-	UserStatus                  *bool `json:"user_status,omitempty"`
-	AllowContextProfileField    *bool `json:"allow_context_profile_field,omitempty"`
+	AllowContextProfileField *bool `json:"allow_context_profile_field,omitempty"`
+
+	Email                       *bool `json:"email,omitempty" scope:"email"`
+	GroupsAccessMemberInfo      *bool `json:"groups_access_member_info,omitempty" scope:"groups_access_member_info"`
+	PublishToGroups             *bool `json:"publish_to_groups,omitempty" scope:"publish_to_groups"`
+	UserAgeRange                *bool `json:"user_age_range,omitempty" scope:"user_age_range"`
+	UserBirthday                *bool `json:"user_birthday,omitempty" scope:"user_birthday"`
+	AdsManagement               *bool `json:"ads_management,omitempty" scope:"ads_management"`
+	AdsRead                     *bool `json:"ads_read,omitempty" scope:"ads_read"`
+	ReadAudienceNetworkInsights *bool `json:"read_audience_network_insights,omitempty" scope:"read_audience_network_insights"`
+	ReadInsights                *bool `json:"read_insights,omitempty" scope:"read_insights"`
+	ManageNotifications         *bool `json:"manage_notifications,omitempty" scope:"manage_notifications"`
+	PublishActions              *bool `json:"publish_actions,omitempty" scope:"publish_actions"`
+	ReadMailbox                 *bool `json:"read_mailbox,omitempty" scope:"read_mailbox"`
+	PublicProfile               *bool `json:"public_profile,omitempty" scope:"public_profile"`
+	UserEvents                  *bool `json:"user_events,omitempty" scope:"user_events"`
+	UserFriends                 *bool `json:"user_friends,omitempty" scope:"user_friends"`
+	UserGender                  *bool `json:"user_gender,omitempty" scope:"user_gender"`
+	UserHometown                *bool `json:"user_hometown,omitempty" scope:"user_hometown"`
+	UserLikes                   *bool `json:"user_likes,omitempty" scope:"user_likes"`
+	UserLink                    *bool `json:"user_link,omitempty" scope:"user_link"`
+	UserLocation                *bool `json:"user_location,omitempty" scope:"user_location"`
+	UserPhotos                  *bool `json:"user_photos,omitempty" scope:"user_photos"`
+	UserPosts                   *bool `json:"user_posts,omitempty" scope:"user_posts"`
+	UserTaggedPlaces            *bool `json:"user_tagged_places,omitempty" scope:"user_tagged_places"`
+	UserVideos                  *bool `json:"user_videos,omitempty" scope:"user_videos"`
+	BusinessManagement          *bool `json:"business_management,omitempty" scope:"business_management"`
+	LeadsRetrieval              *bool `json:"leads_retrieval,omitempty" scope:"leads_retrieval"`
+	ManagePages                 *bool `json:"manage_pages,omitempty" scope:"manage_pages"`
+	PagesManageCTA              *bool `json:"pages_manage_cta,omitempty" scope:"pages_manage_cta"`
+	PagesManageInstantArticles  *bool `json:"pages_manage_instant_articles,omitempty" scope:"pages_manage_instant_articles"`
+	PagesShowList               *bool `json:"pages_show_list,omitempty" scope:"pages_show_list"`
+	PagesMessaging              *bool `json:"pages_messaging,omitempty" scope:"pages_messaging"`
+	PagesMessagingPhoneNumber   *bool `json:"pages_messaging_phone_number,omitempty" scope:"pages_messaging_phone_number"`
+	PagesMessagingSubscriptions *bool `json:"pages_messaging_subscriptions,omitempty" scope:"pages_messaging_subscriptions"`
+	PublishPages                *bool `json:"publish_pages,omitempty" scope:"publish_pages"`
+	PublishVideo                *bool `json:"publish_video,omitempty" scope:"publish_video"`
+	ReadPageMailboxes           *bool `json:"read_page_mailboxes,omitempty" scope:"read_page_mailboxes"`
+	ReadStream                  *bool `json:"read_stream,omitempty" scope:"read_stream"`
+	UserGroups                  *bool `json:"user_groups,omitempty" scope:"user_groups"`
+	UserManagedGroups           *bool `json:"user_managed_groups,omitempty" scope:"user_managed_groups"`
+	UserStatus                  *bool `json:"user_status,omitempty" scope:"user_status"`
 
 	// Scope is a comma separated list of scopes.
 	Scope *string `json:"scope,omitempty"`
+}
+
+func (c *ConnectionOptionsFacebook) Scopes() []string {
+	return tag.Scopes(c)
+}
+
+func (c *ConnectionOptionsFacebook) SetScopes(enable bool, scopes ...string) {
+	tag.SetScopes(c, true, scopes...)
 }
 
 type ConnectionOptionsApple struct {
@@ -258,10 +277,18 @@ type ConnectionOptionsApple struct {
 	TeamID *string `json:"team_id,omitempty"`
 	KeyID  *string `json:"kid,omitempty"`
 
-	Name  *bool `json:"name,omitempty"`
-	Email *bool `json:"email,omitempty"`
+	Name  *bool `json:"name,omitempty" scope:"name"`
+	Email *bool `json:"email,omitempty" scope:"email"`
 
 	Scope *string `json:"scope,omitempty"`
+}
+
+func (c *ConnectionOptionsApple) Scopes() []string {
+	return tag.Scopes(c)
+}
+
+func (c *ConnectionOptionsApple) SetScopes(enable bool, scopes ...string) {
+	tag.SetScopes(c, true, scopes...)
 }
 
 type ConnectionOptionsLinkedin struct {
@@ -270,43 +297,59 @@ type ConnectionOptionsLinkedin struct {
 
 	StrategyVersion *int `json:"strategy_version"`
 
-	Email        *bool `json:"email,omitempty"`
-	Profile      *bool `json:"profile,omitempty"`
-	BasicProfile *bool `json:"basic_profile,omitempty"`
+	Email        *bool `json:"email,omitempty" scope:"email"`
+	Profile      *bool `json:"profile,omitempty" scope:"profile"`
+	BasicProfile *bool `json:"basic_profile,omitempty" scope:"basic_profile"`
 
 	Scope []interface{} `json:"scope,omitempty"`
 
 	SetUserAttributes *string `json:"set_user_root_attributes,omitempty"`
 }
 
+func (c *ConnectionOptionsLinkedin) Scopes() []string {
+	return tag.Scopes(c)
+}
+
+func (c *ConnectionOptionsLinkedin) SetScopes(enable bool, scopes ...string) {
+	tag.SetScopes(c, true, scopes...)
+}
+
 type ConnectionOptionsGitHub struct {
 	ClientID     *string `json:"client_id,omitempty"`
 	ClientSecret *string `json:"client_secret,omitempty"`
 
-	Email          *bool `json:"email,omitempty"`
-	ReadUser       *bool `json:"read_user,omitempty"`
-	Follow         *bool `json:"follow,omitempty"`
-	PublicRepo     *bool `json:"public_repo,omitempty"`
-	Repo           *bool `json:"repo,omitempty"`
-	RepoDeployment *bool `json:"repo_deployment,omitempty"`
-	RepoStatus     *bool `json:"repo_status,omitempty"`
-	DeleteRepo     *bool `json:"delete_repo,omitempty"`
-	Notifications  *bool `json:"notifications,omitempty"`
-	Gist           *bool `json:"gist,omitempty"`
-	ReadRepoHook   *bool `json:"read_repo_hook,omitempty"`
-	WriteRepoHook  *bool `json:"write_repo_hook,omitempty"`
-	AdminRepoHook  *bool `json:"admin_repo_hook,omitempty"`
-	ReadOrg        *bool `json:"read_org,omitempty"`
-	AdminOrg       *bool `json:"admin_org,omitempty"`
-	ReadPublicKey  *bool `json:"read_public_key,omitempty"`
-	WritePublicKey *bool `json:"write_public_key,omitempty"`
-	AdminPublicKey *bool `json:"admin_public_key,omitempty"`
-	WriteOrg       *bool `json:"write_org,omitempty"`
-	Profile        *bool `json:"profile,omitempty"`
+	Email          *bool `json:"email,omitempty" scope:"email"`
+	ReadUser       *bool `json:"read_user,omitempty" scope:"read_user"`
+	Follow         *bool `json:"follow,omitempty" scope:"follow"`
+	PublicRepo     *bool `json:"public_repo,omitempty" scope:"public_repo"`
+	Repo           *bool `json:"repo,omitempty" scope:"repo"`
+	RepoDeployment *bool `json:"repo_deployment,omitempty" scope:"repo_deployment"`
+	RepoStatus     *bool `json:"repo_status,omitempty" scope:"repo_status"`
+	DeleteRepo     *bool `json:"delete_repo,omitempty" scope:"delete_repo"`
+	Notifications  *bool `json:"notifications,omitempty" scope:"notifications"`
+	Gist           *bool `json:"gist,omitempty" scope:"gist"`
+	ReadRepoHook   *bool `json:"read_repo_hook,omitempty" scope:"read_repo_hook"`
+	WriteRepoHook  *bool `json:"write_repo_hook,omitempty" scope:"write_repo_hook"`
+	AdminRepoHook  *bool `json:"admin_repo_hook,omitempty" scope:"admin_repo_hook"`
+	ReadOrg        *bool `json:"read_org,omitempty" scope:"read_org"`
+	AdminOrg       *bool `json:"admin_org,omitempty" scope:"admin_org"`
+	ReadPublicKey  *bool `json:"read_public_key,omitempty" scope:"read_public_key"`
+	WritePublicKey *bool `json:"write_public_key,omitempty" scope:"write_public_key"`
+	AdminPublicKey *bool `json:"admin_public_key,omitempty" scope:"admin_public_key"`
+	WriteOrg       *bool `json:"write_org,omitempty" scope:"write_org"`
+	Profile        *bool `json:"profile,omitempty" scope:"profile"`
 
 	Scope []interface{} `json:"scope,omitempty"`
 
 	SetUserAttributes *string `json:"set_user_root_attributes,omitempty"`
+}
+
+func (c *ConnectionOptionsGitHub) Scopes() []string {
+	return tag.Scopes(c)
+}
+
+func (c *ConnectionOptionsGitHub) SetScopes(enable bool, scopes ...string) {
+	tag.SetScopes(c, true, scopes...)
 }
 
 type ConnectionOptionsEmail struct {
@@ -352,44 +395,60 @@ type ConnectionOptionsWindowsLive struct {
 
 	StrategyVersion *int `json:"strategy_version"`
 
-	OfflineAccess   *bool `json:"offline_access,omitempty"`
-	UserUpdate      *bool `json:"graph_user_update,omitempty"`
-	UserActivity    *bool `json:"graph_user_activity,omitempty"`
-	Device          *bool `json:"graph_device,omitempty"`
-	Emails          *bool `json:"graph_emails,omitempty"`
-	NotesUpdate     *bool `json:"graph_notes_update,omitempty"`
-	User            *bool `json:"graph_user,omitempty"`
-	DeviceCommand   *bool `json:"graph_device_command,omitempty"`
-	EmailsUpdate    *bool `json:"graph_emails_update,omitempty"`
-	Calendars       *bool `json:"graph_calendars,omitempty"`
-	CalendarsUpdate *bool `json:"graph_calendars_update,omitempty"`
-	Contacts        *bool `json:"graph_contacts,omitempty"`
-	ContactsUpdate  *bool `json:"graph_contacts_update,omitempty"`
-	Files           *bool `json:"graph_files,omitempty"`
-	FilesAll        *bool `json:"graph_files_all,omitempty"`
-	FilesUpdate     *bool `json:"graph_files_update,omitempty"`
-	FilesAllUpdate  *bool `json:"graph_files_all_update,omitempty"`
-	Notes           *bool `json:"graph_notes,omitempty"`
-	NotesCreate     *bool `json:"graph_notes_create,omitempty"`
-	Tasks           *bool `json:"graph_tasks,omitempty"`
-	TasksUpdate     *bool `json:"graph_tasks_update,omitempty"`
-	Signin          *bool `json:"signin,omitempty"`
+	OfflineAccess   *bool `json:"offline_access,omitempty" scope:"offline_access"`
+	UserUpdate      *bool `json:"graph_user_update,omitempty" scope:"graph_user_update"`
+	UserActivity    *bool `json:"graph_user_activity,omitempty" scope:"graph_user_activity"`
+	Device          *bool `json:"graph_device,omitempty" scope:"graph_device"`
+	Emails          *bool `json:"graph_emails,omitempty" scope:"graph_emails"`
+	NotesUpdate     *bool `json:"graph_notes_update,omitempty" scope:"graph_notes_update"`
+	User            *bool `json:"graph_user,omitempty" scope:"graph_user"`
+	DeviceCommand   *bool `json:"graph_device_command,omitempty" scope:"graph_device_command"`
+	EmailsUpdate    *bool `json:"graph_emails_update,omitempty" scope:"graph_emails_update"`
+	Calendars       *bool `json:"graph_calendars,omitempty" scope:"graph_calendars"`
+	CalendarsUpdate *bool `json:"graph_calendars_update,omitempty" scope:"graph_calendars_update"`
+	Contacts        *bool `json:"graph_contacts,omitempty" scope:"graph_contacts"`
+	ContactsUpdate  *bool `json:"graph_contacts_update,omitempty" scope:"graph_contacts_update"`
+	Files           *bool `json:"graph_files,omitempty" scope:"graph_files"`
+	FilesAll        *bool `json:"graph_files_all,omitempty" scope:"graph_files_all"`
+	FilesUpdate     *bool `json:"graph_files_update,omitempty" scope:"graph_files_update"`
+	FilesAllUpdate  *bool `json:"graph_files_all_update,omitempty" scope:"graph_files_all_update"`
+	Notes           *bool `json:"graph_notes,omitempty" scope:"graph_notes"`
+	NotesCreate     *bool `json:"graph_notes_create,omitempty" scope:"graph_notes_create"`
+	Tasks           *bool `json:"graph_tasks,omitempty" scope:"graph_tasks"`
+	TasksUpdate     *bool `json:"graph_tasks_update,omitempty" scope:"graph_tasks_update"`
+	Signin          *bool `json:"signin,omitempty" scope:"signin"`
 
 	Scope []interface{} `json:"scope,omitempty"`
 
 	SetUserAttributes *string `json:"set_user_root_attributes,omitempty"`
 }
 
+func (c *ConnectionOptionsWindowsLive) Scopes() []string {
+	return tag.Scopes(c)
+}
+
+func (c *ConnectionOptionsWindowsLive) SetScopes(enable bool, scopes ...string) {
+	tag.SetScopes(c, true, scopes...)
+}
+
 type ConnectionOptionsSalesforce struct {
 	ClientID     *string `json:"client_id,omitempty"`
 	ClientSecret *string `json:"client_secret,omitempty"`
 
-	Profile *bool `json:"profile,omitempty"`
+	Profile *bool `json:"profile,omitempty" scope:"profile"`
 
 	Scope []interface{} `json:"scope,omitempty"`
 
 	CommunityBaseURL  *string `json:"community_base_url,omitempty"`
 	SetUserAttributes *string `json:"set_user_root_attributes,omitempty"`
+}
+
+func (c *ConnectionOptionsSalesforce) Scopes() []string {
+	return tag.Scopes(c)
+}
+
+func (c *ConnectionOptionsSalesforce) SetScopes(enable bool, scopes ...string) {
+	tag.SetScopes(c, true, scopes...)
 }
 
 type ConnectionOptionsOIDC struct {
@@ -431,14 +490,22 @@ type ConnectionOptionsAzureAD struct {
 	EnableUsersAPI      *bool   `json:"api_enable_users,omitempty"`
 	MaxGroupsToRetrieve *string `json:"max_groups_to_retrieve,omitempty"`
 
-	BasicProfile    *bool `json:"basic_profile,omitempty"`
-	ExtendedProfile *bool `json:"ext_profile,omitempty"`
-	Groups          *bool `json:"ext_groups,omitempty"`
-	NestedGroups    *bool `json:"ext_nested_groups,omitempty"`
-	Admin           *bool `json:"ext_admin,omitempty"`
-	IsSuspended     *bool `json:"ext_is_suspended,omitempty"`
-	AgreedTerms     *bool `json:"ext_agreed_terms,omitempty"`
-	AssignedPlans   *bool `json:"ext_assigned_plans,omitempty"`
+	BasicProfile    *bool `json:"basic_profile,omitempty" scope:"basic_profile"`
+	ExtendedProfile *bool `json:"ext_profile,omitempty" scope:"ext_profile"`
+	Groups          *bool `json:"ext_groups,omitempty" scope:"ext_groups"`
+	NestedGroups    *bool `json:"ext_nested_groups,omitempty" scope:"ext_nested_groups"`
+	Admin           *bool `json:"ext_admin,omitempty" scope:"ext_admin"`
+	IsSuspended     *bool `json:"ext_is_suspended,omitempty" scope:"ext_is_suspended"`
+	AgreedTerms     *bool `json:"ext_agreed_terms,omitempty" scope:"ext_agreed_terms"`
+	AssignedPlans   *bool `json:"ext_assigned_plans,omitempty" scope:"ext_assigned_plans"`
+}
+
+func (c *ConnectionOptionsAzureAD) Scopes() []string {
+	return tag.Scopes(c)
+}
+
+func (c *ConnectionOptionsAzureAD) SetScopes(enable bool, scopes ...string) {
+	tag.SetScopes(c, true, scopes...)
 }
 
 type ConnectionOptionsADFS struct {

--- a/management/connection.go
+++ b/management/connection.go
@@ -1,5 +1,10 @@
 package management
 
+import (
+	"encoding/json"
+	"reflect"
+)
+
 type Connection struct {
 	// A generated string identifying the connection.
 	ID *string `json:"id,omitempty"`
@@ -29,7 +34,8 @@ type Connection struct {
 	IsDomainConnection *bool `json:"is_domain_connection,omitempty"`
 
 	// Options for validation.
-	Options *ConnectionOptions `json:"options,omitempty"`
+	Options    interface{}     `json:"-"`
+	RawOptions json.RawMessage `json:"options,omitempty"`
 
 	// The identifiers of the clients for which the connection is to be
 	// enabled. If the array is empty or the property is not specified, no
@@ -44,8 +50,80 @@ type Connection struct {
 	Metadata *interface{} `json:"metadata,omitempty"`
 }
 
-// ConnectionOptions general options
+func (c *Connection) MarshalJSON() ([]byte, error) {
+
+	type connection Connection
+
+	if c.Options != nil {
+		b, err := json.Marshal(c.Options)
+		if err != nil {
+			return nil, err
+		}
+		c.RawOptions = b
+	}
+
+	return json.Marshal((*connection)(c))
+}
+
+func (c *Connection) UnmarshalJSON(b []byte) error {
+
+	type connection Connection
+
+	err := json.Unmarshal(b, (*connection)(c))
+	if err != nil {
+		return err
+	}
+
+	if c.Strategy != nil {
+
+		var v interface{}
+
+		switch *c.Strategy {
+		case "auth0":
+			v = &ConnectionOptions{}
+		case "google-oauth2":
+			v = &ConnectionOptionsGooleOAuth2{}
+		case "facebook":
+			v = &ConnectionOptionsFacebook{}
+		case "apple":
+			v = &ConnectionOptionsApple{}
+		case "linkedin":
+			v = &ConnectionOptionsLinkedin{}
+		case "github":
+			v = &ConnectionOptionsGitHub{}
+		case "windowslive":
+			v = &ConnectionOptionsWindowsLive{}
+		case "salesforce":
+			v = &ConnectionOptionsSalesforce{}
+		case "email":
+			v = &ConnectionOptionsEmail{}
+		case "sms":
+			v = &ConnectionOptionsSMS{}
+		case "oidc":
+			v = &ConnectionOptionsOIDC{}
+		case "waad":
+			v = &ConnectionOptionsAzureAD{}
+		default:
+			v = &map[string]interface{}{}
+		}
+
+		err = json.Unmarshal(c.RawOptions, &v)
+		if err != nil {
+			return err
+		}
+
+		c.Options = reflect.ValueOf(v).Elem().Interface()
+	}
+
+	return nil
+}
+
 type ConnectionOptions struct {
+
+	// Options for multifactor authentication. Can be used to set active and
+	// return_enroll_settings.
+	MFA map[string]interface{} `json:"mfa,omitempty"`
+
 	// Options for validation.
 	Validation map[string]interface{} `json:"validation,omitempty"`
 
@@ -65,34 +143,15 @@ type ConnectionOptions struct {
 	// Options for password complexity options.
 	PasswordComplexityOptions map[string]interface{} `json:"password_complexity_options,omitempty"`
 
-	APIEnableUsers               *bool `json:"api_enable_users,omitempty"`
-	BasicProfile                 *bool `json:"basic_profile,omitempty"`
-	ExtAdmin                     *bool `json:"ext_admin,omitempty"`
-	ExtIsSuspended               *bool `json:"ext_is_suspended,omitempty"`
-	ExtAgreedTerms               *bool `json:"ext_agreed_terms,omitempty"`
-	ExtGroups                    *bool `json:"ext_groups,omitempty"`
-	ExtNestedGroups              *bool `json:"ext_nested_groups,omitempty"`
-	ExtAssignedPlans             *bool `json:"ext_assigned_plans,omitempty"`
-	ExtProfile                   *bool `json:"ext_profile,omitempty"`
 	EnabledDatabaseCustomization *bool `json:"enabledDatabaseCustomization,omitempty"`
-	BruteForceProtection         *bool `json:"brute_force_protection,omitempty"`
-	ImportMode                   *bool `json:"import_mode,omitempty"`
-	DisableSignup                *bool `json:"disable_signup,omitempty"`
-	RequiresUsername             *bool `json:"requires_username,omitempty"`
 
-	// Options for adding parameters in the request to the upstream IdP.
-	UpstreamParams *interface{} `json:"upstream_params,omitempty"`
+	BruteForceProtection *bool `json:"brute_force_protection,omitempty"`
 
-	ClientID            *string       `json:"client_id,omitempty"`
-	ClientSecret        *string       `json:"client_secret,omitempty"`
-	TenantDomain        *string       `json:"tenant_domain,omitempty"`
-	DomainAliases       []interface{} `json:"domain_aliases,omitempty"`
-	UseWsfed            *bool         `json:"use_wsfed,omitempty"`
-	WaadProtocol        *string       `json:"waad_protocol,omitempty"`
-	WaadCommonEndpoint  *bool         `json:"waad_common_endpoint,omitempty"`
-	AppID               *string       `json:"app_id,omitempty"`
-	AppDomain           *string       `json:"app_domain,omitempty"`
-	MaxGroupsToRetrieve *string       `json:"max_groups_to_retrieve,omitempty"`
+	ImportMode *bool `json:"import_mode,omitempty"`
+
+	DisableSignup *bool `json:"disable_signup,omitempty"`
+
+	RequiresUsername *bool `json:"requires_username,omitempty"`
 
 	// Scripts for the connection
 	// Allowed keys are: "get_user", "login", "create", "verify", "change_password", "delete" or "change_email".
@@ -100,27 +159,304 @@ type ConnectionOptions struct {
 	// configuration variables that can be used in custom scripts
 	Configuration map[string]interface{} `json:"configuration,omitempty"`
 
-	// Options to add integration with Twilio
-	// https://community.auth0.com/t/using-management-api-to-create-a-twilio-connection/23576/3
-	Totp                *ConnectionOptionsTotp `json:"totp,omitempty"`
-	Name                *string                `json:"name,omitempty"`
-	TwilioSid           *string                `json:"twilio_sid,omitempty"`
-	TwilioToken         *string                `json:"twilio_token,omitempty"`
-	From                *string                `json:"from,omitempty"`
-	Syntax              *string                `json:"syntax,omitempty"`
-	Template            *string                `json:"template,omitempty"`
-	MessagingServiceSid *string                `json:"messaging_service_sid,omitempty"`
-
-	// Adfs
-	AdfsServer *string `json:"adfs_server,omitempty"`
-
-	// Salesforce community
-	CommunityBaseURL *string `json:"community_base_url"`
-
-	// Windowslive strategy version:
-	//   1 => Live Connect (DEPRECATED)
-	//   2 => Azure AD (personal accounts)
 	StrategyVersion *int `json:"strategy_version"`
+}
+
+type ConnectionOptionsGooleOAuth2 struct {
+	ClientID     *string `json:"client_id,omitempty"`
+	ClientSecret *string `json:"client_secret,omitempty"`
+
+	AllowedAudiences []interface{} `json:"allowed_audiences,omitempty"`
+
+	Email                  *bool `json:"email,omitempty"`
+	Profile                *bool `json:"profile,omitempty"`
+	Contacts               *bool `json:"contacts,omitempty"`
+	Blogger                *bool `json:"blogger,omitempty"`
+	Calendar               *bool `json:"calendar,omitempty"`
+	Gmail                  *bool `json:"gmail,omitempty"`
+	GooglePlus             *bool `json:"google_plus,omitempty"`
+	Orkut                  *bool `json:"orkut,omitempty"`
+	PicasaWeb              *bool `json:"picasa_web,omitempty"`
+	Tasks                  *bool `json:"tasks,omitempty"`
+	Youtube                *bool `json:"youtube,omitempty"`
+	AdsenseManagement      *bool `json:"adsense_management,omitempty"`
+	GoogleAffiliateNetwork *bool `json:"google_affiliate_network,omitempty"`
+	Analytics              *bool `json:"analytics,omitempty"`
+	GoogleBooks            *bool `json:"google_books,omitempty"`
+	GoogleCloudStorage     *bool `json:"google_cloud_storage,omitempty"`
+	ContentAPIForShopping  *bool `json:"content_api_for_shopping,omitempty"`
+	ChromeWebStore         *bool `json:"chrome_web_store,omitempty"`
+	DocumentList           *bool `json:"document_list,omitempty"`
+	GoogleDrive            *bool `json:"google_drive,omitempty"`
+	GoogleDriveFiles       *bool `json:"google_drive_files,omitempty"`
+	LatitudeBest           *bool `json:"latitude_best,omitempty"`
+	LatitudeCity           *bool `json:"latitude_city,omitempty"`
+	Moderator              *bool `json:"moderator,omitempty"`
+	Sites                  *bool `json:"sites,omitempty"`
+	Spreadsheets           *bool `json:"spreadsheets,omitempty"`
+	URLShortener           *bool `json:"url_shortener,omitempty"`
+	WebmasterTools         *bool `json:"webmaster_tools,omitempty"`
+	Coordinate             *bool `json:"coordinate,omitempty"`
+	CoordinateReadonly     *bool `json:"coordinate_readonly,omitempty"`
+
+	Scope []interface{} `json:"scope,omitempty"`
+}
+
+type ConnectionOptionsFacebook struct {
+	ClientID     *string `json:"client_id,omitempty"`
+	ClientSecret *string `json:"client_secret,omitempty"`
+
+	Email                       *bool `json:"email,omitempty"`
+	GroupsAccessMemberInfo      *bool `json:"groups_access_member_info,omitempty"`
+	PublishToGroups             *bool `json:"publish_to_groups,omitempty"`
+	UserAgeRange                *bool `json:"user_age_range,omitempty"`
+	UserBirthday                *bool `json:"user_birthday,omitempty"`
+	AdsManagement               *bool `json:"ads_management,omitempty"`
+	AdsRead                     *bool `json:"ads_read,omitempty"`
+	ReadAudienceNetworkInsights *bool `json:"read_audience_network_insights,omitempty"`
+	ReadInsights                *bool `json:"read_insights,omitempty"`
+	ManageNotifications         *bool `json:"manage_notifications,omitempty"`
+	PublishActions              *bool `json:"publish_actions,omitempty"`
+	ReadMailbox                 *bool `json:"read_mailbox,omitempty"`
+	PublicProfile               *bool `json:"public_profile,omitempty"`
+	UserEvents                  *bool `json:"user_events,omitempty"`
+	UserFriends                 *bool `json:"user_friends,omitempty"`
+	UserGender                  *bool `json:"user_gender,omitempty"`
+	UserHometown                *bool `json:"user_hometown,omitempty"`
+	UserLikes                   *bool `json:"user_likes,omitempty"`
+	UserLink                    *bool `json:"user_link,omitempty"`
+	UserLocation                *bool `json:"user_location,omitempty"`
+	UserPhotos                  *bool `json:"user_photos,omitempty"`
+	UserPosts                   *bool `json:"user_posts,omitempty"`
+	UserTaggedPlaces            *bool `json:"user_tagged_places,omitempty"`
+	UserVideos                  *bool `json:"user_videos,omitempty"`
+	BusinessManagement          *bool `json:"business_management,omitempty"`
+	LeadsRetrieval              *bool `json:"leads_retrieval,omitempty"`
+	ManagePages                 *bool `json:"manage_pages,omitempty"`
+	PagesManageCTA              *bool `json:"pages_manage_cta,omitempty"`
+	PagesManageInstantArticles  *bool `json:"pages_manage_instant_articles,omitempty"`
+	PagesShowList               *bool `json:"pages_show_list,omitempty"`
+	PagesMessaging              *bool `json:"pages_messaging,omitempty"`
+	PagesMessagingPhoneNumber   *bool `json:"pages_messaging_phone_number,omitempty"`
+	PagesMessagingSubscriptions *bool `json:"pages_messaging_subscriptions,omitempty"`
+	PublishPages                *bool `json:"publish_pages,omitempty"`
+	PublishVideo                *bool `json:"publish_video,omitempty"`
+	ReadPageMailboxes           *bool `json:"read_page_mailboxes,omitempty"`
+	ReadStream                  *bool `json:"read_stream,omitempty"`
+	UserGroups                  *bool `json:"user_groups,omitempty"`
+	UserManagedGroups           *bool `json:"user_managed_groups,omitempty"`
+	UserStatus                  *bool `json:"user_status,omitempty"`
+	AllowContextProfileField    *bool `json:"allow_context_profile_field,omitempty"`
+
+	// Scope is a comma separated list of scopes.
+	Scope *string `json:"scope,omitempty"`
+}
+
+type ConnectionOptionsApple struct {
+	ClientID               *string `json:"client_id,omitempty"`
+	ClientSecretSigningKey *string `json:"app_secret,omitempty"`
+
+	TeamID *string `json:"team_id,omitempty"`
+	KeyID  *string `json:"kid,omitempty"`
+
+	Name  *bool `json:"name,omitempty"`
+	Email *bool `json:"email,omitempty"`
+
+	Scope *string `json:"scope,omitempty"`
+}
+
+type ConnectionOptionsLinkedin struct {
+	ClientID     *string `json:"client_id,omitempty"`
+	ClientSecret *string `json:"client_secret,omitempty"`
+
+	StrategyVersion *int `json:"strategy_version"`
+
+	Email        *bool `json:"email,omitempty"`
+	Profile      *bool `json:"profile,omitempty"`
+	BasicProfile *bool `json:"basic_profile,omitempty"`
+
+	Scope []interface{} `json:"scope,omitempty"`
+
+	SetUserAttributes *string `json:"set_user_root_attributes,omitempty"`
+}
+
+type ConnectionOptionsGitHub struct {
+	ClientID     *string `json:"client_id,omitempty"`
+	ClientSecret *string `json:"client_secret,omitempty"`
+
+	Email          *bool `json:"email,omitempty"`
+	ReadUser       *bool `json:"read_user,omitempty"`
+	Follow         *bool `json:"follow,omitempty"`
+	PublicRepo     *bool `json:"public_repo,omitempty"`
+	Repo           *bool `json:"repo,omitempty"`
+	RepoDeployment *bool `json:"repo_deployment,omitempty"`
+	RepoStatus     *bool `json:"repo_status,omitempty"`
+	DeleteRepo     *bool `json:"delete_repo,omitempty"`
+	Notifications  *bool `json:"notifications,omitempty"`
+	Gist           *bool `json:"gist,omitempty"`
+	ReadRepoHook   *bool `json:"read_repo_hook,omitempty"`
+	WriteRepoHook  *bool `json:"write_repo_hook,omitempty"`
+	AdminRepoHook  *bool `json:"admin_repo_hook,omitempty"`
+	ReadOrg        *bool `json:"read_org,omitempty"`
+	AdminOrg       *bool `json:"admin_org,omitempty"`
+	ReadPublicKey  *bool `json:"read_public_key,omitempty"`
+	WritePublicKey *bool `json:"write_public_key,omitempty"`
+	AdminPublicKey *bool `json:"admin_public_key,omitempty"`
+	WriteOrg       *bool `json:"write_org,omitempty"`
+	Profile        *bool `json:"profile,omitempty"`
+
+	Scope []interface{} `json:"scope,omitempty"`
+
+	SetUserAttributes *string `json:"set_user_root_attributes,omitempty"`
+}
+
+type ConnectionOptionsEmail struct {
+	Name  *string                         `json:"name,omitempty"`
+	Email *ConnectionOptionsEmailSettings `json:"email,omitempty"`
+	OTP   *ConnectionOptionsOTP           `json:"totp,omitempty"`
+
+	DisableSignup        *bool `json:"disable_signup,omitempty"`
+	BruteForceProtection *bool `json:"brute_force_protection,omitempty"`
+}
+
+type ConnectionOptionsEmailSettings struct {
+	Syntax  *string `json:"syntax,omitempty"`
+	From    *string `json:"from,omitempty"`
+	Subject *string `json:"subject,omitempty"`
+	Body    *string `json:"body,omitempty"`
+}
+
+type ConnectionOptionsOTP struct {
+	TimeStep *int `json:"time_step,omitempty"`
+	Length   *int `json:"length,omitempty"`
+}
+
+type ConnectionOptionsSMS struct {
+	Name     *string `json:"name,omitempty"`
+	From     *string `json:"from,omitempty"`
+	Syntax   *string `json:"syntax,omitempty"`
+	Template *string `json:"template,omitempty"`
+
+	OTP *ConnectionOptionsOTP `json:"totp,omitempty"`
+
+	TwilioSID           *string `json:"twilio_sid"`
+	TwilioToken         *string `json:"twilio_token"`
+	MessagingServiceSID *string `json:"messaging_service_sid"`
+
+	DisableSignup        *bool `json:"disable_signup,omitempty"`
+	BruteForceProtection *bool `json:"brute_force_protection,omitempty"`
+}
+
+type ConnectionOptionsWindowsLive struct {
+	ClientID     *string `json:"client_id,omitempty"`
+	ClientSecret *string `json:"client_secret,omitempty"`
+
+	StrategyVersion *int `json:"strategy_version"`
+
+	OfflineAccess   *bool `json:"offline_access,omitempty"`
+	UserUpdate      *bool `json:"graph_user_update,omitempty"`
+	UserActivity    *bool `json:"graph_user_activity,omitempty"`
+	Device          *bool `json:"graph_device,omitempty"`
+	Emails          *bool `json:"graph_emails,omitempty"`
+	NotesUpdate     *bool `json:"graph_notes_update,omitempty"`
+	User            *bool `json:"graph_user,omitempty"`
+	DeviceCommand   *bool `json:"graph_device_command,omitempty"`
+	EmailsUpdate    *bool `json:"graph_emails_update,omitempty"`
+	Calendars       *bool `json:"graph_calendars,omitempty"`
+	CalendarsUpdate *bool `json:"graph_calendars_update,omitempty"`
+	Contacts        *bool `json:"graph_contacts,omitempty"`
+	ContactsUpdate  *bool `json:"graph_contacts_update,omitempty"`
+	Files           *bool `json:"graph_files,omitempty"`
+	FilesAll        *bool `json:"graph_files_all,omitempty"`
+	FilesUpdate     *bool `json:"graph_files_update,omitempty"`
+	FilesAllUpdate  *bool `json:"graph_files_all_update,omitempty"`
+	Notes           *bool `json:"graph_notes,omitempty"`
+	NotesCreate     *bool `json:"graph_notes_create,omitempty"`
+	Tasks           *bool `json:"graph_tasks,omitempty"`
+	TasksUpdate     *bool `json:"graph_tasks_update,omitempty"`
+	Signin          *bool `json:"signin,omitempty"`
+
+	Scope []interface{} `json:"scope,omitempty"`
+
+	SetUserAttributes *string `json:"set_user_root_attributes,omitempty"`
+}
+
+// Salesforce
+type ConnectionOptionsSalesforce struct {
+	ClientID     *string `json:"client_id,omitempty"`
+	ClientSecret *string `json:"client_secret,omitempty"`
+
+	Profile *bool `json:"profile,omitempty"`
+
+	Scope []interface{} `json:"scope,omitempty"`
+
+	CommunityBaseURL  *string `json:"community_base_url,omitempty"`
+	SetUserAttributes *string `json:"set_user_root_attributes,omitempty"`
+}
+
+type ConnectionOptionsOIDC struct {
+	ClientID     *string `json:"client_id,omitempty"`
+	ClientSecret *string `json:"client_secret,omitempty"`
+
+	TenantDomain  *string       `json:"tenant_domain,omitempty"`
+	DomainAliases []interface{} `json:"domain_aliases,omitempty"`
+	LogoURL       *string       `json:"icon_url,omitempty"`
+
+	DiscoveryURL          *string `json:"discovery_url"`
+	AuthorizationEndpoint *string `json:"authorization_endpoint"`
+	Issuer                *string `json:"issuer"`
+	JWKSURI               *string `json:"jwks_uri"`
+	Type                  *string `json:"type"`
+	UserInfoEndpoint      *string `json:"userinfo_endpoint"`
+	TokenEndpoint         *string `json:"token_endpoint"`
+
+	Scope *string `json:"scope,omitempty"`
+
+	// "scope": "openid profile email",
+	// "icon_url": "https://alexkappa.com/logo.png",
+	// "discovery_url": "https://alexkappa.eu.auth0.com",
+	// "authorization_endpoint": "https://alexkappa.eu.auth0.com/authorize",
+	// "issuer": "https://alexkappa.eu.auth0.com/",
+	// "jwks_uri": "https://alexkappa.eu.auth0.com/.well-known/jwks.json",
+	// "type": "front_channel",
+	// "userinfo_endpoint": "https://alexkappa.eu.auth0.com/userinfo",
+	// "token_endpoint": null,
+	// "client_id": "foo",
+	// "domain_aliases": [
+	// 	"alexkappa.com",
+	// 	"api.alexkappa.com"
+	// ],
+	// "tenant_domain": "alexkappa.com"
+}
+
+// Azure AD
+type ConnectionOptionsAzureAD struct {
+	ClientID     *string `json:"client_id,omitempty"`
+	ClientSecret *string `json:"client_secret,omitempty"`
+
+	TenantDomain  *string       `json:"tenant_domain,omitempty"`
+	Domain        *string       `json:"domain,omitempty"`
+	DomainAliases []interface{} `json:"domain_aliases,omitempty"`
+	LogoURL       *string       `json:"icon_url,omitempty"`
+
+	IdentityAPI *string `json:"identity_api"`
+
+	WAADProtocol       *string `json:"waad_protocol,omitempty"`
+	WAADCommonEndpoint *bool   `json:"waad_common_endpoint,omitempty"`
+
+	UseWSFederation     *bool   `json:"use_wsfed,omitempty"`
+	UseCommonEndpoint   *bool   `json:"useCommonEndpoint,omitempty"`
+	EnableUsersAPI      *bool   `json:"api_enable_users,omitempty"`
+	MaxGroupsToRetrieve *string `json:"max_groups_to_retrieve,omitempty"`
+
+	BasicProfile     *bool `json:"basic_profile,omitempty"`
+	ExtProfile       *bool `json:"ext_profile,omitempty"`
+	ExtGroups        *bool `json:"ext_groups,omitempty"`
+	ExtNestedGroups  *bool `json:"ext_nested_groups,omitempty"`
+	ExtAdmin         *bool `json:"ext_admin,omitempty"`
+	ExtIsSuspended   *bool `json:"ext_is_suspended,omitempty"`
+	ExtAgreedTerms   *bool `json:"ext_agreed_terms,omitempty"`
+	ExtAssignedPlans *bool `json:"ext_assigned_plans,omitempty"`
 }
 
 type ConnectionManager struct {

--- a/management/connection.go
+++ b/management/connection.go
@@ -416,6 +416,7 @@ type ConnectionOptionsAzureAD struct {
 	ClientID     *string `json:"client_id,omitempty"`
 	ClientSecret *string `json:"client_secret,omitempty"`
 
+	AppID         *string       `json:"app_id,omitempty"`
 	TenantDomain  *string       `json:"tenant_domain,omitempty"`
 	Domain        *string       `json:"domain,omitempty"`
 	DomainAliases []interface{} `json:"domain_aliases,omitempty"`

--- a/management/connection.go
+++ b/management/connection.go
@@ -432,14 +432,14 @@ type ConnectionOptionsAzureAD struct {
 	EnableUsersAPI      *bool   `json:"api_enable_users,omitempty"`
 	MaxGroupsToRetrieve *string `json:"max_groups_to_retrieve,omitempty"`
 
-	BasicProfile     *bool `json:"basic_profile,omitempty"`
-	ExtProfile       *bool `json:"ext_profile,omitempty"`
-	ExtGroups        *bool `json:"ext_groups,omitempty"`
-	ExtNestedGroups  *bool `json:"ext_nested_groups,omitempty"`
-	ExtAdmin         *bool `json:"ext_admin,omitempty"`
-	ExtIsSuspended   *bool `json:"ext_is_suspended,omitempty"`
-	ExtAgreedTerms   *bool `json:"ext_agreed_terms,omitempty"`
-	ExtAssignedPlans *bool `json:"ext_assigned_plans,omitempty"`
+	BasicProfile    *bool `json:"basic_profile,omitempty"`
+	ExtendedProfile *bool `json:"ext_profile,omitempty"`
+	Groups          *bool `json:"ext_groups,omitempty"`
+	NestedGroups    *bool `json:"ext_nested_groups,omitempty"`
+	Admin           *bool `json:"ext_admin,omitempty"`
+	IsSuspended     *bool `json:"ext_is_suspended,omitempty"`
+	AgreedTerms     *bool `json:"ext_agreed_terms,omitempty"`
+	AssignedPlans   *bool `json:"ext_assigned_plans,omitempty"`
 }
 
 type ConnectionManager struct {

--- a/management/connection.go
+++ b/management/connection.go
@@ -253,8 +253,8 @@ type ConnectionOptionsFacebook struct {
 }
 
 type ConnectionOptionsApple struct {
-	ClientID               *string `json:"client_id,omitempty"`
-	ClientSecretSigningKey *string `json:"app_secret,omitempty"`
+	ClientID     *string `json:"client_id,omitempty"`
+	ClientSecret *string `json:"app_secret,omitempty"`
 
 	TeamID *string `json:"team_id,omitempty"`
 	KeyID  *string `json:"kid,omitempty"`
@@ -412,7 +412,6 @@ type ConnectionOptionsOIDC struct {
 	Scope *string `json:"scope,omitempty"`
 }
 
-// Azure AD
 type ConnectionOptionsAzureAD struct {
 	ClientID     *string `json:"client_id,omitempty"`
 	ClientSecret *string `json:"client_secret,omitempty"`
@@ -442,13 +441,20 @@ type ConnectionOptionsAzureAD struct {
 	AssignedPlans   *bool `json:"ext_assigned_plans,omitempty"`
 }
 
-type ConnectionManager struct {
-	*Management
+type ConnectionOptionsADFS struct {
+	TenantDomain  *string       `json:"tenant_domain,omitempty"`
+	DomainAliases []interface{} `json:"domain_aliases,omitempty"`
+	LogoURL       *string       `json:"icon_url,omitempty"`
+	ADFSServer    *string       `json:"adfs_server,omitempty"`
+
+	EnableUsersAPI *bool `json:"api_enable_users,omitempty"`
+
+	// Set to on_first_login to avoid setting user attributes at each login.
+	SetUserAttributes *string `json:"set_user_root_attributes,omitempty"`
 }
 
-type ConnectionOptionsTotp struct {
-	TimeStep *int `json:"time_step,omitempty"`
-	Length   *int `json:"length,omitempty"`
+type ConnectionManager struct {
+	*Management
 }
 
 type ConnectionList struct {

--- a/management/connection.go
+++ b/management/connection.go
@@ -3,7 +3,7 @@ package management
 import (
 	"encoding/json"
 
-	"gopkg.in/auth0.v3/internal/tag"
+	"gopkg.in/auth0.v4/internal/tag"
 )
 
 const (

--- a/management/connection.go
+++ b/management/connection.go
@@ -2,7 +2,6 @@ package management
 
 import (
 	"encoding/json"
-	"reflect"
 )
 
 type Connection struct {
@@ -104,7 +103,7 @@ func (c *Connection) UnmarshalJSON(b []byte) error {
 		case "waad":
 			v = &ConnectionOptionsAzureAD{}
 		default:
-			v = &map[string]interface{}{}
+			v = make(map[string]interface{})
 		}
 
 		err = json.Unmarshal(c.RawOptions, &v)
@@ -112,7 +111,7 @@ func (c *Connection) UnmarshalJSON(b []byte) error {
 			return err
 		}
 
-		c.Options = reflect.ValueOf(v).Elem().Interface()
+		c.Options = v
 	}
 
 	return nil

--- a/management/connection_test.go
+++ b/management/connection_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"gopkg.in/auth0.v3"
+	"gopkg.in/auth0.v3/internal/testing/expect"
 )
 
 func TestConnection(t *testing.T) {
@@ -148,9 +149,10 @@ func TestConnection(t *testing.T) {
 			t.Fatalf("unexpected type %T", o)
 		}
 
-		_ = o.GetProfile() // check some getters as they have a pointer receiver
-		_ = o.GetCalendar()
-		_ = o.GetYoutube()
+		expect.Expect(t, o.GetProfile(), true)
+		expect.Expect(t, o.GetCalendar(), true)
+		expect.Expect(t, o.GetYoutube(), false)
+		expect.Expect(t, o.Scopes(), []string{"email", "profile", "calendar"})
 
 		t.Logf("%s\n", g)
 	})

--- a/management/connection_test.go
+++ b/management/connection_test.go
@@ -21,7 +21,7 @@ func TestConnection(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if _, ok := c.Options.(ConnectionOptions); !ok {
+		if _, ok := c.Options.(*ConnectionOptions); !ok {
 			t.Errorf("unexpected options type %T", c.Options)
 		}
 		t.Logf("%v\n", c)
@@ -44,29 +44,29 @@ func TestConnection(t *testing.T) {
 			var ok bool
 			switch c.GetStrategy() {
 			case "auth0":
-				_, ok = c.Options.(ConnectionOptions)
+				_, ok = c.Options.(*ConnectionOptions)
 			case "google-oauth2":
-				_, ok = c.Options.(ConnectionOptionsGoogleOAuth2)
+				_, ok = c.Options.(*ConnectionOptionsGoogleOAuth2)
 			case "facebook":
-				_, ok = c.Options.(ConnectionOptionsFacebook)
+				_, ok = c.Options.(*ConnectionOptionsFacebook)
 			case "apple":
-				_, ok = c.Options.(ConnectionOptionsApple)
+				_, ok = c.Options.(*ConnectionOptionsApple)
 			case "linkedin":
-				_, ok = c.Options.(ConnectionOptionsLinkedin)
+				_, ok = c.Options.(*ConnectionOptionsLinkedin)
 			case "github":
-				_, ok = c.Options.(ConnectionOptionsGitHub)
+				_, ok = c.Options.(*ConnectionOptionsGitHub)
 			case "windowslive":
-				_, ok = c.Options.(ConnectionOptionsWindowsLive)
+				_, ok = c.Options.(*ConnectionOptionsWindowsLive)
 			case "salesforce":
-				_, ok = c.Options.(ConnectionOptionsSalesforce)
+				_, ok = c.Options.(*ConnectionOptionsSalesforce)
 			case "email":
-				_, ok = c.Options.(ConnectionOptionsEmail)
+				_, ok = c.Options.(*ConnectionOptionsEmail)
 			case "sms":
-				_, ok = c.Options.(ConnectionOptionsSMS)
+				_, ok = c.Options.(*ConnectionOptionsSMS)
 			case "oidc":
-				_, ok = c.Options.(ConnectionOptionsOIDC)
+				_, ok = c.Options.(*ConnectionOptionsOIDC)
 			case "waad":
-				_, ok = c.Options.(ConnectionOptionsAzureAD)
+				_, ok = c.Options.(*ConnectionOptionsAzureAD)
 			default:
 				_, ok = c.Options.(map[string]interface{})
 			}
@@ -143,7 +143,7 @@ func TestConnection(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		o, ok := g.Options.(ConnectionOptionsGoogleOAuth2)
+		o, ok := g.Options.(*ConnectionOptionsGoogleOAuth2)
 		if !ok {
 			t.Fatalf("unexpected type %T", o)
 		}

--- a/management/connection_test.go
+++ b/management/connection_test.go
@@ -46,7 +46,7 @@ func TestConnection(t *testing.T) {
 			case "auth0":
 				_, ok = c.Options.(ConnectionOptions)
 			case "google-oauth2":
-				_, ok = c.Options.(ConnectionOptionsGooleOAuth2)
+				_, ok = c.Options.(ConnectionOptionsGoogleOAuth2)
 			case "facebook":
 				_, ok = c.Options.(ConnectionOptionsFacebook)
 			case "apple":
@@ -125,7 +125,7 @@ func TestConnection(t *testing.T) {
 		g := &Connection{
 			Name:     auth0.Stringf("Test-Connection-%d", time.Now().Unix()),
 			Strategy: auth0.String("google-oauth2"),
-			Options: &ConnectionOptionsGooleOAuth2{
+			Options: &ConnectionOptionsGoogleOAuth2{
 				AllowedAudiences: []interface{}{
 					"example.com",
 					"api.example.com",
@@ -143,7 +143,7 @@ func TestConnection(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		o, ok := g.Options.(ConnectionOptionsGooleOAuth2)
+		o, ok := g.Options.(ConnectionOptionsGoogleOAuth2)
 		if !ok {
 			t.Fatalf("unexpected type %T", o)
 		}

--- a/management/connection_test.go
+++ b/management/connection_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 	"time"
 
-	"gopkg.in/auth0.v3"
-	"gopkg.in/auth0.v3/internal/testing/expect"
+	"gopkg.in/auth0.v4"
+	"gopkg.in/auth0.v4/internal/testing/expect"
 )
 
 func TestConnection(t *testing.T) {

--- a/management/connection_test.go
+++ b/management/connection_test.go
@@ -43,30 +43,33 @@ func TestConnection(t *testing.T) {
 		}
 		for _, c := range cs.Connections {
 			var ok bool
+
 			switch c.GetStrategy() {
-			case "auth0":
+			case ConnectionStrategyAuth0:
 				_, ok = c.Options.(*ConnectionOptions)
-			case "google-oauth2":
+			case ConnectionStrategyGoogleOAuth2:
 				_, ok = c.Options.(*ConnectionOptionsGoogleOAuth2)
-			case "facebook":
+			case ConnectionStrategyFacebook:
 				_, ok = c.Options.(*ConnectionOptionsFacebook)
-			case "apple":
+			case ConnectionStrategyApple:
 				_, ok = c.Options.(*ConnectionOptionsApple)
-			case "linkedin":
+			case ConnectionStrategyLinkedin:
 				_, ok = c.Options.(*ConnectionOptionsLinkedin)
-			case "github":
+			case ConnectionStrategyGitHub:
 				_, ok = c.Options.(*ConnectionOptionsGitHub)
-			case "windowslive":
+			case ConnectionStrategyWindowsLive:
 				_, ok = c.Options.(*ConnectionOptionsWindowsLive)
-			case "salesforce":
+			case ConnectionStrategySalesforce, ConnectionStrategySalesforceCommunity, ConnectionStrategySalesforceSandbox:
 				_, ok = c.Options.(*ConnectionOptionsSalesforce)
-			case "email":
+			case ConnectionStrategyEmail:
 				_, ok = c.Options.(*ConnectionOptionsEmail)
-			case "sms":
+			case ConnectionStrategySMS:
 				_, ok = c.Options.(*ConnectionOptionsSMS)
-			case "oidc":
+			case ConnectionStrategyOIDC:
 				_, ok = c.Options.(*ConnectionOptionsOIDC)
-			case "waad":
+			case ConnectionStrategyAD:
+				_, ok = c.Options.(*ConnectionOptionsAD)
+			case ConnectionStrategyAzureAD:
 				_, ok = c.Options.(*ConnectionOptionsAzureAD)
 			default:
 				_, ok = c.Options.(map[string]interface{})

--- a/management/custom_domain_test.go
+++ b/management/custom_domain_test.go
@@ -4,7 +4,7 @@ import (
 	"net/http"
 	"testing"
 
-	"gopkg.in/auth0.v3"
+	"gopkg.in/auth0.v4"
 )
 
 func TestCustomDomain(t *testing.T) {

--- a/management/email_template_test.go
+++ b/management/email_template_test.go
@@ -4,7 +4,7 @@ import (
 	"net/http"
 	"testing"
 
-	"gopkg.in/auth0.v3"
+	"gopkg.in/auth0.v4"
 )
 
 func TestEmailTemplate(t *testing.T) {

--- a/management/email_test.go
+++ b/management/email_test.go
@@ -3,8 +3,8 @@ package management
 import (
 	"testing"
 
-	"gopkg.in/auth0.v3"
-	"gopkg.in/auth0.v3/internal/testing/expect"
+	"gopkg.in/auth0.v4"
+	"gopkg.in/auth0.v4/internal/testing/expect"
 )
 
 func TestEmail(t *testing.T) {

--- a/management/example_test.go
+++ b/management/example_test.go
@@ -1,6 +1,7 @@
 package management_test
 
 import (
+	"fmt"
 	"os"
 
 	"gopkg.in/auth0.v3"
@@ -124,4 +125,25 @@ func ExampleUserManager_List_pagination() {
 		}
 		page++
 	}
+}
+
+func ExampleConnectionManager_List() {
+	l, err := api.Connection.List(
+		management.Parameter("strategy", "auth0"),
+	)
+	if err != nil {
+		// handle err
+	}
+	for _, c := range l.Connections {
+
+		fmt.Println(c.GetName())
+
+		if o, ok := c.Options.(management.ConnectionOptions); ok {
+			fmt.Printf("\tPassword Policy: %s\n", o.GetPasswordPolicy())
+			fmt.Printf("\tMulti-Factor Auth Enabled: %t\n", o.MFA["active"])
+		}
+	}
+	// Output: Username-Password-Authentication
+	// 	Password Policy: good
+	// 	Multi-Factor Auth Enabled: true
 }

--- a/management/example_test.go
+++ b/management/example_test.go
@@ -3,6 +3,7 @@ package management_test
 import (
 	"fmt"
 	"os"
+	"time"
 
 	"gopkg.in/auth0.v3"
 	"gopkg.in/auth0.v3/management"
@@ -146,4 +147,29 @@ func ExampleConnectionManager_List() {
 	// Output: Username-Password-Authentication
 	// 	Password Policy: good
 	// 	Multi-Factor Auth Enabled: true
+}
+
+func ExampleConnectionManager_Create() {
+	c := &management.Connection{
+		Name:     auth0.Stringf("Test-Google-OAuth2-%d", time.Now().Unix()),
+		Strategy: auth0.String("google-oauth2"),
+		Options: &management.ConnectionOptionsGooleOAuth2{
+			ClientID:     auth0.String(""), // replace with your client id
+			ClientSecret: auth0.String(""),
+			AllowedAudiences: []interface{}{
+				"example.com",
+				"api.example.com",
+			},
+			Profile:  auth0.Bool(true),
+			Calendar: auth0.Bool(true),
+			Youtube:  auth0.Bool(false),
+		},
+	}
+
+	defer api.Connection.Delete(c.GetID())
+
+	err := api.Connection.Create(c)
+	if err != nil {
+		// handle err
+	}
 }

--- a/management/example_test.go
+++ b/management/example_test.go
@@ -153,7 +153,7 @@ func ExampleConnectionManager_Create() {
 	c := &management.Connection{
 		Name:     auth0.Stringf("Test-Google-OAuth2-%d", time.Now().Unix()),
 		Strategy: auth0.String("google-oauth2"),
-		Options: &management.ConnectionOptionsGooleOAuth2{
+		Options: &management.ConnectionOptionsGoogleOAuth2{
 			ClientID:     auth0.String(""), // replace with your client id
 			ClientSecret: auth0.String(""),
 			AllowedAudiences: []interface{}{

--- a/management/example_test.go
+++ b/management/example_test.go
@@ -139,7 +139,7 @@ func ExampleConnectionManager_List() {
 
 		fmt.Println(c.GetName())
 
-		if o, ok := c.Options.(management.ConnectionOptions); ok {
+		if o, ok := c.Options.(*management.ConnectionOptions); ok {
 			fmt.Printf("\tPassword Policy: %s\n", o.GetPasswordPolicy())
 			fmt.Printf("\tMulti-Factor Auth Enabled: %t\n", o.MFA["active"])
 		}

--- a/management/example_test.go
+++ b/management/example_test.go
@@ -5,8 +5,8 @@ import (
 	"os"
 	"time"
 
-	"gopkg.in/auth0.v3"
-	"gopkg.in/auth0.v3/management"
+	"gopkg.in/auth0.v4"
+	"gopkg.in/auth0.v4/management"
 )
 
 var (

--- a/management/guardian_test.go
+++ b/management/guardian_test.go
@@ -3,7 +3,7 @@ package management
 import (
 	"testing"
 
-	"gopkg.in/auth0.v3"
+	"gopkg.in/auth0.v4"
 )
 
 func TestGuardian(t *testing.T) {

--- a/management/hook_test.go
+++ b/management/hook_test.go
@@ -3,7 +3,7 @@ package management
 import (
 	"testing"
 
-	"gopkg.in/auth0.v3"
+	"gopkg.in/auth0.v4"
 )
 
 func TestHook(t *testing.T) {

--- a/management/job_test.go
+++ b/management/job_test.go
@@ -3,7 +3,7 @@ package management
 import (
 	"testing"
 
-	"gopkg.in/auth0.v3"
+	"gopkg.in/auth0.v4"
 )
 
 func TestJob(t *testing.T) {

--- a/management/log_test.go
+++ b/management/log_test.go
@@ -3,7 +3,7 @@ package management
 import (
 	"testing"
 
-	"gopkg.in/auth0.v3"
+	"gopkg.in/auth0.v4"
 )
 
 func TestLog(t *testing.T) {

--- a/management/management.gen.go
+++ b/management/management.gen.go
@@ -460,6 +460,51 @@ func (c *ConnectionOptions) String() string {
 	return Stringify(c)
 }
 
+// GetADFSServer returns the ADFSServer field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsADFS) GetADFSServer() string {
+	if c == nil || c.ADFSServer == nil {
+		return ""
+	}
+	return *c.ADFSServer
+}
+
+// GetEnableUsersAPI returns the EnableUsersAPI field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsADFS) GetEnableUsersAPI() bool {
+	if c == nil || c.EnableUsersAPI == nil {
+		return false
+	}
+	return *c.EnableUsersAPI
+}
+
+// GetLogoURL returns the LogoURL field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsADFS) GetLogoURL() string {
+	if c == nil || c.LogoURL == nil {
+		return ""
+	}
+	return *c.LogoURL
+}
+
+// GetSetUserAttributes returns the SetUserAttributes field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsADFS) GetSetUserAttributes() string {
+	if c == nil || c.SetUserAttributes == nil {
+		return ""
+	}
+	return *c.SetUserAttributes
+}
+
+// GetTenantDomain returns the TenantDomain field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsADFS) GetTenantDomain() string {
+	if c == nil || c.TenantDomain == nil {
+		return ""
+	}
+	return *c.TenantDomain
+}
+
+// String returns a string representation of ConnectionOptionsADFS.
+func (c *ConnectionOptionsADFS) String() string {
+	return Stringify(c)
+}
+
 // GetClientID returns the ClientID field if it's non-nil, zero value otherwise.
 func (c *ConnectionOptionsApple) GetClientID() string {
 	if c == nil || c.ClientID == nil {
@@ -468,12 +513,12 @@ func (c *ConnectionOptionsApple) GetClientID() string {
 	return *c.ClientID
 }
 
-// GetClientSecretSigningKey returns the ClientSecretSigningKey field if it's non-nil, zero value otherwise.
-func (c *ConnectionOptionsApple) GetClientSecretSigningKey() string {
-	if c == nil || c.ClientSecretSigningKey == nil {
+// GetClientSecret returns the ClientSecret field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsApple) GetClientSecret() string {
+	if c == nil || c.ClientSecret == nil {
 		return ""
 	}
-	return *c.ClientSecretSigningKey
+	return *c.ClientSecret
 }
 
 // GetEmail returns the Email field if it's non-nil, zero value otherwise.
@@ -535,6 +580,14 @@ func (c *ConnectionOptionsAzureAD) GetAgreedTerms() bool {
 		return false
 	}
 	return *c.AgreedTerms
+}
+
+// GetAppID returns the AppID field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsAzureAD) GetAppID() string {
+	if c == nil || c.AppID == nil {
+		return ""
+	}
+	return *c.AppID
 }
 
 // GetAssignedPlans returns the AssignedPlans field if it's non-nil, zero value otherwise.
@@ -1885,27 +1938,6 @@ func (c *ConnectionOptionsSMS) GetTwilioToken() string {
 
 // String returns a string representation of ConnectionOptionsSMS.
 func (c *ConnectionOptionsSMS) String() string {
-	return Stringify(c)
-}
-
-// GetLength returns the Length field if it's non-nil, zero value otherwise.
-func (c *ConnectionOptionsTotp) GetLength() int {
-	if c == nil || c.Length == nil {
-		return 0
-	}
-	return *c.Length
-}
-
-// GetTimeStep returns the TimeStep field if it's non-nil, zero value otherwise.
-func (c *ConnectionOptionsTotp) GetTimeStep() int {
-	if c == nil || c.TimeStep == nil {
-		return 0
-	}
-	return *c.TimeStep
-}
-
-// String returns a string representation of ConnectionOptionsTotp.
-func (c *ConnectionOptionsTotp) String() string {
 	return Stringify(c)
 }
 

--- a/management/management.gen.go
+++ b/management/management.gen.go
@@ -381,14 +381,6 @@ func (c *Connection) GetName() string {
 	return *c.Name
 }
 
-// GetOptions returns the Options field.
-func (c *Connection) GetOptions() *ConnectionOptions {
-	if c == nil {
-		return nil
-	}
-	return c.Options
-}
-
 // GetStrategy returns the Strategy field if it's non-nil, zero value otherwise.
 func (c *Connection) GetStrategy() string {
 	if c == nil || c.Strategy == nil {
@@ -407,76 +399,12 @@ func (c *ConnectionList) String() string {
 	return Stringify(c)
 }
 
-// GetAdfsServer returns the AdfsServer field if it's non-nil, zero value otherwise.
-func (c *ConnectionOptions) GetAdfsServer() string {
-	if c == nil || c.AdfsServer == nil {
-		return ""
-	}
-	return *c.AdfsServer
-}
-
-// GetAPIEnableUsers returns the APIEnableUsers field if it's non-nil, zero value otherwise.
-func (c *ConnectionOptions) GetAPIEnableUsers() bool {
-	if c == nil || c.APIEnableUsers == nil {
-		return false
-	}
-	return *c.APIEnableUsers
-}
-
-// GetAppDomain returns the AppDomain field if it's non-nil, zero value otherwise.
-func (c *ConnectionOptions) GetAppDomain() string {
-	if c == nil || c.AppDomain == nil {
-		return ""
-	}
-	return *c.AppDomain
-}
-
-// GetAppID returns the AppID field if it's non-nil, zero value otherwise.
-func (c *ConnectionOptions) GetAppID() string {
-	if c == nil || c.AppID == nil {
-		return ""
-	}
-	return *c.AppID
-}
-
-// GetBasicProfile returns the BasicProfile field if it's non-nil, zero value otherwise.
-func (c *ConnectionOptions) GetBasicProfile() bool {
-	if c == nil || c.BasicProfile == nil {
-		return false
-	}
-	return *c.BasicProfile
-}
-
 // GetBruteForceProtection returns the BruteForceProtection field if it's non-nil, zero value otherwise.
 func (c *ConnectionOptions) GetBruteForceProtection() bool {
 	if c == nil || c.BruteForceProtection == nil {
 		return false
 	}
 	return *c.BruteForceProtection
-}
-
-// GetClientID returns the ClientID field if it's non-nil, zero value otherwise.
-func (c *ConnectionOptions) GetClientID() string {
-	if c == nil || c.ClientID == nil {
-		return ""
-	}
-	return *c.ClientID
-}
-
-// GetClientSecret returns the ClientSecret field if it's non-nil, zero value otherwise.
-func (c *ConnectionOptions) GetClientSecret() string {
-	if c == nil || c.ClientSecret == nil {
-		return ""
-	}
-	return *c.ClientSecret
-}
-
-// GetCommunityBaseURL returns the CommunityBaseURL field if it's non-nil, zero value otherwise.
-func (c *ConnectionOptions) GetCommunityBaseURL() string {
-	if c == nil || c.CommunityBaseURL == nil {
-		return ""
-	}
-	return *c.CommunityBaseURL
 }
 
 // GetDisableSignup returns the DisableSignup field if it's non-nil, zero value otherwise.
@@ -495,100 +423,12 @@ func (c *ConnectionOptions) GetEnabledDatabaseCustomization() bool {
 	return *c.EnabledDatabaseCustomization
 }
 
-// GetExtAdmin returns the ExtAdmin field if it's non-nil, zero value otherwise.
-func (c *ConnectionOptions) GetExtAdmin() bool {
-	if c == nil || c.ExtAdmin == nil {
-		return false
-	}
-	return *c.ExtAdmin
-}
-
-// GetExtAgreedTerms returns the ExtAgreedTerms field if it's non-nil, zero value otherwise.
-func (c *ConnectionOptions) GetExtAgreedTerms() bool {
-	if c == nil || c.ExtAgreedTerms == nil {
-		return false
-	}
-	return *c.ExtAgreedTerms
-}
-
-// GetExtAssignedPlans returns the ExtAssignedPlans field if it's non-nil, zero value otherwise.
-func (c *ConnectionOptions) GetExtAssignedPlans() bool {
-	if c == nil || c.ExtAssignedPlans == nil {
-		return false
-	}
-	return *c.ExtAssignedPlans
-}
-
-// GetExtGroups returns the ExtGroups field if it's non-nil, zero value otherwise.
-func (c *ConnectionOptions) GetExtGroups() bool {
-	if c == nil || c.ExtGroups == nil {
-		return false
-	}
-	return *c.ExtGroups
-}
-
-// GetExtIsSuspended returns the ExtIsSuspended field if it's non-nil, zero value otherwise.
-func (c *ConnectionOptions) GetExtIsSuspended() bool {
-	if c == nil || c.ExtIsSuspended == nil {
-		return false
-	}
-	return *c.ExtIsSuspended
-}
-
-// GetExtNestedGroups returns the ExtNestedGroups field if it's non-nil, zero value otherwise.
-func (c *ConnectionOptions) GetExtNestedGroups() bool {
-	if c == nil || c.ExtNestedGroups == nil {
-		return false
-	}
-	return *c.ExtNestedGroups
-}
-
-// GetExtProfile returns the ExtProfile field if it's non-nil, zero value otherwise.
-func (c *ConnectionOptions) GetExtProfile() bool {
-	if c == nil || c.ExtProfile == nil {
-		return false
-	}
-	return *c.ExtProfile
-}
-
-// GetFrom returns the From field if it's non-nil, zero value otherwise.
-func (c *ConnectionOptions) GetFrom() string {
-	if c == nil || c.From == nil {
-		return ""
-	}
-	return *c.From
-}
-
 // GetImportMode returns the ImportMode field if it's non-nil, zero value otherwise.
 func (c *ConnectionOptions) GetImportMode() bool {
 	if c == nil || c.ImportMode == nil {
 		return false
 	}
 	return *c.ImportMode
-}
-
-// GetMaxGroupsToRetrieve returns the MaxGroupsToRetrieve field if it's non-nil, zero value otherwise.
-func (c *ConnectionOptions) GetMaxGroupsToRetrieve() string {
-	if c == nil || c.MaxGroupsToRetrieve == nil {
-		return ""
-	}
-	return *c.MaxGroupsToRetrieve
-}
-
-// GetMessagingServiceSid returns the MessagingServiceSid field if it's non-nil, zero value otherwise.
-func (c *ConnectionOptions) GetMessagingServiceSid() string {
-	if c == nil || c.MessagingServiceSid == nil {
-		return ""
-	}
-	return *c.MessagingServiceSid
-}
-
-// GetName returns the Name field if it's non-nil, zero value otherwise.
-func (c *ConnectionOptions) GetName() string {
-	if c == nil || c.Name == nil {
-		return ""
-	}
-	return *c.Name
 }
 
 // GetPasswordPolicy returns the PasswordPolicy field if it's non-nil, zero value otherwise.
@@ -607,8 +447,1412 @@ func (c *ConnectionOptions) GetRequiresUsername() bool {
 	return *c.RequiresUsername
 }
 
+// GetStrategyVersion returns the StrategyVersion field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptions) GetStrategyVersion() int {
+	if c == nil || c.StrategyVersion == nil {
+		return 0
+	}
+	return *c.StrategyVersion
+}
+
+// String returns a string representation of ConnectionOptions.
+func (c *ConnectionOptions) String() string {
+	return Stringify(c)
+}
+
+// GetClientID returns the ClientID field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsApple) GetClientID() string {
+	if c == nil || c.ClientID == nil {
+		return ""
+	}
+	return *c.ClientID
+}
+
+// GetClientSecretSigningKey returns the ClientSecretSigningKey field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsApple) GetClientSecretSigningKey() string {
+	if c == nil || c.ClientSecretSigningKey == nil {
+		return ""
+	}
+	return *c.ClientSecretSigningKey
+}
+
+// GetEmail returns the Email field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsApple) GetEmail() bool {
+	if c == nil || c.Email == nil {
+		return false
+	}
+	return *c.Email
+}
+
+// GetKeyID returns the KeyID field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsApple) GetKeyID() string {
+	if c == nil || c.KeyID == nil {
+		return ""
+	}
+	return *c.KeyID
+}
+
+// GetName returns the Name field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsApple) GetName() bool {
+	if c == nil || c.Name == nil {
+		return false
+	}
+	return *c.Name
+}
+
+// GetScope returns the Scope field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsApple) GetScope() string {
+	if c == nil || c.Scope == nil {
+		return ""
+	}
+	return *c.Scope
+}
+
+// GetTeamID returns the TeamID field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsApple) GetTeamID() string {
+	if c == nil || c.TeamID == nil {
+		return ""
+	}
+	return *c.TeamID
+}
+
+// String returns a string representation of ConnectionOptionsApple.
+func (c *ConnectionOptionsApple) String() string {
+	return Stringify(c)
+}
+
+// GetBasicProfile returns the BasicProfile field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsAzureAD) GetBasicProfile() bool {
+	if c == nil || c.BasicProfile == nil {
+		return false
+	}
+	return *c.BasicProfile
+}
+
+// GetClientID returns the ClientID field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsAzureAD) GetClientID() string {
+	if c == nil || c.ClientID == nil {
+		return ""
+	}
+	return *c.ClientID
+}
+
+// GetClientSecret returns the ClientSecret field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsAzureAD) GetClientSecret() string {
+	if c == nil || c.ClientSecret == nil {
+		return ""
+	}
+	return *c.ClientSecret
+}
+
+// GetDomain returns the Domain field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsAzureAD) GetDomain() string {
+	if c == nil || c.Domain == nil {
+		return ""
+	}
+	return *c.Domain
+}
+
+// GetEnableUsersAPI returns the EnableUsersAPI field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsAzureAD) GetEnableUsersAPI() bool {
+	if c == nil || c.EnableUsersAPI == nil {
+		return false
+	}
+	return *c.EnableUsersAPI
+}
+
+// GetExtAdmin returns the ExtAdmin field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsAzureAD) GetExtAdmin() bool {
+	if c == nil || c.ExtAdmin == nil {
+		return false
+	}
+	return *c.ExtAdmin
+}
+
+// GetExtAgreedTerms returns the ExtAgreedTerms field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsAzureAD) GetExtAgreedTerms() bool {
+	if c == nil || c.ExtAgreedTerms == nil {
+		return false
+	}
+	return *c.ExtAgreedTerms
+}
+
+// GetExtAssignedPlans returns the ExtAssignedPlans field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsAzureAD) GetExtAssignedPlans() bool {
+	if c == nil || c.ExtAssignedPlans == nil {
+		return false
+	}
+	return *c.ExtAssignedPlans
+}
+
+// GetExtGroups returns the ExtGroups field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsAzureAD) GetExtGroups() bool {
+	if c == nil || c.ExtGroups == nil {
+		return false
+	}
+	return *c.ExtGroups
+}
+
+// GetExtIsSuspended returns the ExtIsSuspended field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsAzureAD) GetExtIsSuspended() bool {
+	if c == nil || c.ExtIsSuspended == nil {
+		return false
+	}
+	return *c.ExtIsSuspended
+}
+
+// GetExtNestedGroups returns the ExtNestedGroups field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsAzureAD) GetExtNestedGroups() bool {
+	if c == nil || c.ExtNestedGroups == nil {
+		return false
+	}
+	return *c.ExtNestedGroups
+}
+
+// GetExtProfile returns the ExtProfile field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsAzureAD) GetExtProfile() bool {
+	if c == nil || c.ExtProfile == nil {
+		return false
+	}
+	return *c.ExtProfile
+}
+
+// GetIdentityAPI returns the IdentityAPI field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsAzureAD) GetIdentityAPI() string {
+	if c == nil || c.IdentityAPI == nil {
+		return ""
+	}
+	return *c.IdentityAPI
+}
+
+// GetLogoURL returns the LogoURL field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsAzureAD) GetLogoURL() string {
+	if c == nil || c.LogoURL == nil {
+		return ""
+	}
+	return *c.LogoURL
+}
+
+// GetMaxGroupsToRetrieve returns the MaxGroupsToRetrieve field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsAzureAD) GetMaxGroupsToRetrieve() string {
+	if c == nil || c.MaxGroupsToRetrieve == nil {
+		return ""
+	}
+	return *c.MaxGroupsToRetrieve
+}
+
+// GetTenantDomain returns the TenantDomain field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsAzureAD) GetTenantDomain() string {
+	if c == nil || c.TenantDomain == nil {
+		return ""
+	}
+	return *c.TenantDomain
+}
+
+// GetUseCommonEndpoint returns the UseCommonEndpoint field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsAzureAD) GetUseCommonEndpoint() bool {
+	if c == nil || c.UseCommonEndpoint == nil {
+		return false
+	}
+	return *c.UseCommonEndpoint
+}
+
+// GetUseWSFederation returns the UseWSFederation field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsAzureAD) GetUseWSFederation() bool {
+	if c == nil || c.UseWSFederation == nil {
+		return false
+	}
+	return *c.UseWSFederation
+}
+
+// GetWAADCommonEndpoint returns the WAADCommonEndpoint field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsAzureAD) GetWAADCommonEndpoint() bool {
+	if c == nil || c.WAADCommonEndpoint == nil {
+		return false
+	}
+	return *c.WAADCommonEndpoint
+}
+
+// GetWAADProtocol returns the WAADProtocol field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsAzureAD) GetWAADProtocol() string {
+	if c == nil || c.WAADProtocol == nil {
+		return ""
+	}
+	return *c.WAADProtocol
+}
+
+// String returns a string representation of ConnectionOptionsAzureAD.
+func (c *ConnectionOptionsAzureAD) String() string {
+	return Stringify(c)
+}
+
+// GetBruteForceProtection returns the BruteForceProtection field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsEmail) GetBruteForceProtection() bool {
+	if c == nil || c.BruteForceProtection == nil {
+		return false
+	}
+	return *c.BruteForceProtection
+}
+
+// GetDisableSignup returns the DisableSignup field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsEmail) GetDisableSignup() bool {
+	if c == nil || c.DisableSignup == nil {
+		return false
+	}
+	return *c.DisableSignup
+}
+
+// GetEmail returns the Email field.
+func (c *ConnectionOptionsEmail) GetEmail() *ConnectionOptionsEmailSettings {
+	if c == nil {
+		return nil
+	}
+	return c.Email
+}
+
+// GetName returns the Name field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsEmail) GetName() string {
+	if c == nil || c.Name == nil {
+		return ""
+	}
+	return *c.Name
+}
+
+// GetOTP returns the OTP field.
+func (c *ConnectionOptionsEmail) GetOTP() *ConnectionOptionsOTP {
+	if c == nil {
+		return nil
+	}
+	return c.OTP
+}
+
+// String returns a string representation of ConnectionOptionsEmail.
+func (c *ConnectionOptionsEmail) String() string {
+	return Stringify(c)
+}
+
+// GetBody returns the Body field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsEmailSettings) GetBody() string {
+	if c == nil || c.Body == nil {
+		return ""
+	}
+	return *c.Body
+}
+
+// GetFrom returns the From field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsEmailSettings) GetFrom() string {
+	if c == nil || c.From == nil {
+		return ""
+	}
+	return *c.From
+}
+
+// GetSubject returns the Subject field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsEmailSettings) GetSubject() string {
+	if c == nil || c.Subject == nil {
+		return ""
+	}
+	return *c.Subject
+}
+
 // GetSyntax returns the Syntax field if it's non-nil, zero value otherwise.
-func (c *ConnectionOptions) GetSyntax() string {
+func (c *ConnectionOptionsEmailSettings) GetSyntax() string {
+	if c == nil || c.Syntax == nil {
+		return ""
+	}
+	return *c.Syntax
+}
+
+// String returns a string representation of ConnectionOptionsEmailSettings.
+func (c *ConnectionOptionsEmailSettings) String() string {
+	return Stringify(c)
+}
+
+// GetAdsManagement returns the AdsManagement field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsFacebook) GetAdsManagement() bool {
+	if c == nil || c.AdsManagement == nil {
+		return false
+	}
+	return *c.AdsManagement
+}
+
+// GetAdsRead returns the AdsRead field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsFacebook) GetAdsRead() bool {
+	if c == nil || c.AdsRead == nil {
+		return false
+	}
+	return *c.AdsRead
+}
+
+// GetAllowContextProfileField returns the AllowContextProfileField field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsFacebook) GetAllowContextProfileField() bool {
+	if c == nil || c.AllowContextProfileField == nil {
+		return false
+	}
+	return *c.AllowContextProfileField
+}
+
+// GetBusinessManagement returns the BusinessManagement field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsFacebook) GetBusinessManagement() bool {
+	if c == nil || c.BusinessManagement == nil {
+		return false
+	}
+	return *c.BusinessManagement
+}
+
+// GetClientID returns the ClientID field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsFacebook) GetClientID() string {
+	if c == nil || c.ClientID == nil {
+		return ""
+	}
+	return *c.ClientID
+}
+
+// GetClientSecret returns the ClientSecret field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsFacebook) GetClientSecret() string {
+	if c == nil || c.ClientSecret == nil {
+		return ""
+	}
+	return *c.ClientSecret
+}
+
+// GetEmail returns the Email field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsFacebook) GetEmail() bool {
+	if c == nil || c.Email == nil {
+		return false
+	}
+	return *c.Email
+}
+
+// GetGroupsAccessMemberInfo returns the GroupsAccessMemberInfo field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsFacebook) GetGroupsAccessMemberInfo() bool {
+	if c == nil || c.GroupsAccessMemberInfo == nil {
+		return false
+	}
+	return *c.GroupsAccessMemberInfo
+}
+
+// GetLeadsRetrieval returns the LeadsRetrieval field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsFacebook) GetLeadsRetrieval() bool {
+	if c == nil || c.LeadsRetrieval == nil {
+		return false
+	}
+	return *c.LeadsRetrieval
+}
+
+// GetManageNotifications returns the ManageNotifications field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsFacebook) GetManageNotifications() bool {
+	if c == nil || c.ManageNotifications == nil {
+		return false
+	}
+	return *c.ManageNotifications
+}
+
+// GetManagePages returns the ManagePages field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsFacebook) GetManagePages() bool {
+	if c == nil || c.ManagePages == nil {
+		return false
+	}
+	return *c.ManagePages
+}
+
+// GetPagesManageCTA returns the PagesManageCTA field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsFacebook) GetPagesManageCTA() bool {
+	if c == nil || c.PagesManageCTA == nil {
+		return false
+	}
+	return *c.PagesManageCTA
+}
+
+// GetPagesManageInstantArticles returns the PagesManageInstantArticles field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsFacebook) GetPagesManageInstantArticles() bool {
+	if c == nil || c.PagesManageInstantArticles == nil {
+		return false
+	}
+	return *c.PagesManageInstantArticles
+}
+
+// GetPagesMessaging returns the PagesMessaging field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsFacebook) GetPagesMessaging() bool {
+	if c == nil || c.PagesMessaging == nil {
+		return false
+	}
+	return *c.PagesMessaging
+}
+
+// GetPagesMessagingPhoneNumber returns the PagesMessagingPhoneNumber field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsFacebook) GetPagesMessagingPhoneNumber() bool {
+	if c == nil || c.PagesMessagingPhoneNumber == nil {
+		return false
+	}
+	return *c.PagesMessagingPhoneNumber
+}
+
+// GetPagesMessagingSubscriptions returns the PagesMessagingSubscriptions field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsFacebook) GetPagesMessagingSubscriptions() bool {
+	if c == nil || c.PagesMessagingSubscriptions == nil {
+		return false
+	}
+	return *c.PagesMessagingSubscriptions
+}
+
+// GetPagesShowList returns the PagesShowList field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsFacebook) GetPagesShowList() bool {
+	if c == nil || c.PagesShowList == nil {
+		return false
+	}
+	return *c.PagesShowList
+}
+
+// GetPublicProfile returns the PublicProfile field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsFacebook) GetPublicProfile() bool {
+	if c == nil || c.PublicProfile == nil {
+		return false
+	}
+	return *c.PublicProfile
+}
+
+// GetPublishActions returns the PublishActions field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsFacebook) GetPublishActions() bool {
+	if c == nil || c.PublishActions == nil {
+		return false
+	}
+	return *c.PublishActions
+}
+
+// GetPublishPages returns the PublishPages field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsFacebook) GetPublishPages() bool {
+	if c == nil || c.PublishPages == nil {
+		return false
+	}
+	return *c.PublishPages
+}
+
+// GetPublishToGroups returns the PublishToGroups field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsFacebook) GetPublishToGroups() bool {
+	if c == nil || c.PublishToGroups == nil {
+		return false
+	}
+	return *c.PublishToGroups
+}
+
+// GetPublishVideo returns the PublishVideo field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsFacebook) GetPublishVideo() bool {
+	if c == nil || c.PublishVideo == nil {
+		return false
+	}
+	return *c.PublishVideo
+}
+
+// GetReadAudienceNetworkInsights returns the ReadAudienceNetworkInsights field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsFacebook) GetReadAudienceNetworkInsights() bool {
+	if c == nil || c.ReadAudienceNetworkInsights == nil {
+		return false
+	}
+	return *c.ReadAudienceNetworkInsights
+}
+
+// GetReadInsights returns the ReadInsights field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsFacebook) GetReadInsights() bool {
+	if c == nil || c.ReadInsights == nil {
+		return false
+	}
+	return *c.ReadInsights
+}
+
+// GetReadMailbox returns the ReadMailbox field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsFacebook) GetReadMailbox() bool {
+	if c == nil || c.ReadMailbox == nil {
+		return false
+	}
+	return *c.ReadMailbox
+}
+
+// GetReadPageMailboxes returns the ReadPageMailboxes field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsFacebook) GetReadPageMailboxes() bool {
+	if c == nil || c.ReadPageMailboxes == nil {
+		return false
+	}
+	return *c.ReadPageMailboxes
+}
+
+// GetReadStream returns the ReadStream field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsFacebook) GetReadStream() bool {
+	if c == nil || c.ReadStream == nil {
+		return false
+	}
+	return *c.ReadStream
+}
+
+// GetScope returns the Scope field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsFacebook) GetScope() string {
+	if c == nil || c.Scope == nil {
+		return ""
+	}
+	return *c.Scope
+}
+
+// GetUserAgeRange returns the UserAgeRange field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsFacebook) GetUserAgeRange() bool {
+	if c == nil || c.UserAgeRange == nil {
+		return false
+	}
+	return *c.UserAgeRange
+}
+
+// GetUserBirthday returns the UserBirthday field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsFacebook) GetUserBirthday() bool {
+	if c == nil || c.UserBirthday == nil {
+		return false
+	}
+	return *c.UserBirthday
+}
+
+// GetUserEvents returns the UserEvents field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsFacebook) GetUserEvents() bool {
+	if c == nil || c.UserEvents == nil {
+		return false
+	}
+	return *c.UserEvents
+}
+
+// GetUserFriends returns the UserFriends field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsFacebook) GetUserFriends() bool {
+	if c == nil || c.UserFriends == nil {
+		return false
+	}
+	return *c.UserFriends
+}
+
+// GetUserGender returns the UserGender field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsFacebook) GetUserGender() bool {
+	if c == nil || c.UserGender == nil {
+		return false
+	}
+	return *c.UserGender
+}
+
+// GetUserGroups returns the UserGroups field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsFacebook) GetUserGroups() bool {
+	if c == nil || c.UserGroups == nil {
+		return false
+	}
+	return *c.UserGroups
+}
+
+// GetUserHometown returns the UserHometown field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsFacebook) GetUserHometown() bool {
+	if c == nil || c.UserHometown == nil {
+		return false
+	}
+	return *c.UserHometown
+}
+
+// GetUserLikes returns the UserLikes field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsFacebook) GetUserLikes() bool {
+	if c == nil || c.UserLikes == nil {
+		return false
+	}
+	return *c.UserLikes
+}
+
+// GetUserLink returns the UserLink field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsFacebook) GetUserLink() bool {
+	if c == nil || c.UserLink == nil {
+		return false
+	}
+	return *c.UserLink
+}
+
+// GetUserLocation returns the UserLocation field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsFacebook) GetUserLocation() bool {
+	if c == nil || c.UserLocation == nil {
+		return false
+	}
+	return *c.UserLocation
+}
+
+// GetUserManagedGroups returns the UserManagedGroups field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsFacebook) GetUserManagedGroups() bool {
+	if c == nil || c.UserManagedGroups == nil {
+		return false
+	}
+	return *c.UserManagedGroups
+}
+
+// GetUserPhotos returns the UserPhotos field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsFacebook) GetUserPhotos() bool {
+	if c == nil || c.UserPhotos == nil {
+		return false
+	}
+	return *c.UserPhotos
+}
+
+// GetUserPosts returns the UserPosts field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsFacebook) GetUserPosts() bool {
+	if c == nil || c.UserPosts == nil {
+		return false
+	}
+	return *c.UserPosts
+}
+
+// GetUserStatus returns the UserStatus field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsFacebook) GetUserStatus() bool {
+	if c == nil || c.UserStatus == nil {
+		return false
+	}
+	return *c.UserStatus
+}
+
+// GetUserTaggedPlaces returns the UserTaggedPlaces field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsFacebook) GetUserTaggedPlaces() bool {
+	if c == nil || c.UserTaggedPlaces == nil {
+		return false
+	}
+	return *c.UserTaggedPlaces
+}
+
+// GetUserVideos returns the UserVideos field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsFacebook) GetUserVideos() bool {
+	if c == nil || c.UserVideos == nil {
+		return false
+	}
+	return *c.UserVideos
+}
+
+// String returns a string representation of ConnectionOptionsFacebook.
+func (c *ConnectionOptionsFacebook) String() string {
+	return Stringify(c)
+}
+
+// GetAdminOrg returns the AdminOrg field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsGitHub) GetAdminOrg() bool {
+	if c == nil || c.AdminOrg == nil {
+		return false
+	}
+	return *c.AdminOrg
+}
+
+// GetAdminPublicKey returns the AdminPublicKey field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsGitHub) GetAdminPublicKey() bool {
+	if c == nil || c.AdminPublicKey == nil {
+		return false
+	}
+	return *c.AdminPublicKey
+}
+
+// GetAdminRepoHook returns the AdminRepoHook field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsGitHub) GetAdminRepoHook() bool {
+	if c == nil || c.AdminRepoHook == nil {
+		return false
+	}
+	return *c.AdminRepoHook
+}
+
+// GetClientID returns the ClientID field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsGitHub) GetClientID() string {
+	if c == nil || c.ClientID == nil {
+		return ""
+	}
+	return *c.ClientID
+}
+
+// GetClientSecret returns the ClientSecret field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsGitHub) GetClientSecret() string {
+	if c == nil || c.ClientSecret == nil {
+		return ""
+	}
+	return *c.ClientSecret
+}
+
+// GetDeleteRepo returns the DeleteRepo field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsGitHub) GetDeleteRepo() bool {
+	if c == nil || c.DeleteRepo == nil {
+		return false
+	}
+	return *c.DeleteRepo
+}
+
+// GetEmail returns the Email field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsGitHub) GetEmail() bool {
+	if c == nil || c.Email == nil {
+		return false
+	}
+	return *c.Email
+}
+
+// GetFollow returns the Follow field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsGitHub) GetFollow() bool {
+	if c == nil || c.Follow == nil {
+		return false
+	}
+	return *c.Follow
+}
+
+// GetGist returns the Gist field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsGitHub) GetGist() bool {
+	if c == nil || c.Gist == nil {
+		return false
+	}
+	return *c.Gist
+}
+
+// GetNotifications returns the Notifications field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsGitHub) GetNotifications() bool {
+	if c == nil || c.Notifications == nil {
+		return false
+	}
+	return *c.Notifications
+}
+
+// GetProfile returns the Profile field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsGitHub) GetProfile() bool {
+	if c == nil || c.Profile == nil {
+		return false
+	}
+	return *c.Profile
+}
+
+// GetPublicRepo returns the PublicRepo field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsGitHub) GetPublicRepo() bool {
+	if c == nil || c.PublicRepo == nil {
+		return false
+	}
+	return *c.PublicRepo
+}
+
+// GetReadOrg returns the ReadOrg field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsGitHub) GetReadOrg() bool {
+	if c == nil || c.ReadOrg == nil {
+		return false
+	}
+	return *c.ReadOrg
+}
+
+// GetReadPublicKey returns the ReadPublicKey field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsGitHub) GetReadPublicKey() bool {
+	if c == nil || c.ReadPublicKey == nil {
+		return false
+	}
+	return *c.ReadPublicKey
+}
+
+// GetReadRepoHook returns the ReadRepoHook field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsGitHub) GetReadRepoHook() bool {
+	if c == nil || c.ReadRepoHook == nil {
+		return false
+	}
+	return *c.ReadRepoHook
+}
+
+// GetReadUser returns the ReadUser field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsGitHub) GetReadUser() bool {
+	if c == nil || c.ReadUser == nil {
+		return false
+	}
+	return *c.ReadUser
+}
+
+// GetRepo returns the Repo field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsGitHub) GetRepo() bool {
+	if c == nil || c.Repo == nil {
+		return false
+	}
+	return *c.Repo
+}
+
+// GetRepoDeployment returns the RepoDeployment field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsGitHub) GetRepoDeployment() bool {
+	if c == nil || c.RepoDeployment == nil {
+		return false
+	}
+	return *c.RepoDeployment
+}
+
+// GetRepoStatus returns the RepoStatus field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsGitHub) GetRepoStatus() bool {
+	if c == nil || c.RepoStatus == nil {
+		return false
+	}
+	return *c.RepoStatus
+}
+
+// GetSetUserAttributes returns the SetUserAttributes field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsGitHub) GetSetUserAttributes() string {
+	if c == nil || c.SetUserAttributes == nil {
+		return ""
+	}
+	return *c.SetUserAttributes
+}
+
+// GetWriteOrg returns the WriteOrg field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsGitHub) GetWriteOrg() bool {
+	if c == nil || c.WriteOrg == nil {
+		return false
+	}
+	return *c.WriteOrg
+}
+
+// GetWritePublicKey returns the WritePublicKey field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsGitHub) GetWritePublicKey() bool {
+	if c == nil || c.WritePublicKey == nil {
+		return false
+	}
+	return *c.WritePublicKey
+}
+
+// GetWriteRepoHook returns the WriteRepoHook field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsGitHub) GetWriteRepoHook() bool {
+	if c == nil || c.WriteRepoHook == nil {
+		return false
+	}
+	return *c.WriteRepoHook
+}
+
+// String returns a string representation of ConnectionOptionsGitHub.
+func (c *ConnectionOptionsGitHub) String() string {
+	return Stringify(c)
+}
+
+// GetAdsenseManagement returns the AdsenseManagement field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsGooleOAuth2) GetAdsenseManagement() bool {
+	if c == nil || c.AdsenseManagement == nil {
+		return false
+	}
+	return *c.AdsenseManagement
+}
+
+// GetAnalytics returns the Analytics field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsGooleOAuth2) GetAnalytics() bool {
+	if c == nil || c.Analytics == nil {
+		return false
+	}
+	return *c.Analytics
+}
+
+// GetBlogger returns the Blogger field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsGooleOAuth2) GetBlogger() bool {
+	if c == nil || c.Blogger == nil {
+		return false
+	}
+	return *c.Blogger
+}
+
+// GetCalendar returns the Calendar field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsGooleOAuth2) GetCalendar() bool {
+	if c == nil || c.Calendar == nil {
+		return false
+	}
+	return *c.Calendar
+}
+
+// GetChromeWebStore returns the ChromeWebStore field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsGooleOAuth2) GetChromeWebStore() bool {
+	if c == nil || c.ChromeWebStore == nil {
+		return false
+	}
+	return *c.ChromeWebStore
+}
+
+// GetClientID returns the ClientID field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsGooleOAuth2) GetClientID() string {
+	if c == nil || c.ClientID == nil {
+		return ""
+	}
+	return *c.ClientID
+}
+
+// GetClientSecret returns the ClientSecret field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsGooleOAuth2) GetClientSecret() string {
+	if c == nil || c.ClientSecret == nil {
+		return ""
+	}
+	return *c.ClientSecret
+}
+
+// GetContacts returns the Contacts field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsGooleOAuth2) GetContacts() bool {
+	if c == nil || c.Contacts == nil {
+		return false
+	}
+	return *c.Contacts
+}
+
+// GetContentAPIForShopping returns the ContentAPIForShopping field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsGooleOAuth2) GetContentAPIForShopping() bool {
+	if c == nil || c.ContentAPIForShopping == nil {
+		return false
+	}
+	return *c.ContentAPIForShopping
+}
+
+// GetCoordinate returns the Coordinate field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsGooleOAuth2) GetCoordinate() bool {
+	if c == nil || c.Coordinate == nil {
+		return false
+	}
+	return *c.Coordinate
+}
+
+// GetCoordinateReadonly returns the CoordinateReadonly field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsGooleOAuth2) GetCoordinateReadonly() bool {
+	if c == nil || c.CoordinateReadonly == nil {
+		return false
+	}
+	return *c.CoordinateReadonly
+}
+
+// GetDocumentList returns the DocumentList field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsGooleOAuth2) GetDocumentList() bool {
+	if c == nil || c.DocumentList == nil {
+		return false
+	}
+	return *c.DocumentList
+}
+
+// GetEmail returns the Email field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsGooleOAuth2) GetEmail() bool {
+	if c == nil || c.Email == nil {
+		return false
+	}
+	return *c.Email
+}
+
+// GetGmail returns the Gmail field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsGooleOAuth2) GetGmail() bool {
+	if c == nil || c.Gmail == nil {
+		return false
+	}
+	return *c.Gmail
+}
+
+// GetGoogleAffiliateNetwork returns the GoogleAffiliateNetwork field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsGooleOAuth2) GetGoogleAffiliateNetwork() bool {
+	if c == nil || c.GoogleAffiliateNetwork == nil {
+		return false
+	}
+	return *c.GoogleAffiliateNetwork
+}
+
+// GetGoogleBooks returns the GoogleBooks field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsGooleOAuth2) GetGoogleBooks() bool {
+	if c == nil || c.GoogleBooks == nil {
+		return false
+	}
+	return *c.GoogleBooks
+}
+
+// GetGoogleCloudStorage returns the GoogleCloudStorage field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsGooleOAuth2) GetGoogleCloudStorage() bool {
+	if c == nil || c.GoogleCloudStorage == nil {
+		return false
+	}
+	return *c.GoogleCloudStorage
+}
+
+// GetGoogleDrive returns the GoogleDrive field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsGooleOAuth2) GetGoogleDrive() bool {
+	if c == nil || c.GoogleDrive == nil {
+		return false
+	}
+	return *c.GoogleDrive
+}
+
+// GetGoogleDriveFiles returns the GoogleDriveFiles field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsGooleOAuth2) GetGoogleDriveFiles() bool {
+	if c == nil || c.GoogleDriveFiles == nil {
+		return false
+	}
+	return *c.GoogleDriveFiles
+}
+
+// GetGooglePlus returns the GooglePlus field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsGooleOAuth2) GetGooglePlus() bool {
+	if c == nil || c.GooglePlus == nil {
+		return false
+	}
+	return *c.GooglePlus
+}
+
+// GetLatitudeBest returns the LatitudeBest field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsGooleOAuth2) GetLatitudeBest() bool {
+	if c == nil || c.LatitudeBest == nil {
+		return false
+	}
+	return *c.LatitudeBest
+}
+
+// GetLatitudeCity returns the LatitudeCity field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsGooleOAuth2) GetLatitudeCity() bool {
+	if c == nil || c.LatitudeCity == nil {
+		return false
+	}
+	return *c.LatitudeCity
+}
+
+// GetModerator returns the Moderator field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsGooleOAuth2) GetModerator() bool {
+	if c == nil || c.Moderator == nil {
+		return false
+	}
+	return *c.Moderator
+}
+
+// GetOrkut returns the Orkut field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsGooleOAuth2) GetOrkut() bool {
+	if c == nil || c.Orkut == nil {
+		return false
+	}
+	return *c.Orkut
+}
+
+// GetPicasaWeb returns the PicasaWeb field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsGooleOAuth2) GetPicasaWeb() bool {
+	if c == nil || c.PicasaWeb == nil {
+		return false
+	}
+	return *c.PicasaWeb
+}
+
+// GetProfile returns the Profile field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsGooleOAuth2) GetProfile() bool {
+	if c == nil || c.Profile == nil {
+		return false
+	}
+	return *c.Profile
+}
+
+// GetSites returns the Sites field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsGooleOAuth2) GetSites() bool {
+	if c == nil || c.Sites == nil {
+		return false
+	}
+	return *c.Sites
+}
+
+// GetSpreadsheets returns the Spreadsheets field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsGooleOAuth2) GetSpreadsheets() bool {
+	if c == nil || c.Spreadsheets == nil {
+		return false
+	}
+	return *c.Spreadsheets
+}
+
+// GetTasks returns the Tasks field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsGooleOAuth2) GetTasks() bool {
+	if c == nil || c.Tasks == nil {
+		return false
+	}
+	return *c.Tasks
+}
+
+// GetURLShortener returns the URLShortener field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsGooleOAuth2) GetURLShortener() bool {
+	if c == nil || c.URLShortener == nil {
+		return false
+	}
+	return *c.URLShortener
+}
+
+// GetWebmasterTools returns the WebmasterTools field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsGooleOAuth2) GetWebmasterTools() bool {
+	if c == nil || c.WebmasterTools == nil {
+		return false
+	}
+	return *c.WebmasterTools
+}
+
+// GetYoutube returns the Youtube field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsGooleOAuth2) GetYoutube() bool {
+	if c == nil || c.Youtube == nil {
+		return false
+	}
+	return *c.Youtube
+}
+
+// String returns a string representation of ConnectionOptionsGooleOAuth2.
+func (c *ConnectionOptionsGooleOAuth2) String() string {
+	return Stringify(c)
+}
+
+// GetBasicProfile returns the BasicProfile field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsLinkedin) GetBasicProfile() bool {
+	if c == nil || c.BasicProfile == nil {
+		return false
+	}
+	return *c.BasicProfile
+}
+
+// GetClientID returns the ClientID field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsLinkedin) GetClientID() string {
+	if c == nil || c.ClientID == nil {
+		return ""
+	}
+	return *c.ClientID
+}
+
+// GetClientSecret returns the ClientSecret field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsLinkedin) GetClientSecret() string {
+	if c == nil || c.ClientSecret == nil {
+		return ""
+	}
+	return *c.ClientSecret
+}
+
+// GetEmail returns the Email field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsLinkedin) GetEmail() bool {
+	if c == nil || c.Email == nil {
+		return false
+	}
+	return *c.Email
+}
+
+// GetProfile returns the Profile field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsLinkedin) GetProfile() bool {
+	if c == nil || c.Profile == nil {
+		return false
+	}
+	return *c.Profile
+}
+
+// GetSetUserAttributes returns the SetUserAttributes field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsLinkedin) GetSetUserAttributes() string {
+	if c == nil || c.SetUserAttributes == nil {
+		return ""
+	}
+	return *c.SetUserAttributes
+}
+
+// GetStrategyVersion returns the StrategyVersion field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsLinkedin) GetStrategyVersion() int {
+	if c == nil || c.StrategyVersion == nil {
+		return 0
+	}
+	return *c.StrategyVersion
+}
+
+// String returns a string representation of ConnectionOptionsLinkedin.
+func (c *ConnectionOptionsLinkedin) String() string {
+	return Stringify(c)
+}
+
+// GetAuthorizationEndpoint returns the AuthorizationEndpoint field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsOIDC) GetAuthorizationEndpoint() string {
+	if c == nil || c.AuthorizationEndpoint == nil {
+		return ""
+	}
+	return *c.AuthorizationEndpoint
+}
+
+// GetClientID returns the ClientID field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsOIDC) GetClientID() string {
+	if c == nil || c.ClientID == nil {
+		return ""
+	}
+	return *c.ClientID
+}
+
+// GetClientSecret returns the ClientSecret field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsOIDC) GetClientSecret() string {
+	if c == nil || c.ClientSecret == nil {
+		return ""
+	}
+	return *c.ClientSecret
+}
+
+// GetDiscoveryURL returns the DiscoveryURL field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsOIDC) GetDiscoveryURL() string {
+	if c == nil || c.DiscoveryURL == nil {
+		return ""
+	}
+	return *c.DiscoveryURL
+}
+
+// GetIssuer returns the Issuer field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsOIDC) GetIssuer() string {
+	if c == nil || c.Issuer == nil {
+		return ""
+	}
+	return *c.Issuer
+}
+
+// GetJWKSURI returns the JWKSURI field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsOIDC) GetJWKSURI() string {
+	if c == nil || c.JWKSURI == nil {
+		return ""
+	}
+	return *c.JWKSURI
+}
+
+// GetLogoURL returns the LogoURL field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsOIDC) GetLogoURL() string {
+	if c == nil || c.LogoURL == nil {
+		return ""
+	}
+	return *c.LogoURL
+}
+
+// GetScope returns the Scope field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsOIDC) GetScope() string {
+	if c == nil || c.Scope == nil {
+		return ""
+	}
+	return *c.Scope
+}
+
+// GetTenantDomain returns the TenantDomain field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsOIDC) GetTenantDomain() string {
+	if c == nil || c.TenantDomain == nil {
+		return ""
+	}
+	return *c.TenantDomain
+}
+
+// GetTokenEndpoint returns the TokenEndpoint field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsOIDC) GetTokenEndpoint() string {
+	if c == nil || c.TokenEndpoint == nil {
+		return ""
+	}
+	return *c.TokenEndpoint
+}
+
+// GetType returns the Type field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsOIDC) GetType() string {
+	if c == nil || c.Type == nil {
+		return ""
+	}
+	return *c.Type
+}
+
+// GetUserInfoEndpoint returns the UserInfoEndpoint field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsOIDC) GetUserInfoEndpoint() string {
+	if c == nil || c.UserInfoEndpoint == nil {
+		return ""
+	}
+	return *c.UserInfoEndpoint
+}
+
+// String returns a string representation of ConnectionOptionsOIDC.
+func (c *ConnectionOptionsOIDC) String() string {
+	return Stringify(c)
+}
+
+// GetLength returns the Length field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsOTP) GetLength() int {
+	if c == nil || c.Length == nil {
+		return 0
+	}
+	return *c.Length
+}
+
+// GetTimeStep returns the TimeStep field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsOTP) GetTimeStep() int {
+	if c == nil || c.TimeStep == nil {
+		return 0
+	}
+	return *c.TimeStep
+}
+
+// String returns a string representation of ConnectionOptionsOTP.
+func (c *ConnectionOptionsOTP) String() string {
+	return Stringify(c)
+}
+
+// GetClientID returns the ClientID field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsSalesforce) GetClientID() string {
+	if c == nil || c.ClientID == nil {
+		return ""
+	}
+	return *c.ClientID
+}
+
+// GetClientSecret returns the ClientSecret field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsSalesforce) GetClientSecret() string {
+	if c == nil || c.ClientSecret == nil {
+		return ""
+	}
+	return *c.ClientSecret
+}
+
+// GetCommunityBaseURL returns the CommunityBaseURL field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsSalesforce) GetCommunityBaseURL() string {
+	if c == nil || c.CommunityBaseURL == nil {
+		return ""
+	}
+	return *c.CommunityBaseURL
+}
+
+// GetProfile returns the Profile field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsSalesforce) GetProfile() bool {
+	if c == nil || c.Profile == nil {
+		return false
+	}
+	return *c.Profile
+}
+
+// GetSetUserAttributes returns the SetUserAttributes field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsSalesforce) GetSetUserAttributes() string {
+	if c == nil || c.SetUserAttributes == nil {
+		return ""
+	}
+	return *c.SetUserAttributes
+}
+
+// String returns a string representation of ConnectionOptionsSalesforce.
+func (c *ConnectionOptionsSalesforce) String() string {
+	return Stringify(c)
+}
+
+// GetBruteForceProtection returns the BruteForceProtection field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsSMS) GetBruteForceProtection() bool {
+	if c == nil || c.BruteForceProtection == nil {
+		return false
+	}
+	return *c.BruteForceProtection
+}
+
+// GetDisableSignup returns the DisableSignup field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsSMS) GetDisableSignup() bool {
+	if c == nil || c.DisableSignup == nil {
+		return false
+	}
+	return *c.DisableSignup
+}
+
+// GetFrom returns the From field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsSMS) GetFrom() string {
+	if c == nil || c.From == nil {
+		return ""
+	}
+	return *c.From
+}
+
+// GetMessagingServiceSID returns the MessagingServiceSID field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsSMS) GetMessagingServiceSID() string {
+	if c == nil || c.MessagingServiceSID == nil {
+		return ""
+	}
+	return *c.MessagingServiceSID
+}
+
+// GetName returns the Name field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsSMS) GetName() string {
+	if c == nil || c.Name == nil {
+		return ""
+	}
+	return *c.Name
+}
+
+// GetOTP returns the OTP field.
+func (c *ConnectionOptionsSMS) GetOTP() *ConnectionOptionsOTP {
+	if c == nil {
+		return nil
+	}
+	return c.OTP
+}
+
+// GetSyntax returns the Syntax field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsSMS) GetSyntax() string {
 	if c == nil || c.Syntax == nil {
 		return ""
 	}
@@ -616,71 +1860,31 @@ func (c *ConnectionOptions) GetSyntax() string {
 }
 
 // GetTemplate returns the Template field if it's non-nil, zero value otherwise.
-func (c *ConnectionOptions) GetTemplate() string {
+func (c *ConnectionOptionsSMS) GetTemplate() string {
 	if c == nil || c.Template == nil {
 		return ""
 	}
 	return *c.Template
 }
 
-// GetTenantDomain returns the TenantDomain field if it's non-nil, zero value otherwise.
-func (c *ConnectionOptions) GetTenantDomain() string {
-	if c == nil || c.TenantDomain == nil {
+// GetTwilioSID returns the TwilioSID field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsSMS) GetTwilioSID() string {
+	if c == nil || c.TwilioSID == nil {
 		return ""
 	}
-	return *c.TenantDomain
-}
-
-// GetTotp returns the Totp field.
-func (c *ConnectionOptions) GetTotp() *ConnectionOptionsTotp {
-	if c == nil {
-		return nil
-	}
-	return c.Totp
-}
-
-// GetTwilioSid returns the TwilioSid field if it's non-nil, zero value otherwise.
-func (c *ConnectionOptions) GetTwilioSid() string {
-	if c == nil || c.TwilioSid == nil {
-		return ""
-	}
-	return *c.TwilioSid
+	return *c.TwilioSID
 }
 
 // GetTwilioToken returns the TwilioToken field if it's non-nil, zero value otherwise.
-func (c *ConnectionOptions) GetTwilioToken() string {
+func (c *ConnectionOptionsSMS) GetTwilioToken() string {
 	if c == nil || c.TwilioToken == nil {
 		return ""
 	}
 	return *c.TwilioToken
 }
 
-// GetUseWsfed returns the UseWsfed field if it's non-nil, zero value otherwise.
-func (c *ConnectionOptions) GetUseWsfed() bool {
-	if c == nil || c.UseWsfed == nil {
-		return false
-	}
-	return *c.UseWsfed
-}
-
-// GetWaadCommonEndpoint returns the WaadCommonEndpoint field if it's non-nil, zero value otherwise.
-func (c *ConnectionOptions) GetWaadCommonEndpoint() bool {
-	if c == nil || c.WaadCommonEndpoint == nil {
-		return false
-	}
-	return *c.WaadCommonEndpoint
-}
-
-// GetWaadProtocol returns the WaadProtocol field if it's non-nil, zero value otherwise.
-func (c *ConnectionOptions) GetWaadProtocol() string {
-	if c == nil || c.WaadProtocol == nil {
-		return ""
-	}
-	return *c.WaadProtocol
-}
-
-// String returns a string representation of ConnectionOptions.
-func (c *ConnectionOptions) String() string {
+// String returns a string representation of ConnectionOptionsSMS.
+func (c *ConnectionOptionsSMS) String() string {
 	return Stringify(c)
 }
 
@@ -702,6 +1906,219 @@ func (c *ConnectionOptionsTotp) GetTimeStep() int {
 
 // String returns a string representation of ConnectionOptionsTotp.
 func (c *ConnectionOptionsTotp) String() string {
+	return Stringify(c)
+}
+
+// GetCalendars returns the Calendars field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsWindowsLive) GetCalendars() bool {
+	if c == nil || c.Calendars == nil {
+		return false
+	}
+	return *c.Calendars
+}
+
+// GetCalendarsUpdate returns the CalendarsUpdate field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsWindowsLive) GetCalendarsUpdate() bool {
+	if c == nil || c.CalendarsUpdate == nil {
+		return false
+	}
+	return *c.CalendarsUpdate
+}
+
+// GetClientID returns the ClientID field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsWindowsLive) GetClientID() string {
+	if c == nil || c.ClientID == nil {
+		return ""
+	}
+	return *c.ClientID
+}
+
+// GetClientSecret returns the ClientSecret field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsWindowsLive) GetClientSecret() string {
+	if c == nil || c.ClientSecret == nil {
+		return ""
+	}
+	return *c.ClientSecret
+}
+
+// GetContacts returns the Contacts field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsWindowsLive) GetContacts() bool {
+	if c == nil || c.Contacts == nil {
+		return false
+	}
+	return *c.Contacts
+}
+
+// GetContactsUpdate returns the ContactsUpdate field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsWindowsLive) GetContactsUpdate() bool {
+	if c == nil || c.ContactsUpdate == nil {
+		return false
+	}
+	return *c.ContactsUpdate
+}
+
+// GetDevice returns the Device field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsWindowsLive) GetDevice() bool {
+	if c == nil || c.Device == nil {
+		return false
+	}
+	return *c.Device
+}
+
+// GetDeviceCommand returns the DeviceCommand field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsWindowsLive) GetDeviceCommand() bool {
+	if c == nil || c.DeviceCommand == nil {
+		return false
+	}
+	return *c.DeviceCommand
+}
+
+// GetEmails returns the Emails field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsWindowsLive) GetEmails() bool {
+	if c == nil || c.Emails == nil {
+		return false
+	}
+	return *c.Emails
+}
+
+// GetEmailsUpdate returns the EmailsUpdate field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsWindowsLive) GetEmailsUpdate() bool {
+	if c == nil || c.EmailsUpdate == nil {
+		return false
+	}
+	return *c.EmailsUpdate
+}
+
+// GetFiles returns the Files field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsWindowsLive) GetFiles() bool {
+	if c == nil || c.Files == nil {
+		return false
+	}
+	return *c.Files
+}
+
+// GetFilesAll returns the FilesAll field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsWindowsLive) GetFilesAll() bool {
+	if c == nil || c.FilesAll == nil {
+		return false
+	}
+	return *c.FilesAll
+}
+
+// GetFilesAllUpdate returns the FilesAllUpdate field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsWindowsLive) GetFilesAllUpdate() bool {
+	if c == nil || c.FilesAllUpdate == nil {
+		return false
+	}
+	return *c.FilesAllUpdate
+}
+
+// GetFilesUpdate returns the FilesUpdate field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsWindowsLive) GetFilesUpdate() bool {
+	if c == nil || c.FilesUpdate == nil {
+		return false
+	}
+	return *c.FilesUpdate
+}
+
+// GetNotes returns the Notes field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsWindowsLive) GetNotes() bool {
+	if c == nil || c.Notes == nil {
+		return false
+	}
+	return *c.Notes
+}
+
+// GetNotesCreate returns the NotesCreate field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsWindowsLive) GetNotesCreate() bool {
+	if c == nil || c.NotesCreate == nil {
+		return false
+	}
+	return *c.NotesCreate
+}
+
+// GetNotesUpdate returns the NotesUpdate field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsWindowsLive) GetNotesUpdate() bool {
+	if c == nil || c.NotesUpdate == nil {
+		return false
+	}
+	return *c.NotesUpdate
+}
+
+// GetOfflineAccess returns the OfflineAccess field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsWindowsLive) GetOfflineAccess() bool {
+	if c == nil || c.OfflineAccess == nil {
+		return false
+	}
+	return *c.OfflineAccess
+}
+
+// GetSetUserAttributes returns the SetUserAttributes field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsWindowsLive) GetSetUserAttributes() string {
+	if c == nil || c.SetUserAttributes == nil {
+		return ""
+	}
+	return *c.SetUserAttributes
+}
+
+// GetSignin returns the Signin field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsWindowsLive) GetSignin() bool {
+	if c == nil || c.Signin == nil {
+		return false
+	}
+	return *c.Signin
+}
+
+// GetStrategyVersion returns the StrategyVersion field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsWindowsLive) GetStrategyVersion() int {
+	if c == nil || c.StrategyVersion == nil {
+		return 0
+	}
+	return *c.StrategyVersion
+}
+
+// GetTasks returns the Tasks field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsWindowsLive) GetTasks() bool {
+	if c == nil || c.Tasks == nil {
+		return false
+	}
+	return *c.Tasks
+}
+
+// GetTasksUpdate returns the TasksUpdate field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsWindowsLive) GetTasksUpdate() bool {
+	if c == nil || c.TasksUpdate == nil {
+		return false
+	}
+	return *c.TasksUpdate
+}
+
+// GetUser returns the User field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsWindowsLive) GetUser() bool {
+	if c == nil || c.User == nil {
+		return false
+	}
+	return *c.User
+}
+
+// GetUserActivity returns the UserActivity field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsWindowsLive) GetUserActivity() bool {
+	if c == nil || c.UserActivity == nil {
+		return false
+	}
+	return *c.UserActivity
+}
+
+// GetUserUpdate returns the UserUpdate field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsWindowsLive) GetUserUpdate() bool {
+	if c == nil || c.UserUpdate == nil {
+		return false
+	}
+	return *c.UserUpdate
+}
+
+// String returns a string representation of ConnectionOptionsWindowsLive.
+func (c *ConnectionOptionsWindowsLive) String() string {
 	return Stringify(c)
 }
 

--- a/management/management.gen.go
+++ b/management/management.gen.go
@@ -1315,7 +1315,7 @@ func (c *ConnectionOptionsGitHub) String() string {
 }
 
 // GetAdsenseManagement returns the AdsenseManagement field if it's non-nil, zero value otherwise.
-func (c *ConnectionOptionsGooleOAuth2) GetAdsenseManagement() bool {
+func (c *ConnectionOptionsGoogleOAuth2) GetAdsenseManagement() bool {
 	if c == nil || c.AdsenseManagement == nil {
 		return false
 	}
@@ -1323,7 +1323,7 @@ func (c *ConnectionOptionsGooleOAuth2) GetAdsenseManagement() bool {
 }
 
 // GetAnalytics returns the Analytics field if it's non-nil, zero value otherwise.
-func (c *ConnectionOptionsGooleOAuth2) GetAnalytics() bool {
+func (c *ConnectionOptionsGoogleOAuth2) GetAnalytics() bool {
 	if c == nil || c.Analytics == nil {
 		return false
 	}
@@ -1331,7 +1331,7 @@ func (c *ConnectionOptionsGooleOAuth2) GetAnalytics() bool {
 }
 
 // GetBlogger returns the Blogger field if it's non-nil, zero value otherwise.
-func (c *ConnectionOptionsGooleOAuth2) GetBlogger() bool {
+func (c *ConnectionOptionsGoogleOAuth2) GetBlogger() bool {
 	if c == nil || c.Blogger == nil {
 		return false
 	}
@@ -1339,7 +1339,7 @@ func (c *ConnectionOptionsGooleOAuth2) GetBlogger() bool {
 }
 
 // GetCalendar returns the Calendar field if it's non-nil, zero value otherwise.
-func (c *ConnectionOptionsGooleOAuth2) GetCalendar() bool {
+func (c *ConnectionOptionsGoogleOAuth2) GetCalendar() bool {
 	if c == nil || c.Calendar == nil {
 		return false
 	}
@@ -1347,7 +1347,7 @@ func (c *ConnectionOptionsGooleOAuth2) GetCalendar() bool {
 }
 
 // GetChromeWebStore returns the ChromeWebStore field if it's non-nil, zero value otherwise.
-func (c *ConnectionOptionsGooleOAuth2) GetChromeWebStore() bool {
+func (c *ConnectionOptionsGoogleOAuth2) GetChromeWebStore() bool {
 	if c == nil || c.ChromeWebStore == nil {
 		return false
 	}
@@ -1355,7 +1355,7 @@ func (c *ConnectionOptionsGooleOAuth2) GetChromeWebStore() bool {
 }
 
 // GetClientID returns the ClientID field if it's non-nil, zero value otherwise.
-func (c *ConnectionOptionsGooleOAuth2) GetClientID() string {
+func (c *ConnectionOptionsGoogleOAuth2) GetClientID() string {
 	if c == nil || c.ClientID == nil {
 		return ""
 	}
@@ -1363,7 +1363,7 @@ func (c *ConnectionOptionsGooleOAuth2) GetClientID() string {
 }
 
 // GetClientSecret returns the ClientSecret field if it's non-nil, zero value otherwise.
-func (c *ConnectionOptionsGooleOAuth2) GetClientSecret() string {
+func (c *ConnectionOptionsGoogleOAuth2) GetClientSecret() string {
 	if c == nil || c.ClientSecret == nil {
 		return ""
 	}
@@ -1371,7 +1371,7 @@ func (c *ConnectionOptionsGooleOAuth2) GetClientSecret() string {
 }
 
 // GetContacts returns the Contacts field if it's non-nil, zero value otherwise.
-func (c *ConnectionOptionsGooleOAuth2) GetContacts() bool {
+func (c *ConnectionOptionsGoogleOAuth2) GetContacts() bool {
 	if c == nil || c.Contacts == nil {
 		return false
 	}
@@ -1379,7 +1379,7 @@ func (c *ConnectionOptionsGooleOAuth2) GetContacts() bool {
 }
 
 // GetContentAPIForShopping returns the ContentAPIForShopping field if it's non-nil, zero value otherwise.
-func (c *ConnectionOptionsGooleOAuth2) GetContentAPIForShopping() bool {
+func (c *ConnectionOptionsGoogleOAuth2) GetContentAPIForShopping() bool {
 	if c == nil || c.ContentAPIForShopping == nil {
 		return false
 	}
@@ -1387,7 +1387,7 @@ func (c *ConnectionOptionsGooleOAuth2) GetContentAPIForShopping() bool {
 }
 
 // GetCoordinate returns the Coordinate field if it's non-nil, zero value otherwise.
-func (c *ConnectionOptionsGooleOAuth2) GetCoordinate() bool {
+func (c *ConnectionOptionsGoogleOAuth2) GetCoordinate() bool {
 	if c == nil || c.Coordinate == nil {
 		return false
 	}
@@ -1395,7 +1395,7 @@ func (c *ConnectionOptionsGooleOAuth2) GetCoordinate() bool {
 }
 
 // GetCoordinateReadonly returns the CoordinateReadonly field if it's non-nil, zero value otherwise.
-func (c *ConnectionOptionsGooleOAuth2) GetCoordinateReadonly() bool {
+func (c *ConnectionOptionsGoogleOAuth2) GetCoordinateReadonly() bool {
 	if c == nil || c.CoordinateReadonly == nil {
 		return false
 	}
@@ -1403,7 +1403,7 @@ func (c *ConnectionOptionsGooleOAuth2) GetCoordinateReadonly() bool {
 }
 
 // GetDocumentList returns the DocumentList field if it's non-nil, zero value otherwise.
-func (c *ConnectionOptionsGooleOAuth2) GetDocumentList() bool {
+func (c *ConnectionOptionsGoogleOAuth2) GetDocumentList() bool {
 	if c == nil || c.DocumentList == nil {
 		return false
 	}
@@ -1411,7 +1411,7 @@ func (c *ConnectionOptionsGooleOAuth2) GetDocumentList() bool {
 }
 
 // GetEmail returns the Email field if it's non-nil, zero value otherwise.
-func (c *ConnectionOptionsGooleOAuth2) GetEmail() bool {
+func (c *ConnectionOptionsGoogleOAuth2) GetEmail() bool {
 	if c == nil || c.Email == nil {
 		return false
 	}
@@ -1419,7 +1419,7 @@ func (c *ConnectionOptionsGooleOAuth2) GetEmail() bool {
 }
 
 // GetGmail returns the Gmail field if it's non-nil, zero value otherwise.
-func (c *ConnectionOptionsGooleOAuth2) GetGmail() bool {
+func (c *ConnectionOptionsGoogleOAuth2) GetGmail() bool {
 	if c == nil || c.Gmail == nil {
 		return false
 	}
@@ -1427,7 +1427,7 @@ func (c *ConnectionOptionsGooleOAuth2) GetGmail() bool {
 }
 
 // GetGoogleAffiliateNetwork returns the GoogleAffiliateNetwork field if it's non-nil, zero value otherwise.
-func (c *ConnectionOptionsGooleOAuth2) GetGoogleAffiliateNetwork() bool {
+func (c *ConnectionOptionsGoogleOAuth2) GetGoogleAffiliateNetwork() bool {
 	if c == nil || c.GoogleAffiliateNetwork == nil {
 		return false
 	}
@@ -1435,7 +1435,7 @@ func (c *ConnectionOptionsGooleOAuth2) GetGoogleAffiliateNetwork() bool {
 }
 
 // GetGoogleBooks returns the GoogleBooks field if it's non-nil, zero value otherwise.
-func (c *ConnectionOptionsGooleOAuth2) GetGoogleBooks() bool {
+func (c *ConnectionOptionsGoogleOAuth2) GetGoogleBooks() bool {
 	if c == nil || c.GoogleBooks == nil {
 		return false
 	}
@@ -1443,7 +1443,7 @@ func (c *ConnectionOptionsGooleOAuth2) GetGoogleBooks() bool {
 }
 
 // GetGoogleCloudStorage returns the GoogleCloudStorage field if it's non-nil, zero value otherwise.
-func (c *ConnectionOptionsGooleOAuth2) GetGoogleCloudStorage() bool {
+func (c *ConnectionOptionsGoogleOAuth2) GetGoogleCloudStorage() bool {
 	if c == nil || c.GoogleCloudStorage == nil {
 		return false
 	}
@@ -1451,7 +1451,7 @@ func (c *ConnectionOptionsGooleOAuth2) GetGoogleCloudStorage() bool {
 }
 
 // GetGoogleDrive returns the GoogleDrive field if it's non-nil, zero value otherwise.
-func (c *ConnectionOptionsGooleOAuth2) GetGoogleDrive() bool {
+func (c *ConnectionOptionsGoogleOAuth2) GetGoogleDrive() bool {
 	if c == nil || c.GoogleDrive == nil {
 		return false
 	}
@@ -1459,7 +1459,7 @@ func (c *ConnectionOptionsGooleOAuth2) GetGoogleDrive() bool {
 }
 
 // GetGoogleDriveFiles returns the GoogleDriveFiles field if it's non-nil, zero value otherwise.
-func (c *ConnectionOptionsGooleOAuth2) GetGoogleDriveFiles() bool {
+func (c *ConnectionOptionsGoogleOAuth2) GetGoogleDriveFiles() bool {
 	if c == nil || c.GoogleDriveFiles == nil {
 		return false
 	}
@@ -1467,7 +1467,7 @@ func (c *ConnectionOptionsGooleOAuth2) GetGoogleDriveFiles() bool {
 }
 
 // GetGooglePlus returns the GooglePlus field if it's non-nil, zero value otherwise.
-func (c *ConnectionOptionsGooleOAuth2) GetGooglePlus() bool {
+func (c *ConnectionOptionsGoogleOAuth2) GetGooglePlus() bool {
 	if c == nil || c.GooglePlus == nil {
 		return false
 	}
@@ -1475,7 +1475,7 @@ func (c *ConnectionOptionsGooleOAuth2) GetGooglePlus() bool {
 }
 
 // GetLatitudeBest returns the LatitudeBest field if it's non-nil, zero value otherwise.
-func (c *ConnectionOptionsGooleOAuth2) GetLatitudeBest() bool {
+func (c *ConnectionOptionsGoogleOAuth2) GetLatitudeBest() bool {
 	if c == nil || c.LatitudeBest == nil {
 		return false
 	}
@@ -1483,7 +1483,7 @@ func (c *ConnectionOptionsGooleOAuth2) GetLatitudeBest() bool {
 }
 
 // GetLatitudeCity returns the LatitudeCity field if it's non-nil, zero value otherwise.
-func (c *ConnectionOptionsGooleOAuth2) GetLatitudeCity() bool {
+func (c *ConnectionOptionsGoogleOAuth2) GetLatitudeCity() bool {
 	if c == nil || c.LatitudeCity == nil {
 		return false
 	}
@@ -1491,7 +1491,7 @@ func (c *ConnectionOptionsGooleOAuth2) GetLatitudeCity() bool {
 }
 
 // GetModerator returns the Moderator field if it's non-nil, zero value otherwise.
-func (c *ConnectionOptionsGooleOAuth2) GetModerator() bool {
+func (c *ConnectionOptionsGoogleOAuth2) GetModerator() bool {
 	if c == nil || c.Moderator == nil {
 		return false
 	}
@@ -1499,7 +1499,7 @@ func (c *ConnectionOptionsGooleOAuth2) GetModerator() bool {
 }
 
 // GetOrkut returns the Orkut field if it's non-nil, zero value otherwise.
-func (c *ConnectionOptionsGooleOAuth2) GetOrkut() bool {
+func (c *ConnectionOptionsGoogleOAuth2) GetOrkut() bool {
 	if c == nil || c.Orkut == nil {
 		return false
 	}
@@ -1507,7 +1507,7 @@ func (c *ConnectionOptionsGooleOAuth2) GetOrkut() bool {
 }
 
 // GetPicasaWeb returns the PicasaWeb field if it's non-nil, zero value otherwise.
-func (c *ConnectionOptionsGooleOAuth2) GetPicasaWeb() bool {
+func (c *ConnectionOptionsGoogleOAuth2) GetPicasaWeb() bool {
 	if c == nil || c.PicasaWeb == nil {
 		return false
 	}
@@ -1515,7 +1515,7 @@ func (c *ConnectionOptionsGooleOAuth2) GetPicasaWeb() bool {
 }
 
 // GetProfile returns the Profile field if it's non-nil, zero value otherwise.
-func (c *ConnectionOptionsGooleOAuth2) GetProfile() bool {
+func (c *ConnectionOptionsGoogleOAuth2) GetProfile() bool {
 	if c == nil || c.Profile == nil {
 		return false
 	}
@@ -1523,7 +1523,7 @@ func (c *ConnectionOptionsGooleOAuth2) GetProfile() bool {
 }
 
 // GetSites returns the Sites field if it's non-nil, zero value otherwise.
-func (c *ConnectionOptionsGooleOAuth2) GetSites() bool {
+func (c *ConnectionOptionsGoogleOAuth2) GetSites() bool {
 	if c == nil || c.Sites == nil {
 		return false
 	}
@@ -1531,7 +1531,7 @@ func (c *ConnectionOptionsGooleOAuth2) GetSites() bool {
 }
 
 // GetSpreadsheets returns the Spreadsheets field if it's non-nil, zero value otherwise.
-func (c *ConnectionOptionsGooleOAuth2) GetSpreadsheets() bool {
+func (c *ConnectionOptionsGoogleOAuth2) GetSpreadsheets() bool {
 	if c == nil || c.Spreadsheets == nil {
 		return false
 	}
@@ -1539,7 +1539,7 @@ func (c *ConnectionOptionsGooleOAuth2) GetSpreadsheets() bool {
 }
 
 // GetTasks returns the Tasks field if it's non-nil, zero value otherwise.
-func (c *ConnectionOptionsGooleOAuth2) GetTasks() bool {
+func (c *ConnectionOptionsGoogleOAuth2) GetTasks() bool {
 	if c == nil || c.Tasks == nil {
 		return false
 	}
@@ -1547,7 +1547,7 @@ func (c *ConnectionOptionsGooleOAuth2) GetTasks() bool {
 }
 
 // GetURLShortener returns the URLShortener field if it's non-nil, zero value otherwise.
-func (c *ConnectionOptionsGooleOAuth2) GetURLShortener() bool {
+func (c *ConnectionOptionsGoogleOAuth2) GetURLShortener() bool {
 	if c == nil || c.URLShortener == nil {
 		return false
 	}
@@ -1555,7 +1555,7 @@ func (c *ConnectionOptionsGooleOAuth2) GetURLShortener() bool {
 }
 
 // GetWebmasterTools returns the WebmasterTools field if it's non-nil, zero value otherwise.
-func (c *ConnectionOptionsGooleOAuth2) GetWebmasterTools() bool {
+func (c *ConnectionOptionsGoogleOAuth2) GetWebmasterTools() bool {
 	if c == nil || c.WebmasterTools == nil {
 		return false
 	}
@@ -1563,15 +1563,15 @@ func (c *ConnectionOptionsGooleOAuth2) GetWebmasterTools() bool {
 }
 
 // GetYoutube returns the Youtube field if it's non-nil, zero value otherwise.
-func (c *ConnectionOptionsGooleOAuth2) GetYoutube() bool {
+func (c *ConnectionOptionsGoogleOAuth2) GetYoutube() bool {
 	if c == nil || c.Youtube == nil {
 		return false
 	}
 	return *c.Youtube
 }
 
-// String returns a string representation of ConnectionOptionsGooleOAuth2.
-func (c *ConnectionOptionsGooleOAuth2) String() string {
+// String returns a string representation of ConnectionOptionsGoogleOAuth2.
+func (c *ConnectionOptionsGoogleOAuth2) String() string {
 	return Stringify(c)
 }
 

--- a/management/management.gen.go
+++ b/management/management.gen.go
@@ -521,6 +521,30 @@ func (c *ConnectionOptionsApple) String() string {
 	return Stringify(c)
 }
 
+// GetAdmin returns the Admin field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsAzureAD) GetAdmin() bool {
+	if c == nil || c.Admin == nil {
+		return false
+	}
+	return *c.Admin
+}
+
+// GetAgreedTerms returns the AgreedTerms field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsAzureAD) GetAgreedTerms() bool {
+	if c == nil || c.AgreedTerms == nil {
+		return false
+	}
+	return *c.AgreedTerms
+}
+
+// GetAssignedPlans returns the AssignedPlans field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsAzureAD) GetAssignedPlans() bool {
+	if c == nil || c.AssignedPlans == nil {
+		return false
+	}
+	return *c.AssignedPlans
+}
+
 // GetBasicProfile returns the BasicProfile field if it's non-nil, zero value otherwise.
 func (c *ConnectionOptionsAzureAD) GetBasicProfile() bool {
 	if c == nil || c.BasicProfile == nil {
@@ -561,60 +585,20 @@ func (c *ConnectionOptionsAzureAD) GetEnableUsersAPI() bool {
 	return *c.EnableUsersAPI
 }
 
-// GetExtAdmin returns the ExtAdmin field if it's non-nil, zero value otherwise.
-func (c *ConnectionOptionsAzureAD) GetExtAdmin() bool {
-	if c == nil || c.ExtAdmin == nil {
+// GetExtendedProfile returns the ExtendedProfile field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsAzureAD) GetExtendedProfile() bool {
+	if c == nil || c.ExtendedProfile == nil {
 		return false
 	}
-	return *c.ExtAdmin
+	return *c.ExtendedProfile
 }
 
-// GetExtAgreedTerms returns the ExtAgreedTerms field if it's non-nil, zero value otherwise.
-func (c *ConnectionOptionsAzureAD) GetExtAgreedTerms() bool {
-	if c == nil || c.ExtAgreedTerms == nil {
+// GetGroups returns the Groups field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsAzureAD) GetGroups() bool {
+	if c == nil || c.Groups == nil {
 		return false
 	}
-	return *c.ExtAgreedTerms
-}
-
-// GetExtAssignedPlans returns the ExtAssignedPlans field if it's non-nil, zero value otherwise.
-func (c *ConnectionOptionsAzureAD) GetExtAssignedPlans() bool {
-	if c == nil || c.ExtAssignedPlans == nil {
-		return false
-	}
-	return *c.ExtAssignedPlans
-}
-
-// GetExtGroups returns the ExtGroups field if it's non-nil, zero value otherwise.
-func (c *ConnectionOptionsAzureAD) GetExtGroups() bool {
-	if c == nil || c.ExtGroups == nil {
-		return false
-	}
-	return *c.ExtGroups
-}
-
-// GetExtIsSuspended returns the ExtIsSuspended field if it's non-nil, zero value otherwise.
-func (c *ConnectionOptionsAzureAD) GetExtIsSuspended() bool {
-	if c == nil || c.ExtIsSuspended == nil {
-		return false
-	}
-	return *c.ExtIsSuspended
-}
-
-// GetExtNestedGroups returns the ExtNestedGroups field if it's non-nil, zero value otherwise.
-func (c *ConnectionOptionsAzureAD) GetExtNestedGroups() bool {
-	if c == nil || c.ExtNestedGroups == nil {
-		return false
-	}
-	return *c.ExtNestedGroups
-}
-
-// GetExtProfile returns the ExtProfile field if it's non-nil, zero value otherwise.
-func (c *ConnectionOptionsAzureAD) GetExtProfile() bool {
-	if c == nil || c.ExtProfile == nil {
-		return false
-	}
-	return *c.ExtProfile
+	return *c.Groups
 }
 
 // GetIdentityAPI returns the IdentityAPI field if it's non-nil, zero value otherwise.
@@ -623,6 +607,14 @@ func (c *ConnectionOptionsAzureAD) GetIdentityAPI() string {
 		return ""
 	}
 	return *c.IdentityAPI
+}
+
+// GetIsSuspended returns the IsSuspended field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsAzureAD) GetIsSuspended() bool {
+	if c == nil || c.IsSuspended == nil {
+		return false
+	}
+	return *c.IsSuspended
 }
 
 // GetLogoURL returns the LogoURL field if it's non-nil, zero value otherwise.
@@ -639,6 +631,14 @@ func (c *ConnectionOptionsAzureAD) GetMaxGroupsToRetrieve() string {
 		return ""
 	}
 	return *c.MaxGroupsToRetrieve
+}
+
+// GetNestedGroups returns the NestedGroups field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsAzureAD) GetNestedGroups() bool {
+	if c == nil || c.NestedGroups == nil {
+		return false
+	}
+	return *c.NestedGroups
 }
 
 // GetTenantDomain returns the TenantDomain field if it's non-nil, zero value otherwise.

--- a/management/management.gen.go
+++ b/management/management.gen.go
@@ -460,6 +460,67 @@ func (c *ConnectionOptions) String() string {
 	return Stringify(c)
 }
 
+// GetBruteForceProtection returns the BruteForceProtection field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsAD) GetBruteForceProtection() bool {
+	if c == nil || c.BruteForceProtection == nil {
+		return false
+	}
+	return *c.BruteForceProtection
+}
+
+// GetCertAuth returns the CertAuth field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsAD) GetCertAuth() bool {
+	if c == nil || c.CertAuth == nil {
+		return false
+	}
+	return *c.CertAuth
+}
+
+// GetDisableCache returns the DisableCache field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsAD) GetDisableCache() bool {
+	if c == nil || c.DisableCache == nil {
+		return false
+	}
+	return *c.DisableCache
+}
+
+// GetKerberos returns the Kerberos field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsAD) GetKerberos() bool {
+	if c == nil || c.Kerberos == nil {
+		return false
+	}
+	return *c.Kerberos
+}
+
+// GetLogoURL returns the LogoURL field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsAD) GetLogoURL() string {
+	if c == nil || c.LogoURL == nil {
+		return ""
+	}
+	return *c.LogoURL
+}
+
+// GetSetUserAttributes returns the SetUserAttributes field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsAD) GetSetUserAttributes() string {
+	if c == nil || c.SetUserAttributes == nil {
+		return ""
+	}
+	return *c.SetUserAttributes
+}
+
+// GetTenantDomain returns the TenantDomain field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsAD) GetTenantDomain() string {
+	if c == nil || c.TenantDomain == nil {
+		return ""
+	}
+	return *c.TenantDomain
+}
+
+// String returns a string representation of ConnectionOptionsAD.
+func (c *ConnectionOptionsAD) String() string {
+	return Stringify(c)
+}
+
 // GetADFSServer returns the ADFSServer field if it's non-nil, zero value otherwise.
 func (c *ConnectionOptionsADFS) GetADFSServer() string {
 	if c == nil || c.ADFSServer == nil {

--- a/management/management.go
+++ b/management/management.go
@@ -14,7 +14,7 @@ import (
 	"strings"
 	"time"
 
-	"gopkg.in/auth0.v3/internal/client"
+	"gopkg.in/auth0.v4/internal/client"
 )
 
 // Management is an Auth0 management client used to interact with the Auth0

--- a/management/resource_server_test.go
+++ b/management/resource_server_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"gopkg.in/auth0.v3"
+	"gopkg.in/auth0.v4"
 )
 
 func TestResourceServer(t *testing.T) {

--- a/management/role_test.go
+++ b/management/role_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"gopkg.in/auth0.v3"
+	"gopkg.in/auth0.v4"
 )
 
 func TestRole(t *testing.T) {

--- a/management/rule_config_test.go
+++ b/management/rule_config_test.go
@@ -3,7 +3,7 @@ package management
 import (
 	"testing"
 
-	"gopkg.in/auth0.v3"
+	"gopkg.in/auth0.v4"
 )
 
 func TestRuleConfig(t *testing.T) {

--- a/management/rule_test.go
+++ b/management/rule_test.go
@@ -3,7 +3,7 @@ package management
 import (
 	"testing"
 
-	"gopkg.in/auth0.v3"
+	"gopkg.in/auth0.v4"
 )
 
 func TestRule(t *testing.T) {

--- a/management/tenant_test.go
+++ b/management/tenant_test.go
@@ -3,7 +3,7 @@ package management
 import (
 	"testing"
 
-	"gopkg.in/auth0.v3"
+	"gopkg.in/auth0.v4"
 )
 
 func TestTenant(t *testing.T) {

--- a/management/ticket_test.go
+++ b/management/ticket_test.go
@@ -3,7 +3,7 @@ package management
 import (
 	"testing"
 
-	"gopkg.in/auth0.v3"
+	"gopkg.in/auth0.v4"
 )
 
 func TestTicket(t *testing.T) {

--- a/management/user_test.go
+++ b/management/user_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"gopkg.in/auth0.v3"
+	"gopkg.in/auth0.v4"
 )
 
 func TestUser(t *testing.T) {


### PR DESCRIPTION
Due to the way the Auth0 API handles the various options depending on connection strategy, this SDK is no longer able to continue using a single type for `Connection.Options`.

Depending on the strategy, options fields (and their types) can vary. Sometimes fields are re-used and with different data types. For example `options.email` can be a boolean when strategy is `google-oauth2` and an object when strategy is `email`.

In order to avoid such corner cases, I've introduced specific types for each strategy, and made `Connection.Options` an `interface{}` in order to support any one of the available choices.

The following table shows the type which will be used when Unmarshalling.

| Strategy | Type |
| ------- | --------|
| `auth0` | ConnectionOptions |
| `google-oauth2` | ConnectionOptionsGoogleOAuth2 |
| `facebook` | ConnectionOptionsFacebook |
| `apple` | ConnectionOptionsApple |
| `linkedin` | ConnectionOptionsLinkedin |
| `github` | ConnectionOptionsGitHub |
| `windowslive` | ConnectionOptionsWindowsLive |
| `salesforce` | ConnectionOptionsSalesforce |
| `email` | ConnectionOptionsEmail |
| `sms` | ConnectionOptionsSMS |
| `oidc` | ConnectionOptionsOIDC |
| `waad` | ConnectionOptionsAzureAD |

All other connection strategies can be specified using a `map[string]interface{}`. If you use a strategy that is not included in this list, you are welcome to submit an issue and/or a pull request.

See `ExampleConnectionManager_List` and `ExampleConnectionManager_Create` for sample usage.
