### PR TITLE
Paginate when reading role users or user roles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## v4.2.0
+
+* `management.UserManager`: `Roles()` returns `RoleList` ([#109](https://github.com/go-auth0/auth0/pull/109)).
+* `management.UserManager`: `Permissions()` returns `PermissionList`.
+* `management.RoleManager`: `Users()` returns `UserList`.
+* `management.RoleManager`: `Permissions()` returns `PermissionList`.
+
 ## v4.1.0
 
 * `management.ConnectionOptionsEmail`, `management.ConnectionOptionsSMS`: add `authParams`.

--- a/management/role.go
+++ b/management/role.go
@@ -11,6 +11,11 @@ type Role struct {
 	Description *string `json:"description,omitempty"`
 }
 
+type RoleList struct {
+	List
+	Roles []*Role `json:"roles"`
+}
+
 type Permission struct {
 	// The resource server that the permission is attached to.
 	ResourceServerIdentifier *string `json:"resource_server_identifier,omitempty"`
@@ -25,9 +30,9 @@ type Permission struct {
 	Description *string `json:"description,omitempty"`
 }
 
-type RoleList struct {
+type PermissionList struct {
 	List
-	Roles []*Role `json:"roles"`
+	Permissions []*Permission `json:"permissions"`
 }
 
 type RoleManager struct {
@@ -91,7 +96,8 @@ func (m *RoleManager) AssignUsers(id string, users ...*User) error {
 // Users retrieves all users associated with a role.
 //
 // See: https://auth0.com/docs/api/management/v2#!/Roles/get_role_user
-func (m *RoleManager) Users(id string, opts ...ListOption) (u []*User, err error) {
+func (m *RoleManager) Users(id string, opts ...ListOption) (u *UserList, err error) {
+	opts = m.defaults(opts)
 	err = m.get(m.uri("roles", id, "users")+m.q(opts), &u)
 	return
 }
@@ -108,7 +114,8 @@ func (m *RoleManager) AssociatePermissions(id string, permissions ...*Permission
 // Permissions retrieves all permissions granted by a role.
 //
 // See: https://auth0.com/docs/api/management/v2#!/Roles/get_role_permission
-func (m *RoleManager) Permissions(id string, opts ...ListOption) (p []*Permission, err error) {
+func (m *RoleManager) Permissions(id string, opts ...ListOption) (p *PermissionList, err error) {
+	opts = m.defaults(opts)
 	err = m.get(m.uri("roles", id, "permissions")+m.q(opts), &p)
 	return
 }

--- a/management/role_test.go
+++ b/management/role_test.go
@@ -95,12 +95,11 @@ func TestRole(t *testing.T) {
 	})
 
 	t.Run("Users", func(t *testing.T) {
-		var us []*User
-		us, err = m.Role.Users(auth0.StringValue(r.ID))
+		l, err := m.Role.Users(auth0.StringValue(r.ID))
 		if err != nil {
 			t.Fatal(err)
 		}
-		t.Logf("%v\n", us)
+		t.Logf("%v\n", l.Users)
 	})
 
 	t.Run("AssociatePermissions", func(t *testing.T) {
@@ -115,12 +114,11 @@ func TestRole(t *testing.T) {
 	})
 
 	t.Run("Permissions", func(t *testing.T) {
-		var ps []*Permission
-		ps, err = m.Role.Permissions(auth0.StringValue(r.ID))
+		l, err := m.Role.Permissions(auth0.StringValue(r.ID))
 		if err != nil {
 			t.Fatal(err)
 		}
-		t.Logf("%v\n", ps)
+		t.Logf("%v\n", l.Permissions)
 	})
 
 	t.Run("RemovePermissions", func(t *testing.T) {

--- a/management/user.go
+++ b/management/user.go
@@ -265,9 +265,10 @@ func (m *UserManager) ListByEmail(email string, opts ...ListOption) (us []*User,
 // Roles lists all roles associated with a user.
 //
 // See: https://auth0.com/docs/api/management/v2#!/Users/get_user_roles
-func (m *UserManager) Roles(id string, opts ...ListOption) (roles []*Role, err error) {
-	err = m.get(m.uri("users", id, "roles")+m.q(opts), &roles)
-	return roles, err
+func (m *UserManager) Roles(id string, opts ...ListOption) (r *RoleList, err error) {
+	opts = m.defaults(opts)
+	err = m.get(m.uri("users", id, "roles")+m.q(opts), &r)
+	return r, err
 }
 
 // AssignRoles assignes roles to a user.
@@ -297,9 +298,10 @@ func (m *UserManager) RemoveRoles(id string, roles ...*Role) error {
 // Permissions lists the permissions associated to the user.
 //
 // See: https://auth0.com/docs/api/management/v2#!/Users/get_permissions
-func (m *UserManager) Permissions(id string, opts ...ListOption) (permissions []*Permission, err error) {
-	err = m.get(m.uri("users", id, "permissions")+m.q(opts), &permissions)
-	return permissions, err
+func (m *UserManager) Permissions(id string, opts ...ListOption) (p *PermissionList, err error) {
+	opts = m.defaults(opts)
+	err = m.get(m.uri("users", id, "permissions")+m.q(opts), &p)
+	return p, err
 }
 
 // AssignPermissions assigns permissions to the user.

--- a/management/user_test.go
+++ b/management/user_test.go
@@ -131,12 +131,11 @@ func TestUser(t *testing.T) {
 	})
 
 	t.Run("Roles", func(t *testing.T) {
-		var roles []*Role
-		roles, err = m.User.Roles(auth0.StringValue(u.ID))
+		l, err := m.User.Roles(auth0.StringValue(u.ID))
 		if err != nil {
 			t.Error(err)
 		}
-		t.Logf("%v\n", roles)
+		t.Logf("%v\n", l.Roles)
 	})
 
 	t.Run("AssignRoles", func(t *testing.T) {
@@ -156,12 +155,11 @@ func TestUser(t *testing.T) {
 	})
 
 	t.Run("Permissions", func(t *testing.T) {
-		var permissions []*Permission
-		permissions, err = m.User.Permissions(auth0.StringValue(u.ID))
+		l, err := m.User.Permissions(auth0.StringValue(u.ID))
 		if err != nil {
 			t.Fatal(err)
 		}
-		t.Logf("%v\n", permissions)
+		t.Logf("%v\n", l.Permissions)
 	})
 
 	t.Run("AssignPermissions", func(t *testing.T) {


### PR DESCRIPTION
This PR adds support for paginating:

- `User.Roles()`
- `User.Permissions()`
- `Role.Users()`
- `Role.Permissions()`

Fixes #108 

**Note**: This is a backwards incompatible change.