### PR TITLE
Add more MFA endpoints

### DIFF
--- a/management/guardian.go
+++ b/management/guardian.go
@@ -84,6 +84,13 @@ func (m *MultiFactorManager) List(opts ...RequestOption) (mf []*MultiFactor, err
 	return
 }
 
+// Delete an enrollment
+//
+// See: https://auth0.com/docs/api/management/v2#!/Guardian/delete_enrollments_by_id
+func (m *MultiFactorManager) Delete(id string) error {
+	return m.Request("DELETE", m.URI("guardian", "enrollments", id), nil)
+}
+
 type MultiFactorSMS struct{ *Management }
 
 // Enable enables or disables the SMS Multi-factor Authentication.

--- a/management/user.go
+++ b/management/user.go
@@ -397,7 +397,7 @@ func (m *UserManager) RegenerateRecoveryCode(id string) (*UserRecoveryCode, erro
 //
 // See: https://auth0.com/docs/api/management/v2#!/Users/get_enrollments
 func (m *UserManager) Enrollments(id string) (enrols []*UserEnrollment, err error) {
-	err = m.Request("POST", m.URI("users", id, "enrollments"), &enrols)
+	err = m.Request("GET", m.URI("users", id, "enrollments"), &enrols)
 	return enrols, err
 }
 
@@ -405,6 +405,6 @@ func (m *UserManager) Enrollments(id string) (enrols []*UserEnrollment, err erro
 //
 // It's an undocumented API, see: https://community.auth0.com/t/when-will-api-v2-users-userid-authenticators-be-documented/52722
 func (m *UserManager) ListAuthenticators(id string) (enrols []*UserAuthenticator, err error) {
-	err = m.Request("POST", m.URI("users", id, "authenticators"), &enrols)
+	err = m.Request("GET", m.URI("users", id, "authenticators"), &enrols)
 	return enrols, err
 }

--- a/management/user.go
+++ b/management/user.go
@@ -403,7 +403,7 @@ func (m *UserManager) Enrollments(id string) (enrols []*UserEnrollment, err erro
 
 // ListAuthenticators retrieves all authenticators for a user.
 //
-// It's an undocumented API ¯\_(ツ)_/¯
+// It's an undocumented API, see: https://community.auth0.com/t/when-will-api-v2-users-userid-authenticators-be-documented/52722
 func (m *UserManager) ListAuthenticators(id string) (enrols []*UserAuthenticator, err error) {
 	err = m.Request("POST", m.URI("users", id, "authenticators"), &enrols)
 	return enrols, err

--- a/management/user.go
+++ b/management/user.go
@@ -172,6 +172,46 @@ type UserList struct {
 	Users []*User `json:"users"`
 }
 
+// UserRecoveryCode contains the new recovery code for the user
+type UserRecoveryCode struct {
+	// RecoveryCode is the new account recovery code
+	RecoveryCode *string `json:"recovery_code"`
+}
+
+// UserEnrollment contains information about the Guardian enrollments for the user
+type UserEnrollment struct {
+	// Authentication method for this enrollment. Can be `authentication`, `guardian`, or `sms`.
+	AuthMethod *string `json:"auth_method,omitempty"`
+	// Start date and time of this enrollment.
+	EnrolledAt *time.Time `json:"enrolled_at,omitempty"`
+	// ID of this enrollment.
+	ID *string `json:"id,omitempty"`
+	// Device identifier (usually phone identifier) of this enrollment.
+	Identifier *string `json:"identifier,omitempty"`
+	// Last authentication date and time of this enrollment.
+	LastAuth *time.Time `json:"last_auth,omitempty"`
+	// Name of enrollment (usually phone number).
+	Name *string `json:"name,omitempty"`
+	// Phone number for this enrollment.
+	PhoneNumber *string `json:"phone_number,omitempty"`
+	// Status of this enrollment. Can be `pending` or `confirmed`.
+	Status *string `json:"status,omitempty"`
+	// Type of enrollment.
+	Type *string `json:"type,omitempty"`
+}
+
+// UserAuthenticator contains information about an Authenticator
+type UserAuthenticator struct {
+	// ID of this authenticator.
+	ID *string `json:"id,omitempty"`
+	// Type of authenticator
+	Type *string `json:"type,omitempty"`
+	// Status of the enrollment for this authenticator
+	Confirmed *bool `json:"confirmed,omitempty"`
+	// Start date and time of this enrollment.
+	CreatedAt *time.Time `json:"created_at,omitempty"`
+}
+
 // UserManager manages Auth0 User resources.
 type UserManager struct {
 	*Management
@@ -342,4 +382,29 @@ func (m *UserManager) Blocks(id string, opts ...RequestOption) ([]*UserBlock, er
 // See: https://auth0.com/docs/api/management/v2#!/User_Blocks/delete_user_blocks_by_id
 func (m *UserManager) Unblock(id string, opts ...RequestOption) error {
 	return m.Request("DELETE", m.URI("user-blocks", id), nil, opts...)
+}
+
+// RegenerateRecoveryCode removes the current multi-factor authentication recovery code and generates a new one.
+//
+// See: https://auth0.com/docs/api/management/v2#!/Users/post_recovery_code_regeneration
+func (m *UserManager) RegenerateRecoveryCode(id string) (*UserRecoveryCode, error) {
+	r := new(UserRecoveryCode)
+	err := m.Request("POST", m.URI("users", id, "recovery-code-regeneration"), r)
+	return r, err
+}
+
+// Enrollments retrieves all Guardian enrollments for a user.
+//
+// See: https://auth0.com/docs/api/management/v2#!/Users/get_enrollments
+func (m *UserManager) Enrollments(id string) (enrols []*UserEnrollment, err error) {
+	err = m.Request("POST", m.URI("users", id, "enrollments"), &enrols)
+	return enrols, err
+}
+
+// ListAuthenticators retrieves all authenticators for a user.
+//
+// It's an undocumented API ¯\_(ツ)_/¯
+func (m *UserManager) ListAuthenticators(id string) (enrols []*UserAuthenticator, err error) {
+	err = m.Request("POST", m.URI("users", id, "authenticators"), &enrols)
+	return enrols, err
 }

--- a/management/user.go
+++ b/management/user.go
@@ -401,10 +401,10 @@ func (m *UserManager) Enrollments(id string) (enrols []*UserEnrollment, err erro
 	return enrols, err
 }
 
-// ListAuthenticators retrieves all authenticators for a user.
+// Authenticators retrieves all authenticators for a user.
 //
 // It's an undocumented API, see: https://community.auth0.com/t/when-will-api-v2-users-userid-authenticators-be-documented/52722
-func (m *UserManager) ListAuthenticators(id string) (enrols []*UserAuthenticator, err error) {
-	err = m.Request("GET", m.URI("users", id, "authenticators"), &enrols)
-	return enrols, err
+func (m *UserManager) Authenticators(id string) (auths []*UserAuthenticator, err error) {
+	err = m.Request("GET", m.URI("users", id, "authenticators"), &auths)
+	return auths, err
 }


### PR DESCRIPTION
Because of some custom integration of MFA, we needed a few more Management API endpoints not yet exposed by this library:
- https://auth0.com/docs/api/management/v2#!/Guardian/delete_enrollments_by_id
- https://auth0.com/docs/api/management/v2#!/Users/post_recovery_code_regeneration
- https://auth0.com/docs/api/management/v2#!/Users/get_enrollments

Let me know if I need to tweak something in order to merge!