### PR TITLE
Add access_token of UserIdentity for google social connection

### DIFF
--- a/management/user.go
+++ b/management/user.go
@@ -88,10 +88,11 @@ type User struct {
 }
 
 type UserIdentity struct {
-	Connection *string `json:"connection,omitempty"`
-	UserID     *string `json:"-"`
-	Provider   *string `json:"provider,omitempty"`
-	IsSocial   *bool   `json:"isSocial,omitempty"`
+	Connection  *string `json:"connection,omitempty"`
+	UserID      *string `json:"-"`
+	Provider    *string `json:"provider,omitempty"`
+	IsSocial    *bool   `json:"isSocial,omitempty"`
+	AccessToken *string `json:"access_token,omitempty"`
 }
 
 // UnmarshalJSON is a custom deserializer for the UserIdentity type.


### PR DESCRIPTION
As https://github.com/go-auth0/auth0/issues/100 says,  auth0 management has response of 
`access_token` issued by google.

Without this `access_token`, can't call google's api.

https://auth0.com/docs/tokens/concepts/idp-access-tokens?_ga=2.123250563.948245286.1589091717-1358488943.1589091717#renew-tokens