### PR TITLE
Add DisplayName field to the Connection struct

### DIFF
--- a/management/connection.go
+++ b/management/connection.go
@@ -33,7 +33,8 @@ type Connection struct {
 	// The name of the connection. Must start and end with an alphanumeric
 	// character and can only contain alphanumeric characters and '-'. Max
 	// length 128.
-	Name *string `json:"name,omitempty"`
+	Name        *string `json:"name,omitempty"`
+	DisplayName *string `json:"display_name,omitempty"`
 
 	// The identity provider identifier for the connection. Can be any of the
 	// following:


### PR DESCRIPTION
Auth0 Connections have an optional field Display Name, which is missing from the Connection struct.

![image](https://user-images.githubusercontent.com/6610868/82568740-a6bab200-9b55-11ea-8d3c-0275d5851383.png)

fixes: https://github.com/go-auth0/auth0/issues/114