### PR TITLE
Add mappings for the SAML type connection 

### DIFF
--- a/management/connection.go
+++ b/management/connection.go
@@ -592,6 +592,7 @@ type ConnectionOptionsADFS struct {
 
 type ConnectionOptionsSAML struct {
 	Cert               *string                `json:"cert,omitempty"`
+	Debug              *bool                  `json:"debug,omitempty"`
 	Expires            *string                `json:"expires,omitempty"`
 	SigningCert        *string                `json:"signingCert,omitempty"`
 	Thumbprints        []interface{}          `json:"thumbprints,omitempty"`

--- a/management/connection.go
+++ b/management/connection.go
@@ -591,22 +591,22 @@ type ConnectionOptionsADFS struct {
 }
 
 type ConnectionOptionsSAML struct {
-	Cert               *string           `json:"cert,omitempty"`
-	Expires            *string           `json:"expires,omitempty"`
-	SigningCert        *string           `json:"signingCert,omitempty"`
-	Thumbprints        []interface{}     `json:"thumbprints,omitempty"`
-	BindingMethod      *string           `json:"bindingMethod,omitempty"`
-	TenantDomain       *string           `json:"tenant_domain,omitempty"`
-	DomainAliases      []interface{}     `json:"domain_aliases,omitempty"`
-	SignInEndpoint     *string           `json:"signInEndpoint,omitempty"`
-	SignOutEndpoint    *string           `json:"signOutEndpoint,omitempty"`
-	SignatureAlgorithm *string           `json:"signatureAlgorithm,omitempty"`
-	DigestAglorithm    *string           `json:"digestAlgorithm,omitempty"`
-	MetadataXML        *string           `json:"metadataXml,omitempty"`
-	MetadataURL        *string           `json:"metadataUrl,omitempty"`
-	FieldsMap          map[string]string `json:"fieldsMap,omitempty"`
-	Subject            map[string]string `json:"subject,omitempty"`
-	SignSAMLRequest    *bool             `json:"signSAMLRequest,omitempty"`
+	Cert               *string                `json:"cert,omitempty"`
+	Expires            *string                `json:"expires,omitempty"`
+	SigningCert        *string                `json:"signingCert,omitempty"`
+	Thumbprints        []interface{}          `json:"thumbprints,omitempty"`
+	BindingMethod      *string                `json:"bindingMethod,omitempty"`
+	TenantDomain       *string                `json:"tenant_domain,omitempty"`
+	DomainAliases      []interface{}          `json:"domain_aliases,omitempty"`
+	SignInEndpoint     *string                `json:"signInEndpoint,omitempty"`
+	SignOutEndpoint    *string                `json:"signOutEndpoint,omitempty"`
+	SignatureAlgorithm *string                `json:"signatureAlgorithm,omitempty"`
+	DigestAglorithm    *string                `json:"digestAlgorithm,omitempty"`
+	MetadataXML        *string                `json:"metadataXml,omitempty"`
+	MetadataURL        *string                `json:"metadataUrl,omitempty"`
+	FieldsMap          map[string]interface{} `json:"fieldsMap,omitempty"`
+	Subject            map[string]interface{} `json:"subject,omitempty"`
+	SignSAMLRequest    *bool                  `json:"signSAMLRequest,omitempty"`
 }
 
 type ConnectionManager struct {

--- a/management/connection.go
+++ b/management/connection.go
@@ -24,6 +24,7 @@ const (
 	ConnectionStrategyOIDC                = "oidc"
 	ConnectionStrategyAD                  = "ad"
 	ConnectionStrategyAzureAD             = "waad"
+	ConnectionStrategySAML                = "samlp"
 )
 
 type Connection struct {
@@ -129,6 +130,8 @@ func (c *Connection) UnmarshalJSON(b []byte) error {
 			v = &ConnectionOptionsAD{}
 		case ConnectionStrategyAzureAD:
 			v = &ConnectionOptionsAzureAD{}
+		case ConnectionStrategySAML:
+			v = &ConnectionOptionsSAML{}
 		default:
 			v = make(map[string]interface{})
 		}
@@ -585,6 +588,25 @@ type ConnectionOptionsADFS struct {
 
 	// Set to on_first_login to avoid setting user attributes at each login.
 	SetUserAttributes *string `json:"set_user_root_attributes,omitempty"`
+}
+
+type ConnectionOptionsSAML struct {
+	Cert               *string           `json:"cert,omitempty"`
+	Expires            *string           `json:"expires,omitempty"`
+	SigningCert        *string           `json:"signingCert,omitempty"`
+	Thumbprints        []interface{}     `json:"thumbprints,omitempty"`
+	BindingMethod      *string           `json:"bindingMethod,omitempty"`
+	TenantDomain       *string           `json:"tenant_domain,omitempty"`
+	DomainAliases      []interface{}     `json:"domain_aliases,omitempty"`
+	SignInEndpoint     *string           `json:"signInEndpoint,omitempty"`
+	SignOutEndpoint    *string           `json:"signOutEndpoint,omitempty"`
+	SignatureAlgorithm *string           `json:"signatureAlgorithm,omitempty"`
+	DigestAglorithm    *string           `json:"digestAlgorithm,omitempty"`
+	MetadataXML        *string           `json:"metadataXml,omitempty"`
+	MetadataURL        *string           `json:"metadataUrl,omitempty"`
+	FieldsMap          map[string]string `json:"fieldsMap,omitempty"`
+	Subject            map[string]string `json:"subject,omitempty"`
+	SignSAMLRequest    *bool             `json:"signSAMLRequest,omitempty"`
 }
 
 type ConnectionManager struct {

--- a/management/connection.go
+++ b/management/connection.go
@@ -595,7 +595,7 @@ type ConnectionOptionsSAML struct {
 	Expires            *string                `json:"expires,omitempty"`
 	SigningCert        *string                `json:"signingCert,omitempty"`
 	Thumbprints        []interface{}          `json:"thumbprints,omitempty"`
-	BindingMethod      *string                `json:"bindingMethod,omitempty"`
+	ProtocolBinding      *string                `json:"protocolBinding,omitempty"`
 	TenantDomain       *string                `json:"tenant_domain,omitempty"`
 	DomainAliases      []interface{}          `json:"domain_aliases,omitempty"`
 	SignInEndpoint     *string                `json:"signInEndpoint,omitempty"`

--- a/management/connection.go
+++ b/management/connection.go
@@ -590,6 +590,12 @@ type ConnectionOptionsADFS struct {
 	SetUserAttributes *string `json:"set_user_root_attributes,omitempty"`
 }
 
+type ConnectionOptionsSAMLIdpinitiated struct {
+	ClientID                          *string `json:"client_id,omitempty"`
+	ClientProtocol                *string `json:"client_protocol,omitempty"`
+	ClientAuthorizequery     *string `json:"client_authorizequery"`
+}
+
 type ConnectionOptionsSAML struct {
 	Cert               *string                `json:"cert,omitempty"`
 	Debug              *bool                  `json:"debug,omitempty"`

--- a/management/connection.go
+++ b/management/connection.go
@@ -591,30 +591,30 @@ type ConnectionOptionsADFS struct {
 }
 
 type ConnectionOptionsSAMLIdpinitiated struct {
-	ClientID                          *string `json:"client_id,omitempty"`
-	ClientProtocol                *string `json:"client_protocol,omitempty"`
-	ClientAuthorizequery     *string `json:"client_authorizequery"`
+	ClientID             *string `json:"client_id,omitempty"`
+	ClientProtocol       *string `json:"client_protocol,omitempty"`
+	ClientAuthorizequery *string `json:"client_authorizequery,omitempty"`
 }
 
 type ConnectionOptionsSAML struct {
-	Cert               *string                `json:"cert,omitempty"`
-	Debug              *bool                  `json:"debug,omitempty"`
-	Expires            *string                `json:"expires,omitempty"`
-        IdpInitiated        *ConnectionOptionsSAMLIdpinitiated     `json:"idpinitiated,omitempty"`
-	SigningCert        *string                                                        `json:"signingCert,omitempty"`
-	Thumbprints        []interface{}          `json:"thumbprints,omitempty"`
-	ProtocolBinding      *string                `json:"protocolBinding,omitempty"`
-	TenantDomain       *string                `json:"tenant_domain,omitempty"`
-	DomainAliases      []interface{}          `json:"domain_aliases,omitempty"`
-	SignInEndpoint     *string                `json:"signInEndpoint,omitempty"`
-	SignOutEndpoint    *string                `json:"signOutEndpoint,omitempty"`
-	SignatureAlgorithm *string                `json:"signatureAlgorithm,omitempty"`
-	DigestAglorithm    *string                `json:"digestAlgorithm,omitempty"`
-	MetadataXML        *string                `json:"metadataXml,omitempty"`
-	MetadataURL        *string                `json:"metadataUrl,omitempty"`
-	FieldsMap          map[string]interface{} `json:"fieldsMap,omitempty"`
-	Subject            map[string]interface{} `json:"subject,omitempty"`
-	SignSAMLRequest    *bool                  `json:"signSAMLRequest,omitempty"`
+	Cert               *string                            `json:"cert,omitempty"`
+	Debug              *bool                              `json:"debug,omitempty"`
+	Expires            *string                            `json:"expires,omitempty"`
+	IdpInitiated       *ConnectionOptionsSAMLIdpinitiated `json:"idpinitiated,omitempty"`
+	SigningCert        *string                            `json:"signingCert,omitempty"`
+	Thumbprints        []interface{}                      `json:"thumbprints,omitempty"`
+	ProtocolBinding    *string                            `json:"protocolBinding,omitempty"`
+	TenantDomain       *string                            `json:"tenant_domain,omitempty"`
+	DomainAliases      []interface{}                      `json:"domain_aliases,omitempty"`
+	SignInEndpoint     *string                            `json:"signInEndpoint,omitempty"`
+	SignOutEndpoint    *string                            `json:"signOutEndpoint,omitempty"`
+	SignatureAlgorithm *string                            `json:"signatureAlgorithm,omitempty"`
+	DigestAglorithm    *string                            `json:"digestAlgorithm,omitempty"`
+	MetadataXML        *string                            `json:"metadataXml,omitempty"`
+	MetadataURL        *string                            `json:"metadataUrl,omitempty"`
+	FieldsMap          map[string]interface{}             `json:"fieldsMap,omitempty"`
+	Subject            map[string]interface{}             `json:"subject,omitempty"`
+	SignSAMLRequest    *bool                              `json:"signSAMLRequest,omitempty"`
 }
 
 type ConnectionManager struct {

--- a/management/connection.go
+++ b/management/connection.go
@@ -600,7 +600,8 @@ type ConnectionOptionsSAML struct {
 	Cert               *string                `json:"cert,omitempty"`
 	Debug              *bool                  `json:"debug,omitempty"`
 	Expires            *string                `json:"expires,omitempty"`
-	SigningCert        *string                `json:"signingCert,omitempty"`
+        IdpInitiated        *ConnectionOptionsSAMLIdpinitiated     `json:"idpinitiated,omitempty"`
+	SigningCert        *string                                                        `json:"signingCert,omitempty"`
 	Thumbprints        []interface{}          `json:"thumbprints,omitempty"`
 	ProtocolBinding      *string                `json:"protocolBinding,omitempty"`
 	TenantDomain       *string                `json:"tenant_domain,omitempty"`

--- a/management/connection.go
+++ b/management/connection.go
@@ -590,17 +590,17 @@ type ConnectionOptionsADFS struct {
 	SetUserAttributes *string `json:"set_user_root_attributes,omitempty"`
 }
 
-type ConnectionOptionsSAMLIdpinitiated struct {
+type ConnectionOptionsSAMLIdpInitiated struct {
 	ClientID             *string `json:"client_id,omitempty"`
 	ClientProtocol       *string `json:"client_protocol,omitempty"`
-	ClientAuthorizequery *string `json:"client_authorizequery,omitempty"`
+	ClientAuthorizeQuery *string `json:"client_authorizequery,omitempty"`
 }
 
 type ConnectionOptionsSAML struct {
 	Cert               *string                            `json:"cert,omitempty"`
 	Debug              *bool                              `json:"debug,omitempty"`
 	Expires            *string                            `json:"expires,omitempty"`
-	IdpInitiated       *ConnectionOptionsSAMLIdpinitiated `json:"idpinitiated,omitempty"`
+	IdpInitiated       *ConnectionOptionsSAMLIdpInitiated `json:"idpinitiated,omitempty"`
 	SigningCert        *string                            `json:"signingCert,omitempty"`
 	Thumbprints        []interface{}                      `json:"thumbprints,omitempty"`
 	ProtocolBinding    *string                            `json:"protocolBinding,omitempty"`

--- a/management/connection_test.go
+++ b/management/connection_test.go
@@ -323,7 +323,7 @@ RvOTa8hYiU6A475WuZKyEHcwnGYe57u2I2KbMgcKjPniocj4QzgYsVAVKW3IwaOh
 yE+vPxsiUkvQHdO2fojCkY8jg70jxM+gu59tPDNbw3Uh/2Ij310FgTHsnGQMyA==
 -----END CERTIFICATE-----`),
 				TenantDomain: auth0.String("example.con"),
-				FieldsMap: map[string]string{
+				FieldsMap: map[string]interface{}{
 					"email":       "EmailAddress",
 					"given_name":  "FirstName",
 					"family_name": "LastName",

--- a/management/connection_test.go
+++ b/management/connection_test.go
@@ -323,6 +323,11 @@ RvOTa8hYiU6A475WuZKyEHcwnGYe57u2I2KbMgcKjPniocj4QzgYsVAVKW3IwaOh
 yE+vPxsiUkvQHdO2fojCkY8jg70jxM+gu59tPDNbw3Uh/2Ij310FgTHsnGQMyA==
 -----END CERTIFICATE-----`),
 				TenantDomain: auth0.String("example.con"),
+				FieldsMap: map[string]string{
+					"email":       "EmailAddress",
+					"given_name":  "FirstName",
+					"family_name": "LastName",
+				},
 			},
 		}
 		defer m.Connection.Delete(g.GetID())

--- a/management/connection_test.go
+++ b/management/connection_test.go
@@ -322,7 +322,7 @@ TZZyzmEOyclm3UGFYe82P/iDFt+CeQ3NpmBg+GoaVCuWAARJN/KfglbLyyYygcQq
 RvOTa8hYiU6A475WuZKyEHcwnGYe57u2I2KbMgcKjPniocj4QzgYsVAVKW3IwaOh
 yE+vPxsiUkvQHdO2fojCkY8jg70jxM+gu59tPDNbw3Uh/2Ij310FgTHsnGQMyA==
 -----END CERTIFICATE-----`),
-				TenantDomain: auth0.String("example.con"),
+				TenantDomain: auth0.String("example.com"),
 				FieldsMap: map[string]interface{}{
 					"email":       "EmailAddress",
 					"given_name":  "FirstName",
@@ -343,6 +343,6 @@ yE+vPxsiUkvQHdO2fojCkY8jg70jxM+gu59tPDNbw3Uh/2Ij310FgTHsnGQMyA==
 		}
 
 		expect.Expect(t, o.GetSignInEndpoint(), "https://saml.identity/provider")
-		expect.Expect(t, o.GetTenantDomain(), "example.con")
+		expect.Expect(t, o.GetTenantDomain(), "example.com")
 	})
 }

--- a/management/management.gen.go
+++ b/management/management.gen.go
@@ -402,6 +402,14 @@ func (c *ClientRefreshToken) String() string {
 	return Stringify(c)
 }
 
+// GetDisplayName returns the DisplayName field if it's non-nil, zero value otherwise.
+func (c *Connection) GetDisplayName() string {
+	if c == nil || c.DisplayName == nil {
+		return ""
+	}
+	return *c.DisplayName
+}
+
 // GetID returns the ID field if it's non-nil, zero value otherwise.
 func (c *Connection) GetID() string {
 	if c == nil || c.ID == nil {
@@ -1962,6 +1970,107 @@ func (c *ConnectionOptionsSalesforce) String() string {
 	return Stringify(c)
 }
 
+// GetBindingMethod returns the BindingMethod field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsSAML) GetBindingMethod() string {
+	if c == nil || c.BindingMethod == nil {
+		return ""
+	}
+	return *c.BindingMethod
+}
+
+// GetCert returns the Cert field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsSAML) GetCert() string {
+	if c == nil || c.Cert == nil {
+		return ""
+	}
+	return *c.Cert
+}
+
+// GetDigestAglorithm returns the DigestAglorithm field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsSAML) GetDigestAglorithm() string {
+	if c == nil || c.DigestAglorithm == nil {
+		return ""
+	}
+	return *c.DigestAglorithm
+}
+
+// GetExpires returns the Expires field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsSAML) GetExpires() string {
+	if c == nil || c.Expires == nil {
+		return ""
+	}
+	return *c.Expires
+}
+
+// GetMetadataURL returns the MetadataURL field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsSAML) GetMetadataURL() string {
+	if c == nil || c.MetadataURL == nil {
+		return ""
+	}
+	return *c.MetadataURL
+}
+
+// GetMetadataXML returns the MetadataXML field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsSAML) GetMetadataXML() string {
+	if c == nil || c.MetadataXML == nil {
+		return ""
+	}
+	return *c.MetadataXML
+}
+
+// GetSignatureAlgorithm returns the SignatureAlgorithm field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsSAML) GetSignatureAlgorithm() string {
+	if c == nil || c.SignatureAlgorithm == nil {
+		return ""
+	}
+	return *c.SignatureAlgorithm
+}
+
+// GetSignInEndpoint returns the SignInEndpoint field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsSAML) GetSignInEndpoint() string {
+	if c == nil || c.SignInEndpoint == nil {
+		return ""
+	}
+	return *c.SignInEndpoint
+}
+
+// GetSigningCert returns the SigningCert field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsSAML) GetSigningCert() string {
+	if c == nil || c.SigningCert == nil {
+		return ""
+	}
+	return *c.SigningCert
+}
+
+// GetSignOutEndpoint returns the SignOutEndpoint field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsSAML) GetSignOutEndpoint() string {
+	if c == nil || c.SignOutEndpoint == nil {
+		return ""
+	}
+	return *c.SignOutEndpoint
+}
+
+// GetSignSAMLRequest returns the SignSAMLRequest field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsSAML) GetSignSAMLRequest() bool {
+	if c == nil || c.SignSAMLRequest == nil {
+		return false
+	}
+	return *c.SignSAMLRequest
+}
+
+// GetTenantDomain returns the TenantDomain field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsSAML) GetTenantDomain() string {
+	if c == nil || c.TenantDomain == nil {
+		return ""
+	}
+	return *c.TenantDomain
+}
+
+// String returns a string representation of ConnectionOptionsSAML.
+func (c *ConnectionOptionsSAML) String() string {
+	return Stringify(c)
+}
+
 // GetBruteForceProtection returns the BruteForceProtection field if it's non-nil, zero value otherwise.
 func (c *ConnectionOptionsSMS) GetBruteForceProtection() bool {
 	if c == nil || c.BruteForceProtection == nil {
@@ -3047,6 +3156,11 @@ func (p *Permission) GetResourceServerName() string {
 
 // String returns a string representation of Permission.
 func (p *Permission) String() string {
+	return Stringify(p)
+}
+
+// String returns a string representation of PermissionList.
+func (p *PermissionList) String() string {
 	return Stringify(p)
 }
 

--- a/management/management.gen.go
+++ b/management/management.gen.go
@@ -1970,20 +1970,20 @@ func (c *ConnectionOptionsSalesforce) String() string {
 	return Stringify(c)
 }
 
-// GetBindingMethod returns the BindingMethod field if it's non-nil, zero value otherwise.
-func (c *ConnectionOptionsSAML) GetBindingMethod() string {
-	if c == nil || c.BindingMethod == nil {
-		return ""
-	}
-	return *c.BindingMethod
-}
-
 // GetCert returns the Cert field if it's non-nil, zero value otherwise.
 func (c *ConnectionOptionsSAML) GetCert() string {
 	if c == nil || c.Cert == nil {
 		return ""
 	}
 	return *c.Cert
+}
+
+// GetDebug returns the Debug field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsSAML) GetDebug() bool {
+	if c == nil || c.Debug == nil {
+		return false
+	}
+	return *c.Debug
 }
 
 // GetDigestAglorithm returns the DigestAglorithm field if it's non-nil, zero value otherwise.
@@ -2002,6 +2002,14 @@ func (c *ConnectionOptionsSAML) GetExpires() string {
 	return *c.Expires
 }
 
+// GetIdpInitiated returns the IdpInitiated field.
+func (c *ConnectionOptionsSAML) GetIdpInitiated() *ConnectionOptionsSAMLIdpinitiated {
+	if c == nil {
+		return nil
+	}
+	return c.IdpInitiated
+}
+
 // GetMetadataURL returns the MetadataURL field if it's non-nil, zero value otherwise.
 func (c *ConnectionOptionsSAML) GetMetadataURL() string {
 	if c == nil || c.MetadataURL == nil {
@@ -2016,6 +2024,14 @@ func (c *ConnectionOptionsSAML) GetMetadataXML() string {
 		return ""
 	}
 	return *c.MetadataXML
+}
+
+// GetProtocolBinding returns the ProtocolBinding field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsSAML) GetProtocolBinding() string {
+	if c == nil || c.ProtocolBinding == nil {
+		return ""
+	}
+	return *c.ProtocolBinding
 }
 
 // GetSignatureAlgorithm returns the SignatureAlgorithm field if it's non-nil, zero value otherwise.
@@ -2068,6 +2084,35 @@ func (c *ConnectionOptionsSAML) GetTenantDomain() string {
 
 // String returns a string representation of ConnectionOptionsSAML.
 func (c *ConnectionOptionsSAML) String() string {
+	return Stringify(c)
+}
+
+// GetClientAuthorizequery returns the ClientAuthorizequery field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsSAMLIdpinitiated) GetClientAuthorizequery() string {
+	if c == nil || c.ClientAuthorizequery == nil {
+		return ""
+	}
+	return *c.ClientAuthorizequery
+}
+
+// GetClientID returns the ClientID field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsSAMLIdpinitiated) GetClientID() string {
+	if c == nil || c.ClientID == nil {
+		return ""
+	}
+	return *c.ClientID
+}
+
+// GetClientProtocol returns the ClientProtocol field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsSAMLIdpinitiated) GetClientProtocol() string {
+	if c == nil || c.ClientProtocol == nil {
+		return ""
+	}
+	return *c.ClientProtocol
+}
+
+// String returns a string representation of ConnectionOptionsSAMLIdpinitiated.
+func (c *ConnectionOptionsSAMLIdpinitiated) String() string {
 	return Stringify(c)
 }
 

--- a/management/management.gen.go
+++ b/management/management.gen.go
@@ -2003,7 +2003,7 @@ func (c *ConnectionOptionsSAML) GetExpires() string {
 }
 
 // GetIdpInitiated returns the IdpInitiated field.
-func (c *ConnectionOptionsSAML) GetIdpInitiated() *ConnectionOptionsSAMLIdpinitiated {
+func (c *ConnectionOptionsSAML) GetIdpInitiated() *ConnectionOptionsSAMLIdpInitiated {
 	if c == nil {
 		return nil
 	}
@@ -2087,16 +2087,16 @@ func (c *ConnectionOptionsSAML) String() string {
 	return Stringify(c)
 }
 
-// GetClientAuthorizequery returns the ClientAuthorizequery field if it's non-nil, zero value otherwise.
-func (c *ConnectionOptionsSAMLIdpinitiated) GetClientAuthorizequery() string {
-	if c == nil || c.ClientAuthorizequery == nil {
+// GetClientAuthorizeQuery returns the ClientAuthorizeQuery field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsSAMLIdpInitiated) GetClientAuthorizeQuery() string {
+	if c == nil || c.ClientAuthorizeQuery == nil {
 		return ""
 	}
-	return *c.ClientAuthorizequery
+	return *c.ClientAuthorizeQuery
 }
 
 // GetClientID returns the ClientID field if it's non-nil, zero value otherwise.
-func (c *ConnectionOptionsSAMLIdpinitiated) GetClientID() string {
+func (c *ConnectionOptionsSAMLIdpInitiated) GetClientID() string {
 	if c == nil || c.ClientID == nil {
 		return ""
 	}
@@ -2104,15 +2104,15 @@ func (c *ConnectionOptionsSAMLIdpinitiated) GetClientID() string {
 }
 
 // GetClientProtocol returns the ClientProtocol field if it's non-nil, zero value otherwise.
-func (c *ConnectionOptionsSAMLIdpinitiated) GetClientProtocol() string {
+func (c *ConnectionOptionsSAMLIdpInitiated) GetClientProtocol() string {
 	if c == nil || c.ClientProtocol == nil {
 		return ""
 	}
 	return *c.ClientProtocol
 }
 
-// String returns a string representation of ConnectionOptionsSAMLIdpinitiated.
-func (c *ConnectionOptionsSAMLIdpinitiated) String() string {
+// String returns a string representation of ConnectionOptionsSAMLIdpInitiated.
+func (c *ConnectionOptionsSAMLIdpInitiated) String() string {
 	return Stringify(c)
 }
 

--- a/management/management.go
+++ b/management/management.go
@@ -227,7 +227,7 @@ func (m *Management) request(method, uri string, v interface{}) error {
 		return newError(res.Body)
 	}
 
-	if res.StatusCode != http.StatusNoContent {
+	if res.StatusCode != http.StatusNoContent && res.StatusCode != http.StatusAccepted {
 		err := json.NewDecoder(res.Body).Decode(v)
 		if err != nil {
 			return err


### PR DESCRIPTION
This PR adds the options for the SAML connection type.
 - Added attributes supported by the Management API V2
 - Added relevant tests


