### PR TITLE
Update client.refresh_token to allow for rotation_type and expiration_type fields

### DIFF
--- a/management/client.go
+++ b/management/client.go
@@ -109,12 +109,18 @@ type ClientNativeSocialLogin struct {
 }
 
 type ClientRefreshToken struct {
-	// Refresh token types, one of: reusable, rotating
-	Type *string `json:"type,omitempty"`
+	// Refresh token rotation type. Can be "rotating" or "non-rotating"
+	RotationType *string `json:"rotation_type,omitempty"`
+
+	// Refresh token expiration type. Can be "expiring" or "non-expiring"
+	ExpirationType *string `json:"expiration_type,omitempty"`
 
 	// Period in seconds where the previous refresh token can be exchanged
 	// without triggering breach detection
 	Leeway *int `json:"leeway,omitempty"`
+
+	// Period (in seconds) for which refresh tokens will remain valid.
+	TokenLifetime *int `json:"token_lifetime,omitempty"`
 }
 
 type ClientList struct {

--- a/management/client.go
+++ b/management/client.go
@@ -109,9 +109,9 @@ type ClientNativeSocialLogin struct {
 }
 
 type ClientRefreshToken struct {
-	// Refresh token types, one of: reusable, rotating.
+	// Refresh token types, one of: reusable, rotating
 	//
-	// Deprecated: use RotationType and ExpirationType instead.
+	// Deprecated: use RotationType and ExpirationType instead
 	Type *string `json:"type,omitempty"`
 
 	// Refresh token rotation type. Can be "rotating" or "non-rotating"
@@ -124,7 +124,7 @@ type ClientRefreshToken struct {
 	// without triggering breach detection
 	Leeway *int `json:"leeway,omitempty"`
 
-	// Period (in seconds) for which refresh tokens will remain valid.
+	// Period in seconds for which refresh tokens will remain valid
 	TokenLifetime *int `json:"token_lifetime,omitempty"`
 }
 

--- a/management/client.go
+++ b/management/client.go
@@ -109,6 +109,11 @@ type ClientNativeSocialLogin struct {
 }
 
 type ClientRefreshToken struct {
+	// Refresh token types, one of: reusable, rotating.
+	//
+	// Deprecated: use RotationType and ExpirationType instead.
+	Type *string `json:"type,omitempty"`
+
 	// Refresh token rotation type. Can be "rotating" or "non-rotating"
 	RotationType *string `json:"rotation_type,omitempty"`
 

--- a/management/management.gen.go
+++ b/management/management.gen.go
@@ -413,6 +413,14 @@ func (c *ClientRefreshToken) GetTokenLifetime() int {
 	return *c.TokenLifetime
 }
 
+// GetType returns the Type field if it's non-nil, zero value otherwise.
+func (c *ClientRefreshToken) GetType() string {
+	if c == nil || c.Type == nil {
+		return ""
+	}
+	return *c.Type
+}
+
 // String returns a string representation of ClientRefreshToken.
 func (c *ClientRefreshToken) String() string {
 	return Stringify(c)

--- a/management/management.gen.go
+++ b/management/management.gen.go
@@ -381,6 +381,14 @@ func (c *ClientNativeSocialLogin) String() string {
 	return Stringify(c)
 }
 
+// GetExpirationType returns the ExpirationType field if it's non-nil, zero value otherwise.
+func (c *ClientRefreshToken) GetExpirationType() string {
+	if c == nil || c.ExpirationType == nil {
+		return ""
+	}
+	return *c.ExpirationType
+}
+
 // GetLeeway returns the Leeway field if it's non-nil, zero value otherwise.
 func (c *ClientRefreshToken) GetLeeway() int {
 	if c == nil || c.Leeway == nil {
@@ -389,12 +397,20 @@ func (c *ClientRefreshToken) GetLeeway() int {
 	return *c.Leeway
 }
 
-// GetType returns the Type field if it's non-nil, zero value otherwise.
-func (c *ClientRefreshToken) GetType() string {
-	if c == nil || c.Type == nil {
+// GetRotationType returns the RotationType field if it's non-nil, zero value otherwise.
+func (c *ClientRefreshToken) GetRotationType() string {
+	if c == nil || c.RotationType == nil {
 		return ""
 	}
-	return *c.Type
+	return *c.RotationType
+}
+
+// GetTokenLifetime returns the TokenLifetime field if it's non-nil, zero value otherwise.
+func (c *ClientRefreshToken) GetTokenLifetime() int {
+	if c == nil || c.TokenLifetime == nil {
+		return 0
+	}
+	return *c.TokenLifetime
 }
 
 // String returns a string representation of ClientRefreshToken.

--- a/management/management_test.go
+++ b/management/management_test.go
@@ -16,7 +16,7 @@ var (
 
 func init() {
 	var err error
-	m, err = New(domain, clientID, clientSecret, WithDebug(false))
+	m, err = New(domain, clientID, clientSecret, WithDebug(true))
 	if err != nil {
 		panic(err)
 	}

--- a/management/management_test.go
+++ b/management/management_test.go
@@ -16,7 +16,7 @@ var (
 
 func init() {
 	var err error
-	m, err = New(domain, clientID, clientSecret, WithDebug(true))
+	m, err = New(domain, clientID, clientSecret, WithDebug(false))
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Update `ClientRefreshToken` type.

New fields:
- `RotationType`
- `ExpirationType`

Deprecated fields:
- `Type`