### PR TITLE
Improve connection options tests

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,9 +2,11 @@ name: CodeQL
 
 on:
   push:
+    branches:
+      - master
   pull_request:
-  schedule:
-    - cron: "0 0 * * 0"
+    branches:
+      - '**'
 
 jobs:
   scan:

--- a/management/client.go
+++ b/management/client.go
@@ -110,11 +110,22 @@ type ClientNativeSocialLogin struct {
 
 type ClientRefreshToken struct {
 	// Refresh token types, one of: reusable, rotating
+	//
+	// Deprecated: use RotationType and ExpirationType instead
 	Type *string `json:"type,omitempty"`
+
+	// Refresh token rotation type. Can be "rotating" or "non-rotating"
+	RotationType *string `json:"rotation_type,omitempty"`
+
+	// Refresh token expiration type. Can be "expiring" or "non-expiring"
+	ExpirationType *string `json:"expiration_type,omitempty"`
 
 	// Period in seconds where the previous refresh token can be exchanged
 	// without triggering breach detection
 	Leeway *int `json:"leeway,omitempty"`
+
+	// Period in seconds for which refresh tokens will remain valid
+	TokenLifetime *int `json:"token_lifetime,omitempty"`
 }
 
 type ClientList struct {

--- a/management/management.gen.go
+++ b/management/management.gen.go
@@ -381,12 +381,36 @@ func (c *ClientNativeSocialLogin) String() string {
 	return Stringify(c)
 }
 
+// GetExpirationType returns the ExpirationType field if it's non-nil, zero value otherwise.
+func (c *ClientRefreshToken) GetExpirationType() string {
+	if c == nil || c.ExpirationType == nil {
+		return ""
+	}
+	return *c.ExpirationType
+}
+
 // GetLeeway returns the Leeway field if it's non-nil, zero value otherwise.
 func (c *ClientRefreshToken) GetLeeway() int {
 	if c == nil || c.Leeway == nil {
 		return 0
 	}
 	return *c.Leeway
+}
+
+// GetRotationType returns the RotationType field if it's non-nil, zero value otherwise.
+func (c *ClientRefreshToken) GetRotationType() string {
+	if c == nil || c.RotationType == nil {
+		return ""
+	}
+	return *c.RotationType
+}
+
+// GetTokenLifetime returns the TokenLifetime field if it's non-nil, zero value otherwise.
+func (c *ClientRefreshToken) GetTokenLifetime() int {
+	if c == nil || c.TokenLifetime == nil {
+		return 0
+	}
+	return *c.TokenLifetime
 }
 
 // GetType returns the Type field if it's non-nil, zero value otherwise.


### PR DESCRIPTION
Improve connection options tests.

- Use generated accessors for getting IDs

```diff
- auth0.StringValue(c.ID)
+ c.GetID()
```

- Fix broken deferred deletes by wrapping them in a self invoked function.

```diff
- defer m.Connection.Delete(g.GetID())
+ defer func() { m.Connection.Delete(g.GetID()) }()
```

- Move connection options tests under their own `TestConnectionOptions` test function.
- Various small improvements
