### PR TITLE
add missing SAML Connection Options

### DIFF
--- a/management/connection.go
+++ b/management/connection.go
@@ -609,6 +609,9 @@ type ConnectionOptionsSAML struct {
 	FieldsMap          map[string]interface{}             `json:"fieldsMap,omitempty"`
 	Subject            map[string]interface{}             `json:"subject,omitempty"`
 	SignSAMLRequest    *bool                              `json:"signSAMLRequest,omitempty"`
+	RequestTemplate    *string                            `json:"requestTemplate,omitempty"`
+	UserIDAttribute    *string                            `json:"user_id_attribute,omitempty"`
+	LogoURL            *string                            `json:"icon_url,omitempty"`
 }
 
 type ConnectionOptionsSAMLIdpInitiated struct {

--- a/management/connection.go
+++ b/management/connection.go
@@ -615,6 +615,7 @@ type ConnectionOptionsSAML struct {
 }
 
 type ConnectionOptionsSAMLIdpInitiated struct {
+	Enabled              *bool   `json:"enabled,omitempty"`
 	ClientID             *string `json:"client_id,omitempty"`
 	ClientProtocol       *string `json:"client_protocol,omitempty"`
 	ClientAuthorizeQuery *string `json:"client_authorizequery,omitempty"`

--- a/management/management.gen.go
+++ b/management/management.gen.go
@@ -2034,6 +2034,14 @@ func (c *ConnectionOptionsSAML) GetIdpInitiated() *ConnectionOptionsSAMLIdpIniti
 	return c.IdpInitiated
 }
 
+// GetLogoURL returns the LogoURL field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsSAML) GetLogoURL() string {
+	if c == nil || c.LogoURL == nil {
+		return ""
+	}
+	return *c.LogoURL
+}
+
 // GetMetadataURL returns the MetadataURL field if it's non-nil, zero value otherwise.
 func (c *ConnectionOptionsSAML) GetMetadataURL() string {
 	if c == nil || c.MetadataURL == nil {
@@ -2056,6 +2064,14 @@ func (c *ConnectionOptionsSAML) GetProtocolBinding() string {
 		return ""
 	}
 	return *c.ProtocolBinding
+}
+
+// GetRequestTemplate returns the RequestTemplate field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsSAML) GetRequestTemplate() string {
+	if c == nil || c.RequestTemplate == nil {
+		return ""
+	}
+	return *c.RequestTemplate
 }
 
 // GetSignatureAlgorithm returns the SignatureAlgorithm field if it's non-nil, zero value otherwise.
@@ -2106,6 +2122,14 @@ func (c *ConnectionOptionsSAML) GetTenantDomain() string {
 	return *c.TenantDomain
 }
 
+// GetUserIDAttribute returns the UserIDAttribute field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsSAML) GetUserIDAttribute() string {
+	if c == nil || c.UserIDAttribute == nil {
+		return ""
+	}
+	return *c.UserIDAttribute
+}
+
 // String returns a string representation of ConnectionOptionsSAML.
 func (c *ConnectionOptionsSAML) String() string {
 	return Stringify(c)
@@ -2133,6 +2157,14 @@ func (c *ConnectionOptionsSAMLIdpInitiated) GetClientProtocol() string {
 		return ""
 	}
 	return *c.ClientProtocol
+}
+
+// GetEnabled returns the Enabled field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsSAMLIdpInitiated) GetEnabled() bool {
+	if c == nil || c.Enabled == nil {
+		return false
+	}
+	return *c.Enabled
 }
 
 // String returns a string representation of ConnectionOptionsSAMLIdpInitiated.


### PR DESCRIPTION
Three SAML options got missed when SAML Connection support was re-added to the provider. 

This PR brings parity to what settings can be set with regards to the SAML connection. 