### PR TITLE
Send tenant session_lifetime_in_minutes when session_lifetime is < 1

### DIFF
--- a/auth0.go
+++ b/auth0.go
@@ -31,6 +31,20 @@ func IntValue(i *int) int {
 	return 0
 }
 
+// Float64 returns a pointer to the float64 value passed in.
+func Float64(f float64) *float64 {
+	return &f
+}
+
+// Float64Value returns the value of the float64 pointer passed in or 0 if the pointer
+// is nil.
+func Float64Value(f *float64) float64 {
+	if f != nil {
+		return *f
+	}
+	return 0.00
+}
+
 // String returns a pointer to the string value passed in.
 func String(s string) *string {
 	return &s

--- a/auth0_test.go
+++ b/auth0_test.go
@@ -38,6 +38,23 @@ func TestInt(t *testing.T) {
 	}
 }
 
+func TestFloat64(t *testing.T) {
+	for _, test := range []struct {
+		in       *float64
+		expected float64
+	}{
+		{nil, 0},
+		{Float64(0), 0},
+		{Float64(1), 1},
+		{Float64(-1), -1},
+	} {
+		have := Float64Value(test.in)
+		if have != test.expected {
+			t.Errorf("unexpected output. have %v, expected %v", have, test.expected)
+		}
+	}
+}
+
 func TestString(t *testing.T) {
 	for _, test := range []struct {
 		in       *string

--- a/management/gen-methods.go
+++ b/management/gen-methods.go
@@ -218,6 +218,8 @@ func (t *templateData) addIdent(x *ast.Ident, receiverType, fieldName string) {
 	switch x.String() {
 	case "int", "int64":
 		zeroValue = "0"
+	case "float32", "float64":
+		zeroValue = "0"
 	case "string":
 		zeroValue = `""`
 	case "bool":

--- a/management/management.gen.go
+++ b/management/management.gen.go
@@ -3620,7 +3620,7 @@ func (t *Tenant) GetGuardianMFAPage() *TenantGuardianMFAPage {
 }
 
 // GetIdleSessionLifetime returns the IdleSessionLifetime field if it's non-nil, zero value otherwise.
-func (t *Tenant) GetIdleSessionLifetime() int {
+func (t *Tenant) GetIdleSessionLifetime() float64 {
 	if t == nil || t.IdleSessionLifetime == nil {
 		return 0
 	}
@@ -3644,7 +3644,7 @@ func (t *Tenant) GetSandboxVersion() string {
 }
 
 // GetSessionLifetime returns the SessionLifetime field if it's non-nil, zero value otherwise.
-func (t *Tenant) GetSessionLifetime() int {
+func (t *Tenant) GetSessionLifetime() float64 {
 	if t == nil || t.SessionLifetime == nil {
 		return 0
 	}

--- a/management/tenant.go
+++ b/management/tenant.go
@@ -108,7 +108,7 @@ func (t *Tenant) MarshalJSON() ([]byte, error) {
 			w.IdleSessionLifetime = nil
 			defer func() { w.IdleSessionLifetime = &idleSessionLifetime }()
 		} else {
-			w.IdleSessionLifetime = auth0.Float64(idleSessionLifetime)
+			w.IdleSessionLifetime = auth0.Float64(math.Round(idleSessionLifetime))
 		}
 
 	}

--- a/management/tenant_test.go
+++ b/management/tenant_test.go
@@ -1,9 +1,11 @@
 package management
 
 import (
+	"encoding/json"
 	"testing"
 
 	"gopkg.in/auth0.v5"
+	"gopkg.in/auth0.v5/internal/testing/expect"
 )
 
 func TestTenant(t *testing.T) {
@@ -25,11 +27,33 @@ func TestTenant(t *testing.T) {
 			SupportURL:            auth0.String("https://support.example.com"),
 			SupportEmail:          auth0.String("support@example.com"),
 			DefaultRedirectionURI: auth0.String("https://example.com/login"),
+			SessionLifetime:       auth0.Float64(1080),
+			IdleSessionLifetime:   auth0.Float64(720),
 		})
 		if err != nil {
 			t.Error(err)
 		}
 		tn, _ = m.Tenant.Read()
 		t.Logf("%v\n", tn)
+	})
+
+	t.Run("MarshalJSON", func(t *testing.T) {
+		for tenant, expected := range map[*Tenant]string{
+			{}:                                         `{}`,
+			{SessionLifetime: auth0.Float64(1)}:        `{"session_lifetime":1}`,
+			{SessionLifetime: auth0.Float64(720)}:      `{"session_lifetime":720}`,
+			{IdleSessionLifetime: auth0.Float64(1)}:    `{"idle_session_lifetime":1}`,
+			{SessionLifetime: auth0.Float64(0.25)}:     `{"session_lifetime_in_minutes":15}`,
+			{SessionLifetime: auth0.Float64(0.5)}:      `{"session_lifetime_in_minutes":30}`,
+			{SessionLifetime: auth0.Float64(0.99)}:     `{"session_lifetime_in_minutes":59}`,
+			{IdleSessionLifetime: auth0.Float64(0.25)}: `{"idle_session_lifetime_in_minutes":15}`,
+		} {
+			b, err := json.Marshal(tenant)
+			if err != nil {
+				t.Error(err)
+			}
+			expect.Expect(t, string(b), expected)
+			t.Logf("%v\n", tenant)
+		}
 	})
 }

--- a/management/tenant_test.go
+++ b/management/tenant_test.go
@@ -40,6 +40,8 @@ func TestTenant(t *testing.T) {
 	t.Run("MarshalJSON", func(t *testing.T) {
 		for tenant, expected := range map[*Tenant]string{
 			{}:                                         `{}`,
+			{SessionLifetime: auth0.Float64(1.2)}:      `{"session_lifetime":1}`,
+			{SessionLifetime: auth0.Float64(1.19)}:     `{"session_lifetime":1}`,
 			{SessionLifetime: auth0.Float64(1)}:        `{"session_lifetime":1}`,
 			{SessionLifetime: auth0.Float64(720)}:      `{"session_lifetime":720}`,
 			{IdleSessionLifetime: auth0.Float64(1)}:    `{"idle_session_lifetime":1}`,

--- a/management/tenant_test.go
+++ b/management/tenant_test.go
@@ -28,7 +28,7 @@ func TestTenant(t *testing.T) {
 			SupportEmail:          auth0.String("support@example.com"),
 			DefaultRedirectionURI: auth0.String("https://example.com/login"),
 			SessionLifetime:       auth0.Float64(1080),
-			IdleSessionLifetime:   auth0.Float64(720),
+			IdleSessionLifetime:   auth0.Float64(720.2), // will be rounded off
 		})
 		if err != nil {
 			t.Error(err)
@@ -45,6 +45,7 @@ func TestTenant(t *testing.T) {
 			{SessionLifetime: auth0.Float64(1)}:        `{"session_lifetime":1}`,
 			{SessionLifetime: auth0.Float64(720)}:      `{"session_lifetime":720}`,
 			{IdleSessionLifetime: auth0.Float64(1)}:    `{"idle_session_lifetime":1}`,
+			{IdleSessionLifetime: auth0.Float64(1.2)}:  `{"idle_session_lifetime":1}`,
 			{SessionLifetime: auth0.Float64(0.25)}:     `{"session_lifetime_in_minutes":15}`,
 			{SessionLifetime: auth0.Float64(0.5)}:      `{"session_lifetime_in_minutes":30}`,
 			{SessionLifetime: auth0.Float64(0.99)}:     `{"session_lifetime_in_minutes":59}`,


### PR DESCRIPTION
`Tenant` `session_lifetime` and `idle_session_lifetime` are changed to `float64` types.

Also, when `session_lifetime` is less than 1, it is replaced with `session_lifetime_in_minutes` instead, multiplied by 60.

Fixes: #127 