### PR TITLE
Updated Metadata property on connection to be string map

### DIFF
--- a/management/connection.go
+++ b/management/connection.go
@@ -70,7 +70,7 @@ type Connection struct {
 	// connection name will be added as realm.
 	Realms []interface{} `json:"realms,omitempty"`
 
-	Metadata *interface{} `json:"metadata,omitempty"`
+	Metadata map[string]string `json:"metadata,omitempty"`
 }
 
 func (c *Connection) MarshalJSON() ([]byte, error) {

--- a/management/connection_test.go
+++ b/management/connection_test.go
@@ -308,10 +308,6 @@ func TestConnectionOptions(t *testing.T) {
 		g := &Connection{
 			Name:     auth0.Stringf("Test-SAML-Connection-%d", time.Now().Unix()),
 			Strategy: auth0.String("samlp"),
-			Metadata: map[string]string{
-				"foo": "bar",
-				"bat": "baz",
-			},
 			Options: &ConnectionOptionsSAML{
 				SignInEndpoint: auth0.String("https://saml.identity/provider"),
 				SigningCert: auth0.String(`-----BEGIN CERTIFICATE-----
@@ -358,7 +354,5 @@ yE+vPxsiUkvQHdO2fojCkY8jg70jxM+gu59tPDNbw3Uh/2Ij310FgTHsnGQMyA==
 
 		expect.Expect(t, o.GetSignInEndpoint(), "https://saml.identity/provider")
 		expect.Expect(t, o.GetTenantDomain(), "example.com")
-		expect.Expect(t, g.Metadata["foo"], "bar")
-		expect.Expect(t, g.Metadata["bat"], "baz")
 	})
 }

--- a/management/connection_test.go
+++ b/management/connection_test.go
@@ -308,6 +308,10 @@ func TestConnectionOptions(t *testing.T) {
 		g := &Connection{
 			Name:     auth0.Stringf("Test-SAML-Connection-%d", time.Now().Unix()),
 			Strategy: auth0.String("samlp"),
+			Metadata: map[string]string{
+				"foo": "bar",
+				"bat": "baz",
+			},
 			Options: &ConnectionOptionsSAML{
 				SignInEndpoint: auth0.String("https://saml.identity/provider"),
 				SigningCert: auth0.String(`-----BEGIN CERTIFICATE-----
@@ -354,5 +358,7 @@ yE+vPxsiUkvQHdO2fojCkY8jg70jxM+gu59tPDNbw3Uh/2Ij310FgTHsnGQMyA==
 
 		expect.Expect(t, o.GetSignInEndpoint(), "https://saml.identity/provider")
 		expect.Expect(t, o.GetTenantDomain(), "example.com")
+		expect.Expect(t, g.Metadata["foo"], "bar")
+		expect.Expect(t, g.Metadata["bat"], "baz")
 	})
 }


### PR DESCRIPTION
First off, I have no experience in GoLang so I'm not sure this is the correct solution to this problem.  Please let me know if anything needs to be changed with this PR.

This is step one of me attempting to fix an issue with the terraform provider that utilizes this library. 
[Issue 282 on alexkappa/terraform-provider-auth0](https://github.com/alexkappa/terraform-provider-auth0/issues/282)

When attempting to fix that in the terraform provider I noticed that the data type for the property was an interface pointer which doesn't make sense to me.

I think the Metadata property on connection should be the same data type as "client_metadata" would be on an application/client since connection metadata functions in exactly the same way as client metadata.  I changed it to map[string]string instead of *interface{} and modified a test case to set the property and expect that it was set.