### PR TITLE
Add refreshToken field on UserIdentity

### DIFF
--- a/management/user.go
+++ b/management/user.go
@@ -99,6 +99,7 @@ type UserIdentity struct {
 	Provider    *string `json:"provider,omitempty"`
 	IsSocial    *bool   `json:"isSocial,omitempty"`
 	AccessToken *string `json:"access_token,omitempty"`
+	RefreshToken *string `json:"refresh_token,omitempty"`
 }
 
 // UnmarshalJSON is a custom deserializer for the UserIdentity type.


### PR DESCRIPTION
Add support for reading refresh token on UserIdentity.
Based on: https://auth0.com/docs/tokens/identity-provider-access-tokens#renew-third-party-tokens