### PR TITLE
WIP: User.email_verified is union of string|bool

### DIFF
--- a/boolstring.go
+++ b/boolstring.go
@@ -1,0 +1,47 @@
+package auth0
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+)
+
+var (
+	errUnmarshalBoolString = errors.New("BoolString: json.Unmarshal failed")
+
+	trueStringJSON  = json.RawMessage(`"true"`)
+	falseStringJSON = json.RawMessage(`"false"`)
+
+	trueJSON  = json.RawMessage(`true`)
+	falseJSON = json.RawMessage(`false`)
+	nullJSON  = json.RawMessage(`null`)
+)
+
+type BoolString bool
+
+func NewBoolString(v bool) *BoolString {
+	result := BoolString(v)
+	return &result
+}
+
+func (b BoolString) MarshalJSON() ([]byte, error) {
+	return json.Marshal(bool(b))
+}
+
+func (b *BoolString) UnmarshalJSON(data []byte) error {
+	var v json.RawMessage
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	switch {
+	case bytes.Equal(v, trueStringJSON), bytes.Equal(v, trueJSON):
+		*b = true
+	case bytes.Equal(v, falseStringJSON), bytes.Equal(v, falseJSON), bytes.Equal(v, nullJSON):
+		*b = false
+	default:
+		return errUnmarshalBoolString
+	}
+
+	return nil
+}

--- a/boolstring_test.go
+++ b/boolstring_test.go
@@ -1,0 +1,96 @@
+package auth0
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"testing"
+)
+
+func TestBoolStringMarshal(t *testing.T) {
+	tests := []struct {
+		input BoolString
+		want  []byte
+	}{
+		{
+			input: BoolString(true),
+			want:  []byte(`true`),
+		},
+		{
+			input: BoolString(false),
+			want:  []byte(`false`),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("input=%v", test.input), func(t *testing.T) {
+			got, err := json.Marshal(test.input)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if !bytes.Equal(test.want, got) {
+				t.Fatalf("wanted %q, got %q", test.want, got)
+			}
+		})
+	}
+
+}
+func TestBoolStringUnmarshal(t *testing.T) {
+	var doesNotMatter json.RawMessage
+	errUnexpectedEndOfInput := json.Unmarshal([]byte(""), &doesNotMatter)
+
+	tests := []struct {
+		input     []byte
+		want      BoolString
+		wantError error
+	}{
+		{
+			input: trueJSON,
+			want:  BoolString(true),
+		},
+		{
+			input: trueStringJSON,
+			want:  BoolString(true),
+		},
+		{
+			input: falseJSON,
+			want:  BoolString(false),
+		},
+		{
+			input: falseStringJSON,
+			want:  BoolString(false),
+		},
+		{
+			input: nullJSON,
+			want:  BoolString(false),
+		},
+		{
+			input:     []byte(`1`),
+			wantError: errUnmarshalBoolString,
+		},
+		{
+			input:     []byte(`0`),
+			wantError: errUnmarshalBoolString,
+		},
+		{
+			input:     []byte(``),
+			wantError: errUnexpectedEndOfInput,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("input=%s", test.input), func(t *testing.T) {
+			var got BoolString
+
+			if err := json.Unmarshal(test.input, &got); !reflect.DeepEqual(test.wantError, err) {
+				t.Fatalf("wanted err: %v, got %v", test.wantError, err)
+			}
+
+			if test.want != got {
+				t.Fatalf("wanted %v, got %v", test.want, got)
+			}
+		})
+	}
+}

--- a/management/management.gen.go
+++ b/management/management.gen.go
@@ -4240,7 +4240,7 @@ func (u *User) GetEmailVerified() bool {
 	if u == nil || u.EmailVerified == nil {
 		return false
 	}
-	return *u.EmailVerified
+	return bool(*u.EmailVerified)
 }
 
 // GetFamilyName returns the FamilyName field if it's non-nil, zero value otherwise.

--- a/management/user.go
+++ b/management/user.go
@@ -5,6 +5,8 @@ import (
 	"reflect"
 	"strconv"
 	"time"
+
+	"gopkg.in/auth0.v5"
 )
 
 // User represents an Auth0 user resource
@@ -62,7 +64,7 @@ type User struct {
 	// True if the user's email is verified, false otherwise. If it is true then
 	// the user will not receive a verification email, unless verify_email: true
 	// was specified.
-	EmailVerified *bool `json:"email_verified,omitempty"`
+	EmailVerified *auth0.BoolString `json:"email_verified,omitempty"`
 
 	// If true, the user will receive a verification email after creation, even
 	// if created with email_verified set to true. If false, the user will not

--- a/management/user_test.go
+++ b/management/user_test.go
@@ -22,7 +22,7 @@ func TestUser(t *testing.T) {
 		UserMetadata: map[string]interface{}{
 			"favourite_attack": "roundhouse_kick",
 		},
-		EmailVerified: auth0.Bool(true),
+		EmailVerified: auth0.NewBoolString(true),
 		VerifyEmail:   auth0.Bool(false),
 		AppMetadata: map[string]interface{}{
 			"facts": []string{


### PR DESCRIPTION
Similar to UserIdentity, this is a shim which we can't necessarily fix
without accidentally breaking userspace.

This changes the semantics such that we can handle a string `"true"` or
`"false"` for these boolean types.