### PR TITLE
Add missing field IncludeEmailInRedirect to Ticket

### DIFF
--- a/management/management.gen.go
+++ b/management/management.gen.go
@@ -4166,6 +4166,14 @@ func (t *Ticket) GetMarkEmailAsVerified() bool {
 	return *t.MarkEmailAsVerified
 }
 
+// GetIncludeEmailInRedirect returns the IncludeEmailInRedirect field if it's non-nil, zero value otherwise.
+func (t *Ticket) GetIncludeEmailInRedirect() bool {
+	if t == nil || t.IncludeEmailInRedirect == nil {
+		return false
+	}
+	return *t.IncludeEmailInRedirect
+}
+
 // GetResultURL returns the ResultURL field if it's non-nil, zero value otherwise.
 func (t *Ticket) GetResultURL() string {
 	if t == nil || t.ResultURL == nil {

--- a/management/ticket.go
+++ b/management/ticket.go
@@ -33,6 +33,9 @@ type Ticket struct {
 	// Whether to set the email_verified attribute to true (true) or whether it
 	// should not be updated
 	MarkEmailAsVerified *bool `json:"mark_email_as_verified,omitempty"`
+
+	// Whether to include the email address as part of the returnUrl in the reset_email (true), or not (false - default).
+	IncludeEmailInRedirect *bool `json:"includeEmailInRedirect,omitempty"`
 }
 
 type TicketManager struct {

--- a/management/ticket_test.go
+++ b/management/ticket_test.go
@@ -41,10 +41,11 @@ func TestTicket(t *testing.T) {
 	t.Run("ChangePassword", func(t *testing.T) {
 
 		v := &Ticket{
-			ResultURL:           auth0.String("https://example.com/change-password"),
-			UserID:              auth0.String(userID),
-			TTLSec:              auth0.Int(3600),
-			MarkEmailAsVerified: auth0.Bool(true),
+			ResultURL:              auth0.String("https://example.com/change-password"),
+			UserID:                 auth0.String(userID),
+			TTLSec:                 auth0.Int(3600),
+			MarkEmailAsVerified:    auth0.Bool(true),
+			IncludeEmailInRedirect: auth0.Bool(true),
 		}
 
 		err = m.Ticket.ChangePassword(v)


### PR DESCRIPTION
Adds the missing field `IncludeEmailInRedirect` to `management.Ticket`. 

ref: https://auth0.com/docs/api/management/v2#!/Tickets/post_password_change