### PR TITLE
Add addition client refresh_token fields

### DIFF
--- a/management/client.go
+++ b/management/client.go
@@ -126,6 +126,16 @@ type ClientRefreshToken struct {
 
 	// Period in seconds for which refresh tokens will remain valid
 	TokenLifetime *int `json:"token_lifetime,omitempty"`
+
+	// Whether or not refresh tokens should remain valid indefinitely. If false,
+	// "TokenLifetime" should be set
+	InfiniteTokenLifetime *bool `json:"infinite_token_lifetime,omitempty"`
+
+	// Whether or not inactive refresh tokens should be remain valid indefinitely
+	InfiniteIdleTokenLifetime *bool `json:"infinite_idle_token_lifetime,omitempty"`
+
+	// Period in seconds after which inactive refresh tokens will expire
+	IdleTokenLifetime *int `json:"idle_token_lifetime,omitempty"`
 }
 
 type ClientList struct {


### PR DESCRIPTION
Add support for more refresh_token fields supported by the api:
```
infinite_token_lifetime
infinite_idle_token_lifetime
idle_token_lifetime
```

https://auth0.com/docs/api/management/v2#!/Clients/post_clients

Closes #183 