### PR TITLE
#185: Assert name is not empty in connection.ReadByName function

### DIFF
--- a/management/connection.go
+++ b/management/connection.go
@@ -730,6 +730,9 @@ func (m *ConnectionManager) Delete(id string, opts ...RequestOption) (err error)
 // ReadByName retrieves a connection by its name. This is a helper method when a
 // connection id is not readily available.
 func (m *ConnectionManager) ReadByName(name string, opts ...RequestOption) (*Connection, error) {
+	if name == "" {
+		return nil, &managementError{400, "Bad Request", "Name cannot be empty"}
+	}
 	c, err := m.List(append(opts, Parameter("name", name))...)
 	if err != nil {
 		return nil, err

--- a/management/connection_test.go
+++ b/management/connection_test.go
@@ -128,6 +128,24 @@ func TestConnection(t *testing.T) {
 		}
 		t.Logf("%v\n", cs)
 	})
+
+	t.Run("ReadByNameEmptyName", func(t *testing.T) {
+		cs, err := m.Connection.ReadByName("")
+		if err == nil {
+			t.Fail()
+		}
+		mgmtError, ok := err.(*managementError)
+		if !ok {
+			t.Fail()
+		}
+		if mgmtError.StatusCode != 400 {
+			t.Fail()
+		}
+		if cs != nil {
+			t.Fail()
+		}
+		t.Logf("%v\n", cs)
+	})
 }
 func TestConnectionOptions(t *testing.T) {
 


### PR DESCRIPTION
### Proposed Changes

* ConnectionManager.ReadByName() function returns an error if the `name` parameter is empty.


Fixes #185 

#### Acceptance Test Output

```
$ go test ./... -v -run TestConnection

...
```

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->