### PR TITLE
Add the new identifier_first argument to prompts

### DIFF
--- a/management/management.gen.go
+++ b/management/management.gen.go
@@ -3738,6 +3738,14 @@ func (p *PhoneMessageTypes) String() string {
 	return Stringify(p)
 }
 
+// GetIdentifierFirst returns the IdentifierFirst field if it's non-nil, zero value otherwise.
+func (p *Prompt) GetIdentifierFirst() bool {
+	if p == nil || p.IdentifierFirst == nil {
+		return false
+	}
+	return *p.IdentifierFirst
+}
+
 // String returns a string representation of Prompt.
 func (p *Prompt) String() string {
 	return Stringify(p)

--- a/management/prompt.go
+++ b/management/prompt.go
@@ -3,6 +3,9 @@ package management
 type Prompt struct {
 	// Which login experience to use. Can be `new` or `classic`.
 	UniversalLoginExperience string `json:"universal_login_experience,omitempty"`
+
+	// IdentifierFirst determines if the login screen prompts for just the identifier, identifier and password first.
+	IdentifierFirst *bool `json:"identifier_first,omitempty"`
 }
 
 type PromptManager struct {

--- a/management/prompt_test.go
+++ b/management/prompt_test.go
@@ -1,40 +1,51 @@
 package management
 
 import (
+	"gopkg.in/auth0.v5"
+	"gopkg.in/auth0.v5/internal/testing/expect"
 	"testing"
 )
 
 func TestPrompt(t *testing.T) {
-
-	t.Run("Read", func(t *testing.T) {
-		ps, err := m.Prompt.Read()
-		if err != nil {
-			t.Error(err)
-		}
-		t.Logf("%v\n", ps)
-	})
-
-	t.Run("Update", func(t *testing.T) {
-		defer func() {
-			m.Prompt.Update(&Prompt{
-				UniversalLoginExperience: "classic",
-			})
-		}()
-		expected := "new"
+	t.Cleanup(func() {
 		err := m.Prompt.Update(&Prompt{
-			UniversalLoginExperience: expected,
+			UniversalLoginExperience: "classic",
+			IdentifierFirst:          auth0.Bool(false),
 		})
 		if err != nil {
-			t.Error(err)
+			t.Fatal(err)
 		}
-
-		ps, err := m.Prompt.Read()
-		if err != nil {
-			t.Error(err)
-		}
-		if ps.UniversalLoginExperience != expected {
-			t.Errorf("unexpected output. have %v, expected %v", ps.UniversalLoginExperience, expected)
-		}
-		t.Logf("%v\n", ps)
 	})
+
+	// update to the new identifier first experience
+	err := m.Prompt.Update(&Prompt{
+		UniversalLoginExperience: "new",
+		IdentifierFirst:          auth0.Bool(true),
+	})
+	if err != nil {
+		t.Error(err)
+	}
+
+	ps, err := m.Prompt.Read()
+	if err != nil {
+		t.Error(err)
+	}
+	expect.Expect(t, ps.UniversalLoginExperience, "new")
+	expect.Expect(t, ps.IdentifierFirst, auth0.Bool(true))
+
+	// update to the classic non identifier first experience
+	err = m.Prompt.Update(&Prompt{
+		UniversalLoginExperience: "classic",
+		IdentifierFirst:          auth0.Bool(false),
+	})
+	if err != nil {
+		t.Error(err)
+	}
+
+	ps, err = m.Prompt.Read()
+	if err != nil {
+		t.Error(err)
+	}
+	expect.Expect(t, ps.UniversalLoginExperience, "classic")
+	expect.Expect(t, ps.IdentifierFirst, auth0.Bool(false))
 }


### PR DESCRIPTION
### Proposed Changes

Adds the new `identifier_first` argument to prompts. I will update the terraform provider as well once this lands and is tagged.

https://support.auth0.com/notifications/5fff0ab3f28427000a77941e

#### Acceptance Test Output

```
kpurdon@syndio: ~/.../kpurdon/auth0 go test ./... -v -run TestPrompt
testing: warning: no tests to run
PASS
ok  	gopkg.in/auth0.v5	(cached) [no tests to run]
testing: warning: no tests to run
PASS
ok  	gopkg.in/auth0.v5/internal/client	(cached) [no tests to run]
testing: warning: no tests to run
PASS
ok  	gopkg.in/auth0.v5/internal/tag	(cached) [no tests to run]
testing: warning: no tests to run
PASS
ok  	gopkg.in/auth0.v5/internal/testing/expect	(cached) [no tests to run]
=== RUN   TestPrompt
=== RUN   TestPrompt/Read
    prompt_test.go:14: {
          "universal_login_experience": "classic"
        }
=== RUN   TestPrompt/Update
    prompt_test.go:48: {
          "universal_login_experience": "new",
          "identifier_first": true
        }
--- PASS: TestPrompt (1.67s)
    --- PASS: TestPrompt/Read (1.24s)
    --- PASS: TestPrompt/Update (0.42s)
PASS
ok  	gopkg.in/auth0.v5/management	1.956s
```

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->