### PR TITLE
Add description field to logs

### DIFF
--- a/management/log.go
+++ b/management/log.go
@@ -69,6 +69,9 @@ type Log struct {
 	// The log event type
 	Type *string `json:"type"`
 
+	// The log event description
+	Description *string `json:"description"`
+
 	// The id of the client
 	ClientID *string `json:"client_id"`
 

--- a/management/management.gen.go
+++ b/management/management.gen.go
@@ -402,6 +402,30 @@ func (c *ClientRefreshToken) GetExpirationType() string {
 	return *c.ExpirationType
 }
 
+// GetIdleTokenLifetime returns the IdleTokenLifetime field if it's non-nil, zero value otherwise.
+func (c *ClientRefreshToken) GetIdleTokenLifetime() int {
+	if c == nil || c.IdleTokenLifetime == nil {
+		return 0
+	}
+	return *c.IdleTokenLifetime
+}
+
+// GetInfiniteIdleTokenLifetime returns the InfiniteIdleTokenLifetime field if it's non-nil, zero value otherwise.
+func (c *ClientRefreshToken) GetInfiniteIdleTokenLifetime() bool {
+	if c == nil || c.InfiniteIdleTokenLifetime == nil {
+		return false
+	}
+	return *c.InfiniteIdleTokenLifetime
+}
+
+// GetInfiniteTokenLifetime returns the InfiniteTokenLifetime field if it's non-nil, zero value otherwise.
+func (c *ClientRefreshToken) GetInfiniteTokenLifetime() bool {
+	if c == nil || c.InfiniteTokenLifetime == nil {
+		return false
+	}
+	return *c.InfiniteTokenLifetime
+}
+
 // GetLeeway returns the Leeway field if it's non-nil, zero value otherwise.
 func (c *ClientRefreshToken) GetLeeway() int {
 	if c == nil || c.Leeway == nil {
@@ -4142,6 +4166,14 @@ func (t *TenantUniversalLoginColors) GetPageBackground() string {
 	return *t.PageBackground
 }
 
+// GetPageBackgroundGradient returns the PageBackgroundGradient field.
+func (t *TenantUniversalLoginColors) GetPageBackgroundGradient() *BrandingPageBackgroundGradient {
+	if t == nil {
+		return nil
+	}
+	return t.PageBackgroundGradient
+}
+
 // GetPrimary returns the Primary field if it's non-nil, zero value otherwise.
 func (t *TenantUniversalLoginColors) GetPrimary() string {
 	if t == nil || t.Primary == nil {
@@ -4171,20 +4203,20 @@ func (t *Ticket) GetEmail() string {
 	return *t.Email
 }
 
-// GetMarkEmailAsVerified returns the MarkEmailAsVerified field if it's non-nil, zero value otherwise.
-func (t *Ticket) GetMarkEmailAsVerified() bool {
-	if t == nil || t.MarkEmailAsVerified == nil {
-		return false
-	}
-	return *t.MarkEmailAsVerified
-}
-
 // GetIncludeEmailInRedirect returns the IncludeEmailInRedirect field if it's non-nil, zero value otherwise.
 func (t *Ticket) GetIncludeEmailInRedirect() bool {
 	if t == nil || t.IncludeEmailInRedirect == nil {
 		return false
 	}
 	return *t.IncludeEmailInRedirect
+}
+
+// GetMarkEmailAsVerified returns the MarkEmailAsVerified field if it's non-nil, zero value otherwise.
+func (t *Ticket) GetMarkEmailAsVerified() bool {
+	if t == nil || t.MarkEmailAsVerified == nil {
+		return false
+	}
+	return *t.MarkEmailAsVerified
 }
 
 // GetResultURL returns the ResultURL field if it's non-nil, zero value otherwise.
@@ -4442,6 +4474,14 @@ func (u *UserIdentity) GetProvider() string {
 	return *u.Provider
 }
 
+// GetRefreshToken returns the RefreshToken field if it's non-nil, zero value otherwise.
+func (u *UserIdentity) GetRefreshToken() string {
+	if u == nil || u.RefreshToken == nil {
+		return ""
+	}
+	return *u.RefreshToken
+}
+
 // GetUserID returns the UserID field if it's non-nil, zero value otherwise.
 func (u *UserIdentity) GetUserID() string {
 	if u == nil || u.UserID == nil {
@@ -4452,6 +4492,43 @@ func (u *UserIdentity) GetUserID() string {
 
 // String returns a string representation of UserIdentity.
 func (u *UserIdentity) String() string {
+	return Stringify(u)
+}
+
+// GetConnectionID returns the ConnectionID field if it's non-nil, zero value otherwise.
+func (u *UserIdentityLink) GetConnectionID() string {
+	if u == nil || u.ConnectionID == nil {
+		return ""
+	}
+	return *u.ConnectionID
+}
+
+// GetLinkWith returns the LinkWith field if it's non-nil, zero value otherwise.
+func (u *UserIdentityLink) GetLinkWith() string {
+	if u == nil || u.LinkWith == nil {
+		return ""
+	}
+	return *u.LinkWith
+}
+
+// GetProvider returns the Provider field if it's non-nil, zero value otherwise.
+func (u *UserIdentityLink) GetProvider() string {
+	if u == nil || u.Provider == nil {
+		return ""
+	}
+	return *u.Provider
+}
+
+// GetUserID returns the UserID field if it's non-nil, zero value otherwise.
+func (u *UserIdentityLink) GetUserID() string {
+	if u == nil || u.UserID == nil {
+		return ""
+	}
+	return *u.UserID
+}
+
+// String returns a string representation of UserIdentityLink.
+func (u *UserIdentityLink) String() string {
 	return Stringify(u)
 }
 

--- a/management/management.gen.go
+++ b/management/management.gen.go
@@ -3111,6 +3111,14 @@ func (l *Log) GetDate() time.Time {
 	return *l.Date
 }
 
+// GetDescription returns the Description field if it's non-nil, zero value otherwise.
+func (l *Log) GetDescription() string {
+	if l == nil || l.Description == nil {
+		return ""
+	}
+	return *l.Description
+}
+
 // GetID returns the ID field if it's non-nil, zero value otherwise.
 func (l *Log) GetID() string {
 	if l == nil || l.ID == nil {


### PR DESCRIPTION
### Proposed Changes

* `description` is added in the `Log` struct
* sync'ed accessors with `gen-methods`

#### Acceptance Test Output

<details>
<summary>$ go test ./... -v -run TestLog</summary>

```
=== RUN   TestLog
=== RUN   TestLog/List
    log_test.go:24: {
          "_id": "90020210126192811425000155054908796690747930870001172578",
          "log_id": "90020210126192811425000155054908796690747930870001172578",
          "date": "2021-01-26T19:28:06.431Z",
          "type": "sapi",
          "description": "Create a log stream",
          "client_id": "<client_id_redacted>",
          "client_name": "",
          "ip": "<ip_redacted>",
          "location_info": null,
          "details": {
            "request": {
              "auth": {
                "credentials": {},
                "strategy": "jwt",
                "user": {}
              },
              "body": {
                "name": "Test-LogStream-1611689286",
                "sink": {
                  "awsRegion": "us-west-2"
                },
                "type": "eventbridge"
              },
              "channel": "api",
              "ip": "<ip_redacted>",
              "method": "post",
              "path": "/api/v2/log-streams",
              "query": {},
              "userAgent": "Go-Auth0-SDK/latest"
            },
            "response": {
              "body": {
                "id": "lst_0000000000002921",
                "name": "Test-LogStream-1611689286",
                "sink": {
                  "awsRegion": "us-west-2"
                },
                "type": "eventbridge"
              },
              "statusCode": 200
            }
          },
          "user_id": null
        }
    log_test.go:24: {
          "_id": "90020210126192811225000155054501388689537800769405714530",
          "log_id": "90020210126192811225000155054501388689537800769405714530",
          "date": "2021-01-26T19:28:07.407Z",
          "type": "sapi",
          "description": "Delete log stream",
          "client_id": "<client_id_redacted>",
          "client_name": "",
          "ip": "<ip_redacted>",
          "location_info": null,
          "details": {
            "request": {
              "auth": {
                "credentials": {},
                "strategy": "jwt",
                "user": {}
              },
              "body": {},
              "channel": "api",
              "ip": "<ip_redacted>",
              "method": "delete",
              "path": "/api/v2/log-streams/lst_0000000000002924",
              "query": {},
              "userAgent": "Go-Auth0-SDK/latest"
            },
            "response": {
              "body": {},
              "statusCode": 204
            }
          },
          "user_id": null
        }
    log_test.go:24: {
          "_id": "90020210126192811224000155054500179763718186140231008354",
          "log_id": "90020210126192811224000155054500179763718186140231008354",
          "date": "2021-01-26T19:28:06.734Z",
          "type": "sapi",
          "description": "Create a log stream",
          "client_id": "<client_id_redacted>",
          "client_name": "",
          "ip": "<ip_redacted>",
          "location_info": null,
          "details": {
            "request": {
              "auth": {
                "credentials": {},
                "strategy": "jwt",
                "user": {}
              },
              "body": {
                "name": "Test-LogStream-1611689286",
                "sink": {
                  "httpContentFormat": "JSONLINES",
                  "httpContentType": "application/json"
                },
                "type": "http"
              },
              "channel": "api",
              "ip": "<ip_redacted>",
              "method": "post",
              "path": "/api/v2/log-streams",
              "query": {},
              "userAgent": "Go-Auth0-SDK/latest"
            },
            "response": {
              "body": {
                "id": "lst_0000000000002922",
                "name": "Test-LogStream-1611689286",
                "sink": {
                  "httpContentFormat": "JSONLINES",
                  "httpContentType": "application/json"
                },
                "type": "http"
              },
              "statusCode": 200
            }
          },
          "user_id": null
        }
    log_test.go:24: {
          "_id": "90020210126192810826000571785733486818896153766858326066",
          "log_id": "90020210126192810826000571785733486818896153766858326066",
          "date": "2021-01-26T19:28:06.99Z",
          "type": "sapi",
          "description": "Create a log stream",
          "client_id": "<client_id_redacted>",
          "client_name": "",
          "ip": "<ip_redacted>",
          "location_info": null,
          "details": {
            "request": {
              "auth": {
                "credentials": {},
                "strategy": "jwt",
                "user": {}
              },
              "body": {
                "name": "Test-LogStream-1611689286",
                "type": "datadog"
              },
              "channel": "api",
              "ip": "<ip_redacted>",
              "method": "post",
              "path": "/api/v2/log-streams",
              "query": {},
              "userAgent": "Go-Auth0-SDK/latest"
            },
            "response": {
              "body": {
                "id": "lst_0000000000002923",
                "name": "Test-LogStream-1611689286",
                "type": "datadog"
              },
              "statusCode": 200
            }
          },
          "user_id": null
        }
    log_test.go:24: {
          "_id": "90020210126192810826000571785731068967256924508508913714",
          "log_id": "90020210126192810826000571785731068967256924508508913714",
          "date": "2021-01-26T19:28:06.046Z",
          "type": "sapi",
          "description": "Update a log stream",
          "client_id": "<client_id_redacted>",
          "client_name": "",
          "ip": "<ip_redacted>",
          "location_info": null,
          "details": {
            "request": {
              "auth": {
                "credentials": {},
                "strategy": "jwt",
                "user": {}
              },
              "body": {},
              "channel": "api",
              "ip": "<ip_redacted>",
              "method": "patch",
              "path": "/api/v2/log-streams/lst_0000000000002920",
              "query": {},
              "userAgent": "Go-Auth0-SDK/latest"
            },
            "response": {
              "body": {
                "id": "lst_0000000000002920",
                "name": "Test-LogStream-1611689284",
                "type": "datadog"
              },
              "statusCode": 200
            }
          },
          "user_id": null
        }
=== RUN   TestLog/Read
    log_test.go:38: {
          "_id": "90020210126192811425000155054908796690747930870001172578",
          "log_id": "90020210126192811425000155054908796690747930870001172578",
          "date": "2021-01-26T19:28:06.431Z",
          "type": "sapi",
          "description": "Create a log stream",
          "client_id": "<client_id_redacted>",
          "client_name": "",
          "ip": "<ip_redacted>",
          "location_info": null,
          "details": {
            "request": {
              "auth": {
                "credentials": {},
                "strategy": "jwt",
                "user": {}
              },
              "body": {
                "name": "Test-LogStream-1611689286",
                "sink": {
                  "awsRegion": "us-west-2"
                },
                "type": "eventbridge"
              },
              "channel": "api",
              "ip": "<ip_redacted>",
              "method": "post",
              "path": "/api/v2/log-streams",
              "query": {},
              "userAgent": "Go-Auth0-SDK/latest"
            },
            "response": {
              "body": {
                "id": "lst_0000000000002921",
                "name": "Test-LogStream-1611689286",
                "sink": {
                  "awsRegion": "us-west-2"
                },
                "type": "eventbridge"
              },
              "statusCode": 200
            }
          },
          "user_id": null
        }
=== RUN   TestLog/Search
--- PASS: TestLog (0.41s)
    --- PASS: TestLog/List (0.14s)
    --- PASS: TestLog/Read (0.08s)
    --- PASS: TestLog/Search (0.19s)
PASS
```
</details>

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->