### PR TITLE
Add application signing key endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ The following Auth0 resources are supported:
 - [x] [Tenants](https://auth0.com/docs/api/management/v2#!/Tenants/get_settings)
 - [ ] [Anomaly](https://auth0.com/docs/api/management/v2#!/Anomaly/get_ips_by_id)
 - [x] [Tickets](https://auth0.com/docs/api/management/v2#!/Tickets/post_email_verification)
+- [x] [Signing Keys](https://auth0.com/docs/api/management/v2#!/Keys/get_signing_keys)
 
 ## What is Auth0?
 

--- a/management/management.gen.go
+++ b/management/management.gen.go
@@ -3898,6 +3898,107 @@ func (r *RuleList) String() string {
 	return Stringify(r)
 }
 
+// GetCert returns the Cert field if it's non-nil, zero value otherwise.
+func (s *SigningKey) GetCert() string {
+	if s == nil || s.Cert == nil {
+		return ""
+	}
+	return *s.Cert
+}
+
+// GetCurrent returns the Current field if it's non-nil, zero value otherwise.
+func (s *SigningKey) GetCurrent() bool {
+	if s == nil || s.Current == nil {
+		return false
+	}
+	return *s.Current
+}
+
+// GetCurrentSince returns the CurrentSince field if it's non-nil, zero value otherwise.
+func (s *SigningKey) GetCurrentSince() time.Time {
+	if s == nil || s.CurrentSince == nil {
+		return time.Time{}
+	}
+	return *s.CurrentSince
+}
+
+// GetCurrentUntil returns the CurrentUntil field if it's non-nil, zero value otherwise.
+func (s *SigningKey) GetCurrentUntil() time.Time {
+	if s == nil || s.CurrentUntil == nil {
+		return time.Time{}
+	}
+	return *s.CurrentUntil
+}
+
+// GetFingerprint returns the Fingerprint field if it's non-nil, zero value otherwise.
+func (s *SigningKey) GetFingerprint() string {
+	if s == nil || s.Fingerprint == nil {
+		return ""
+	}
+	return *s.Fingerprint
+}
+
+// GetKID returns the KID field if it's non-nil, zero value otherwise.
+func (s *SigningKey) GetKID() string {
+	if s == nil || s.KID == nil {
+		return ""
+	}
+	return *s.KID
+}
+
+// GetNext returns the Next field if it's non-nil, zero value otherwise.
+func (s *SigningKey) GetNext() bool {
+	if s == nil || s.Next == nil {
+		return false
+	}
+	return *s.Next
+}
+
+// GetPKCS7 returns the PKCS7 field if it's non-nil, zero value otherwise.
+func (s *SigningKey) GetPKCS7() string {
+	if s == nil || s.PKCS7 == nil {
+		return ""
+	}
+	return *s.PKCS7
+}
+
+// GetPrevious returns the Previous field if it's non-nil, zero value otherwise.
+func (s *SigningKey) GetPrevious() bool {
+	if s == nil || s.Previous == nil {
+		return false
+	}
+	return *s.Previous
+}
+
+// GetRevoked returns the Revoked field if it's non-nil, zero value otherwise.
+func (s *SigningKey) GetRevoked() bool {
+	if s == nil || s.Revoked == nil {
+		return false
+	}
+	return *s.Revoked
+}
+
+// GetRevokedAt returns the RevokedAt field if it's non-nil, zero value otherwise.
+func (s *SigningKey) GetRevokedAt() time.Time {
+	if s == nil || s.RevokedAt == nil {
+		return time.Time{}
+	}
+	return *s.RevokedAt
+}
+
+// GetThumbprint returns the Thumbprint field if it's non-nil, zero value otherwise.
+func (s *SigningKey) GetThumbprint() string {
+	if s == nil || s.Thumbprint == nil {
+		return ""
+	}
+	return *s.Thumbprint
+}
+
+// String returns a string representation of SigningKey.
+func (s *SigningKey) String() string {
+	return Stringify(s)
+}
+
 // GetChangePassword returns the ChangePassword field.
 func (t *Tenant) GetChangePassword() *TenantChangePassword {
 	if t == nil {

--- a/management/management.go
+++ b/management/management.go
@@ -153,6 +153,9 @@ type Management struct {
 	// Blacklist manages the auth0 blacklists
 	Blacklist *BlacklistManager
 
+	// SigningKey manages Auth0 Application Signing Keys.
+	SigningKey *SigningKeyManager
+
 	url         *url.URL
 	basePath    string
 	userAgent   string
@@ -219,6 +222,7 @@ func New(domain string, options ...ManagementOption) (*Management, error) {
 	m.Guardian = newGuardianManager(m)
 	m.Prompt = newPromptManager(m)
 	m.Blacklist = newBlacklistManager(m)
+	m.SigningKey = newSigningKeyManager(m)
 
 	return m, nil
 }

--- a/management/management_test.go
+++ b/management/management_test.go
@@ -22,6 +22,10 @@ var (
 )
 
 func init() {
+	initTestManagement()
+}
+
+func initTestManagement() {
 	var err error
 	m, err = New(domain,
 		WithClientCredentials(clientID, clientSecret),

--- a/management/signing_key.go
+++ b/management/signing_key.go
@@ -1,0 +1,82 @@
+package management
+
+import "time"
+
+type SigningKey struct {
+
+	// The key id of the signing key.
+	KID *string `json:"kid,omitempty"`
+
+	// The public certificate of the signing key.
+	Cert *string `json:"cert,omitempty"`
+
+	// The public certificate of the signing key in pkcs7 format.
+	PKCS7 *string `json:"pkcs7,omitempty"`
+
+	// True if the key is the the current key.
+	Current *bool `json:"current,omitempty"`
+
+	// True if the key is the the next key.
+	Next *bool `json:"next,omitempty"`
+
+	// True if the key is the the previous key.
+	Previous *bool `json:"previous,omitempty"`
+
+	// The date and time when the key became the current key.
+	CurrentSince *time.Time `json:"current_since,omitempty"`
+
+	// The date and time when the current key was rotated.
+	CurrentUntil *time.Time `json:"current_until,omitempty"`
+
+	// The cert fingerprint.
+	Fingerprint *string `json:"fingerprint,omitempty"`
+
+	// The cert thumbprint.
+	Thumbprint *string `json:"thumbprint,omitempty"`
+
+	// True if the key is revoked.
+	Revoked *bool `json:"revoked,omitempty"`
+
+	// The date and time when the key was revoked.
+	RevokedAt *time.Time `json:"revoked_at,omitempty"`
+}
+
+type SigningKeyManager struct {
+	*Management
+}
+
+func newSigningKeyManager(m *Management) *SigningKeyManager {
+	return &SigningKeyManager{m}
+}
+
+// List all Application Signing Keys.
+//
+// See: https://auth0.com/docs/api/management/v2#!/Keys/get_signing_keys
+func (m *SigningKeyManager) List(opts ...RequestOption) (ks []*SigningKey, err error) {
+	err = m.Request("GET", m.URI("keys", "signing"), &ks, opts...)
+	return
+}
+
+// Read an Application Signing Key by its key id.
+//
+// See: https://auth0.com/docs/api/management/v2#!/Keys/get_signing_key
+func (m *SigningKeyManager) Read(kid string, opts ...RequestOption) (k *SigningKey, err error) {
+	err = m.Request("GET", m.URI("keys", "signing", kid), &k, opts...)
+	return
+}
+
+// Rotate the Application Signing Key.
+//
+// See: https://auth0.com/docs/api/management/v2#!/Keys/post_signing_keys
+func (m *SigningKeyManager) Rotate(opts ...RequestOption) (k *SigningKey, err error) {
+	err = m.Request("POST", m.URI("keys", "signing", "rotate"), &k, opts...)
+	return
+}
+
+// Revoke an Application Signing Key by its key id.
+//
+// See: https://auth0.com/docs/api/management/v2#!/Keys/put_signing_keys
+func (m *SigningKeyManager) Revoke(kid string, opts ...RequestOption) (k *SigningKey, err error) {
+	err = m.Request("PUT", m.URI("keys", "signing", kid, "revoke"), &k, opts...)
+	return
+}

--- a/management/signing_key_test.go
+++ b/management/signing_key_test.go
@@ -1,0 +1,72 @@
+package management
+
+import (
+	"testing"
+)
+
+func TestSigningKey(t *testing.T) {
+
+	var kid string
+
+	// Our last test revokes the key used to sign the token we're currently
+	// using, so we need to re-authenticate so that subsequent tests still work.
+	t.Cleanup(func() {
+		initTestManagement()
+	})
+
+	t.Run("List", func(t *testing.T) {
+		ks, err := m.SigningKey.List()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(ks) == 0 {
+			t.Error("expected at least one key to be returned")
+		}
+
+		// save kid for later use
+		kid = ks[0].GetKID()
+
+		t.Logf("%v\n", ks)
+	})
+
+	t.Run("Read", func(t *testing.T) {
+		k, err := m.SigningKey.Read(kid)
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Logf("%v\n", k)
+	})
+
+	t.Run("Rotate", func(t *testing.T) {
+		k, err := m.SigningKey.Rotate()
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Logf("%v\n", k)
+	})
+
+	t.Run("Revoke", func(t *testing.T) {
+		ks, err := m.SigningKey.List()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		var pk *SigningKey
+		for _, k := range ks {
+			if k.GetPrevious() {
+				pk = k
+				break
+			}
+		}
+
+		if pk == nil {
+			t.Fatal("previous key not found, nothing to revoke")
+		}
+
+		r, err := m.SigningKey.Revoke(pk.GetKID())
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Logf("%v\n", r)
+	})
+}


### PR DESCRIPTION
### Proposed Changes

This PR adds [application signing key endpoints](https://auth0.com/docs/api/management/v2#!/Keys/get_signing_keys) to the SDK.

**NOTE:** There are a bunch of unrelated `go generate` changes that I'd like to resolve in https://github.com/go-auth0/auth0/pull/189 first (then rebase this one).

#### Acceptance Test Output

```
$ go test ./... -v -run TestKey
ok  	gopkg.in/auth0.v5	(cached) [no tests to run]
ok  	gopkg.in/auth0.v5/internal/client	(cached) [no tests to run]
ok  	gopkg.in/auth0.v5/internal/tag	(cached) [no tests to run]
ok  	gopkg.in/auth0.v5/internal/testing/expect	(cached) [no tests to run]
ok  	gopkg.in/auth0.v5/management	1.780s
...
```

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->
