### PR TITLE
Fixed problem with omitted enabled_clients on connection

### DIFF
--- a/management/connection.go
+++ b/management/connection.go
@@ -61,9 +61,8 @@ type Connection struct {
 	Options interface{} `json:"-"`
 
 	// The identifiers of the clients for which the connection is to be
-	// enabled. If the array is empty or the property is not specified, no
-	// clients are enabled.
-	EnabledClients []interface{} `json:"enabled_clients,omitempty"`
+	// enabled. If the array is empty, no clients are enabled.
+	EnabledClients []interface{} `json:"enabled_clients"`
 
 	// Defines the realms for which the connection will be used (ie: email
 	// domains). If the array is empty or the property is not specified, the


### PR DESCRIPTION
### Proposed Changes
Not omitting empty `enabled_clients`, as this does not work as expected.
* Related to https://github.com/alexkappa/terraform-provider-auth0/issues/325

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->