### PR TITLE
Add missing user fields provided by Twitter

### DIFF
--- a/management/management.gen.go
+++ b/management/management.gen.go
@@ -4336,6 +4336,14 @@ func (u *User) GetCreatedAt() time.Time {
 	return *u.CreatedAt
 }
 
+// GetDescription returns the Description field if it's non-nil, zero value otherwise.
+func (u *User) GetDescription() string {
+	if u == nil || u.Description == nil {
+		return ""
+	}
+	return *u.Description
+}
+
 // GetEmail returns the Email field if it's non-nil, zero value otherwise.
 func (u *User) GetEmail() string {
 	if u == nil || u.Email == nil {
@@ -4390,6 +4398,14 @@ func (u *User) GetLastLogin() time.Time {
 		return time.Time{}
 	}
 	return *u.LastLogin
+}
+
+// GetLocation returns the Location field if it's non-nil, zero value otherwise.
+func (u *User) GetLocation() string {
+	if u == nil || u.Location == nil {
+		return ""
+	}
+	return *u.Location
 }
 
 // GetLoginsCount returns the LoginsCount field if it's non-nil, zero value otherwise.
@@ -4448,12 +4464,28 @@ func (u *User) GetPicture() string {
 	return *u.Picture
 }
 
+// GetScreenName returns the ScreenName field if it's non-nil, zero value otherwise.
+func (u *User) GetScreenName() string {
+	if u == nil || u.ScreenName == nil {
+		return ""
+	}
+	return *u.ScreenName
+}
+
 // GetUpdatedAt returns the UpdatedAt field if it's non-nil, zero value otherwise.
 func (u *User) GetUpdatedAt() time.Time {
 	if u == nil || u.UpdatedAt == nil {
 		return time.Time{}
 	}
 	return *u.UpdatedAt
+}
+
+// GetURL returns the URL field if it's non-nil, zero value otherwise.
+func (u *User) GetURL() string {
+	if u == nil || u.URL == nil {
+		return ""
+	}
+	return *u.URL
 }
 
 // GetUsername returns the Username field if it's non-nil, zero value otherwise.

--- a/management/user.go
+++ b/management/user.go
@@ -37,6 +37,15 @@ type User struct {
 	// The user's nickname
 	Nickname *string `json:"nickname,omitempty"`
 
+	// The screen name, handle, or alias that this user identifies themselves with
+	ScreenName *string `json:"screen_name,omitempty"`
+
+	// The user-defined UTF-8 string describing their account
+	Description *string `json:"description,omitempty"`
+
+	// The user-defined location for this account’s profile
+	Location *string `json:"location,omitempty"`
+
 	// The user's password (mandatory for non SMS connections)
 	Password *string `json:"password,omitempty"`
 
@@ -84,6 +93,9 @@ type User struct {
 	// The user's picture url
 	Picture *string `json:"picture,omitempty"`
 
+	// A URL provided by the user in association with their profile
+	URL *string `json:"url,omitempty"`
+
 	// True if the user is blocked from the application, false if the user is enabled
 	Blocked *bool `json:"blocked,omitempty"`
 
@@ -98,7 +110,6 @@ type User struct {
 //
 // We have to use a custom one due to possible inconsistencies in value types.
 func (u *User) UnmarshalJSON(b []byte) error {
-
 	type user User
 	type userAlias struct {
 		*user
@@ -130,8 +141,8 @@ func (u *User) UnmarshalJSON(b []byte) error {
 
 	return nil
 }
-func (u *User) MarshalJSON() ([]byte, error) {
 
+func (u *User) MarshalJSON() ([]byte, error) {
 	type user User
 	type userAlias struct {
 		*user
@@ -176,7 +187,6 @@ type UserIdentity struct {
 //
 // See https://community.auth0.com/t/users-user-id-returns-inconsistent-type-for-identities-user-id/39236
 func (i *UserIdentity) UnmarshalJSON(b []byte) error {
-
 	type userIdentity UserIdentity
 	type userIdentityAlias struct {
 		*userIdentity
@@ -207,7 +217,6 @@ func (i *UserIdentity) UnmarshalJSON(b []byte) error {
 }
 
 func (i *UserIdentity) MarshalJSON() ([]byte, error) {
-
 	type userIdentity UserIdentity
 	type userIdentityAlias struct {
 		*userIdentity


### PR DESCRIPTION
See https://developer.twitter.com/en/docs/twitter-api/v1/data-dictionary/object-model/user

Here's the raw JSON for my Twitter account copied from the Auth0 console:

```
{
    "created_at": "2021-02-09T17:32:08.973Z",
    "description": "Freelance cloud consultant by day. Aspiring product builder by night.",
    "identities": [
        {
            "provider": "twitter",
            "user_id": "295919262",
            "connection": "twitter",
            "isSocial": true
        }
    ],
    "location": "Hamburg 🇩🇪",
    "name": "Mathias Lafeldt",
    "nickname": "Mathias Lafeldt",
    "picture": "https://pbs.twimg.com/profile_images/1069419719227146240/e8l9msvL_normal.jpg",
    "screen_name": "mlafeldt",
    "updated_at": "2021-02-11T08:56:51.590Z",
    "url": "https://t.co/jXqmcnVmL5",
    "user_id": "twitter|295919262",
    "blocked": false,
    "last_ip": "1.2.3.4",
    "last_login": "2021-02-10T22:10:18.916Z",
    "logins_count": 3,
    "blocked_for": [],
    "guardian_authenticators": []
}
```