### PR TITLE
fix: add missing AzureAD connection option

### DIFF
--- a/management/connection.go
+++ b/management/connection.go
@@ -627,8 +627,8 @@ type ConnectionOptionsAzureAD struct {
 	AgreedTerms     *bool `json:"ext_agreed_terms,omitempty" scope:"ext_agreed_terms"`
 	AssignedPlans   *bool `json:"ext_assigned_plans,omitempty" scope:"ext_assigned_plans"`
 
-	SetUserAttributes *string `json:"set_user_root_attributes,omitempty"`
-	SetEmailVerified  *string `json:"should_trust_email_verified_connection,omitempty"`
+	SetUserAttributes  *string `json:"set_user_root_attributes,omitempty"`
+	TrustEmailVerified *string `json:"should_trust_email_verified_connection,omitempty"`
 }
 
 func (c *ConnectionOptionsAzureAD) Scopes() []string {

--- a/management/connection.go
+++ b/management/connection.go
@@ -628,6 +628,7 @@ type ConnectionOptionsAzureAD struct {
 	AssignedPlans   *bool `json:"ext_assigned_plans,omitempty" scope:"ext_assigned_plans"`
 
 	SetUserAttributes *string `json:"set_user_root_attributes,omitempty"`
+	SetEmailVerified  *string `json:"should_trust_email_verified_connection,omitempty"`
 }
 
 func (c *ConnectionOptionsAzureAD) Scopes() []string {

--- a/management/management.gen.go
+++ b/management/management.gen.go
@@ -885,14 +885,6 @@ func (c *ConnectionOptionsAzureAD) GetNestedGroups() bool {
 	return *c.NestedGroups
 }
 
-// GetSetEmailVerified returns the SetEmailVerified field if it's non-nil, zero value otherwise.
-func (c *ConnectionOptionsAzureAD) GetSetEmailVerified() string {
-	if c == nil || c.SetEmailVerified == nil {
-		return ""
-	}
-	return *c.SetEmailVerified
-}
-
 // GetSetUserAttributes returns the SetUserAttributes field if it's non-nil, zero value otherwise.
 func (c *ConnectionOptionsAzureAD) GetSetUserAttributes() string {
 	if c == nil || c.SetUserAttributes == nil {
@@ -907,6 +899,14 @@ func (c *ConnectionOptionsAzureAD) GetTenantDomain() string {
 		return ""
 	}
 	return *c.TenantDomain
+}
+
+// GetTrustEmailVerified returns the TrustEmailVerified field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsAzureAD) GetTrustEmailVerified() string {
+	if c == nil || c.TrustEmailVerified == nil {
+		return ""
+	}
+	return *c.TrustEmailVerified
 }
 
 // GetUseCommonEndpoint returns the UseCommonEndpoint field if it's non-nil, zero value otherwise.

--- a/management/management.gen.go
+++ b/management/management.gen.go
@@ -885,6 +885,14 @@ func (c *ConnectionOptionsAzureAD) GetNestedGroups() bool {
 	return *c.NestedGroups
 }
 
+// GetSetEmailVerified returns the SetEmailVerified field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsAzureAD) GetSetEmailVerified() string {
+	if c == nil || c.SetEmailVerified == nil {
+		return ""
+	}
+	return *c.SetEmailVerified
+}
+
 // GetSetUserAttributes returns the SetUserAttributes field if it's non-nil, zero value otherwise.
 func (c *ConnectionOptionsAzureAD) GetSetUserAttributes() string {
 	if c == nil || c.SetUserAttributes == nil {


### PR DESCRIPTION
The AzureAD connection type has an advanced option that is currently missing from this API.
It lets you choose whether or not to set the email_verified to true when a new user connects.
Due to the complexities of the azure connections, there are ramifications to setting this which are explained in the auth0 docs.

Adding the extra optional attribute in here so that it can be subsequently added to the terraform provider.

### Proposed Changes

* add optional TrustEmailVerified option to the AzureAD connection object

#### Acceptance Test Output

Unfortunately there are currently no AzureAD specific tests, so nothing to modify.

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->