### PR TITLE
add ProvisioningTicketUrl to Connection

### DIFF
--- a/management/connection.go
+++ b/management/connection.go
@@ -71,6 +71,9 @@ type Connection struct {
 	Realms []interface{} `json:"realms,omitempty"`
 
 	Metadata map[string]string `json:"metadata,omitempty"`
+
+	// Provisioning Ticket URL is Ticket URL for Active Directory/LDAP, etc.
+	ProvisioningTicketUrl *string `json:"provisioning_ticket_url,omitempty"`
 }
 
 func (c *Connection) MarshalJSON() ([]byte, error) {

--- a/management/management.gen.go
+++ b/management/management.gen.go
@@ -495,6 +495,14 @@ func (c *Connection) GetName() string {
 	return *c.Name
 }
 
+// GetProvisioningTicketUrl returns the ProvisioningTicketUrl field if it's non-nil, zero value otherwise.
+func (c *Connection) GetProvisioningTicketUrl() string {
+	if c == nil || c.ProvisioningTicketUrl == nil {
+		return ""
+	}
+	return *c.ProvisioningTicketUrl
+}
+
 // GetStrategy returns the Strategy field if it's non-nil, zero value otherwise.
 func (c *Connection) GetStrategy() string {
 	if c == nil || c.Strategy == nil {


### PR DESCRIPTION
### Proposed Changes

* Add ProvisioningTicketUrl to property of management.Connection.

This item is not listed in the API documentation, but it is issued in some strategies such as "ad".
```
{
  "id":"con_xxxx",
  "options":{
    "certAuth":false,
    "disable_cache":false,
    "kerberos":false,
    "domain_aliases":[
      "idp-domain.com"
    ],
    "tenant_domain":"xyz-domain.com",
    "ips":null,
    "brute_force_protection":true
  },
  "strategy":"ad",
  "name":"xyz-test-ad-conn",
  "provisioning_ticket_url":"https://xyz-dev.us.auth0.com/p/ad/xxxx",
  "is_domain_connection":false,
  "show_as_button":false,
  "display_name":"Xyz-Test-Ad-Conn",
  "enabled_clients":[],
  "realms":[
    "xyz-test-ad-conn"
  ]
}
```

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->