### PR TITLE
Add support for Auth0 SAML connection entityId option

### DIFF
--- a/management/connection.go
+++ b/management/connection.go
@@ -688,6 +688,7 @@ type ConnectionOptionsSAML struct {
 	RequestTemplate    *string                            `json:"requestTemplate,omitempty"`
 	UserIDAttribute    *string                            `json:"user_id_attribute,omitempty"`
 	LogoURL            *string                            `json:"icon_url,omitempty"`
+	EntityID           *string                            `json:"entityId,omitempty"`
 
 	SetUserAttributes  *string   `json:"set_user_root_attributes,omitempty"`
 	NonPersistentAttrs *[]string `json:"non_persistent_attrs,omitempty"`

--- a/management/management.gen.go
+++ b/management/management.gen.go
@@ -2284,6 +2284,14 @@ func (c *ConnectionOptionsSAML) GetDigestAglorithm() string {
 	return *c.DigestAglorithm
 }
 
+// GetEntityID returns the EntityID field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsSAML) GetEntityID() string {
+	if c == nil || c.EntityID == nil {
+		return ""
+	}
+	return *c.EntityID
+}
+
 // GetExpires returns the Expires field if it's non-nil, zero value otherwise.
 func (c *ConnectionOptionsSAML) GetExpires() string {
 	if c == nil || c.Expires == nil {


### PR DESCRIPTION
### Proposed Changes

* Add `EntityID` field to the `ConnectionOptionsSAML` structure which maps to the `options.entityId` field of the Auth0 Connection object for SAML connections.

#### Acceptance Test Output

```
$ go test ./... -v -run TestConnection

...
```

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->