### PR TITLE
Add .env config file support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ vendor/
 # Ignore all local history of files
 .history
 .ionide
+
+### Local .env file
+.env

--- a/README.md
+++ b/README.md
@@ -79,6 +79,17 @@ The following Auth0 resources are supported:
 - [x] [Tickets](https://auth0.com/docs/api/management/v2#!/Tickets/post_email_verification)
 - [x] [Signing Keys](https://auth0.com/docs/api/management/v2#!/Keys/get_signing_keys)
 
+### Tests
+
+The tests must run against an Auth0 tenant. They also need an [M2M app](https://auth0.com/docs/applications/set-up-an-application/register-machine-to-machine-applications) in that tenant that has been authorized to call the Management API. You can easily set one of these up by creating an [API Explorer Application](https://auth0.com/docs/tokens/management-api-access-tokens/create-and-authorize-a-machine-to-machine-application) in your tenant.
+
+Then simply create a local `.env` file with the following settings:
+
+* `AUTH0_DOMAIN`: The **Domain** of the M2M app
+* `AUTH0_CLIENT_ID`: The **Client ID** of the M2M app
+* `AUTH0_CLIENT_SECRET`: The **Client Secret** of the M2M app
+* `AUTH0_DEBUG`: Set to `true` to call the Management API in debug mode, which dumps the HTTP requests and responses to the output
+
 ## What is Auth0?
 
 Auth0 helps you to:

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/aybabtme/iocontrol v0.0.0-20150809002002-ad15bcfc95a0 // indirect
 	github.com/benbjohnson/clock v1.0.3 // indirect
 	github.com/dustin/go-humanize v1.0.0 // indirect
+	github.com/joho/godotenv v1.3.0 // indirect
 	github.com/stretchr/testify v1.4.0
 	golang.org/x/oauth2 v0.0.0-20200902213428-5d25da1a8d43
 )

--- a/go.sum
+++ b/go.sum
@@ -107,6 +107,8 @@ github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5m
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
+github.com/joho/godotenv v1.3.0 h1:Zjp+RcGpHhGlrMbJzXTrZZPrWj+1vfm90La1wgB6Bhc=
+github.com/joho/godotenv v1.3.0/go.mod h1:7hK45KPybAkOC6peb+G5yklZfMxEjkZhHbwpqxOKXbg=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=

--- a/management/management_test.go
+++ b/management/management_test.go
@@ -10,6 +10,8 @@ import (
 	"time"
 
 	"gopkg.in/auth0.v5/internal/testing/expect"
+
+	_ "github.com/joho/godotenv/autoload"
 )
 
 var m *Management


### PR DESCRIPTION
### Proposed Changes

* Add support for using a local `.env` to drive configuration (vs. having to `export` variables explicitly)
* Nothing happens if the `.env` does not exist
* Enhanced README.md to suggest using the `.env` file

#### Acceptance Test Output

```
$ go test ./... -v

...
```

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->