### PR TITLE
Fixed minor bug when unmarshalling Policy string array

### DIFF
--- a/management/guardian.go
+++ b/management/guardian.go
@@ -186,7 +186,7 @@ func (m *MultiFactorManager) List(opts ...RequestOption) (mf []*MultiFactor, err
 //
 // See: https://auth0.com/docs/api/management/v2/#!/Guardian/get_policies
 func (m *MultiFactorManager) Policy(opts ...RequestOption) (p *MultiFactorPolicies, err error) {
-	err = m.Request("GET", m.URI("guardian", "policies"), p, opts...)
+	err = m.Request("GET", m.URI("guardian", "policies"), &p, opts...)
 	return
 }
 

--- a/management/guardian_test.go
+++ b/management/guardian_test.go
@@ -24,7 +24,10 @@ func TestGuardian(t *testing.T) {
 			if err != nil {
 				t.Error(err)
 			}
-			p, _ := m.Guardian.MultiFactor.Policy()
+			p, err := m.Guardian.MultiFactor.Policy()
+			if err != nil {
+				t.Error(err)
+			}
 			t.Logf("%v\n", p)
 		})
 


### PR DESCRIPTION
This is a bugfix to a bug that was introduced in #200. This PR resolves the bug and adds a test that would have caught the bug in the first place.
### Proposed Changes

* Resolves bug when reading policy of MFA options back from auth0

#### Acceptance Test Output

```
$ go test ./management -v -run "TestGuardian/MultiFactor/Policy"
```

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->