### PR TITLE
Support google-apps connection strategy

### DIFF
--- a/management/connection.go
+++ b/management/connection.go
@@ -26,6 +26,7 @@ const (
 	ConnectionStrategyAD                  = "ad"
 	ConnectionStrategyAzureAD             = "waad"
 	ConnectionStrategySAML                = "samlp"
+	ConnectionStrategyGoogleApps          = "google-apps"
 )
 
 type Connection struct {
@@ -149,6 +150,8 @@ func (c *Connection) UnmarshalJSON(b []byte) error {
 			v = &ConnectionOptionsAzureAD{}
 		case ConnectionStrategySAML:
 			v = &ConnectionOptionsSAML{}
+		case ConnectionStrategyGoogleApps:
+			v = &ConnectionOptionsGoogleApps{}
 		default:
 			v = make(map[string]interface{})
 		}
@@ -702,6 +705,26 @@ type ConnectionOptionsSAMLIdpInitiated struct {
 
 	SetUserAttributes  *string   `json:"set_user_root_attributes,omitempty"`
 	NonPersistentAttrs *[]string `json:"non_persistent_attrs,omitempty"`
+}
+
+type ConnectionOptionsGoogleApps struct {
+	ClientID     *string `json:"client_id,omitempty"`
+	ClientSecret *string `json:"client_secret,omitempty"`
+	Domain       *string `json:"domain,omitempty"`
+
+	EnableUsersAPI  *bool `json:"api_enable_users,omitempty"`
+	BasicProfile    *bool `json:"basic_profile,omitempty" scope:"basic_profile"`
+	ExtendedProfile *bool `json:"ext_profile,omitempty" scope:"ext_profile"`
+	Groups          *bool `json:"ext_groups,omitempty" scope:"ext_groups"`
+	Admin           *bool `json:"ext_admin,omitempty" scope:"ext_admin"`
+	IsSuspended     *bool `json:"ext_is_suspended,omitempty" scope:"ext_is_suspended"`
+	AgreedTerms     *bool `json:"ext_agreed_terms,omitempty" scope:"ext_agreed_terms"`
+
+	SetUserAttributes  *string   `json:"set_user_root_attributes,omitempty"`
+	NonPersistentAttrs *[]string `json:"non_persistent_attrs,omitempty"`
+
+	DomainAliases []interface{} `json:"domain_aliases,omitempty"`
+	LogoURL       *string       `json:"icon_url,omitempty"`
 }
 
 type ConnectionManager struct {

--- a/management/connection_test.go
+++ b/management/connection_test.go
@@ -1,10 +1,11 @@
 package management
 
 import (
-	"github.com/stretchr/testify/assert"
 	"log"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 
 	"gopkg.in/auth0.v5"
 	"gopkg.in/auth0.v5/internal/testing/expect"
@@ -77,6 +78,8 @@ func TestConnection(t *testing.T) {
 				_, ok = c.Options.(*ConnectionOptionsAzureAD)
 			case ConnectionStrategySAML:
 				_, ok = c.Options.(*ConnectionOptionsSAML)
+			case ConnectionStrategyGoogleApps:
+				_, ok = c.Options.(*ConnectionOptionsGoogleApps)
 			default:
 				_, ok = c.Options.(map[string]interface{})
 			}

--- a/management/management.gen.go
+++ b/management/management.gen.go
@@ -1662,6 +1662,115 @@ func (c *ConnectionOptionsGitHub) String() string {
 	return Stringify(c)
 }
 
+// GetAdmin returns the Admin field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsGoogleApps) GetAdmin() bool {
+	if c == nil || c.Admin == nil {
+		return false
+	}
+	return *c.Admin
+}
+
+// GetAgreedTerms returns the AgreedTerms field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsGoogleApps) GetAgreedTerms() bool {
+	if c == nil || c.AgreedTerms == nil {
+		return false
+	}
+	return *c.AgreedTerms
+}
+
+// GetBasicProfile returns the BasicProfile field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsGoogleApps) GetBasicProfile() bool {
+	if c == nil || c.BasicProfile == nil {
+		return false
+	}
+	return *c.BasicProfile
+}
+
+// GetClientID returns the ClientID field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsGoogleApps) GetClientID() string {
+	if c == nil || c.ClientID == nil {
+		return ""
+	}
+	return *c.ClientID
+}
+
+// GetClientSecret returns the ClientSecret field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsGoogleApps) GetClientSecret() string {
+	if c == nil || c.ClientSecret == nil {
+		return ""
+	}
+	return *c.ClientSecret
+}
+
+// GetDomain returns the Domain field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsGoogleApps) GetDomain() string {
+	if c == nil || c.Domain == nil {
+		return ""
+	}
+	return *c.Domain
+}
+
+// GetEnableUsersAPI returns the EnableUsersAPI field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsGoogleApps) GetEnableUsersAPI() bool {
+	if c == nil || c.EnableUsersAPI == nil {
+		return false
+	}
+	return *c.EnableUsersAPI
+}
+
+// GetExtendedProfile returns the ExtendedProfile field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsGoogleApps) GetExtendedProfile() bool {
+	if c == nil || c.ExtendedProfile == nil {
+		return false
+	}
+	return *c.ExtendedProfile
+}
+
+// GetGroups returns the Groups field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsGoogleApps) GetGroups() bool {
+	if c == nil || c.Groups == nil {
+		return false
+	}
+	return *c.Groups
+}
+
+// GetIsSuspended returns the IsSuspended field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsGoogleApps) GetIsSuspended() bool {
+	if c == nil || c.IsSuspended == nil {
+		return false
+	}
+	return *c.IsSuspended
+}
+
+// GetLogoURL returns the LogoURL field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsGoogleApps) GetLogoURL() string {
+	if c == nil || c.LogoURL == nil {
+		return ""
+	}
+	return *c.LogoURL
+}
+
+// GetNonPersistentAttrs returns the NonPersistentAttrs field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsGoogleApps) GetNonPersistentAttrs() []string {
+	if c == nil || c.NonPersistentAttrs == nil {
+		return nil
+	}
+	return *c.NonPersistentAttrs
+}
+
+// GetSetUserAttributes returns the SetUserAttributes field if it's non-nil, zero value otherwise.
+func (c *ConnectionOptionsGoogleApps) GetSetUserAttributes() string {
+	if c == nil || c.SetUserAttributes == nil {
+		return ""
+	}
+	return *c.SetUserAttributes
+}
+
+// String returns a string representation of ConnectionOptionsGoogleApps.
+func (c *ConnectionOptionsGoogleApps) String() string {
+	return Stringify(c)
+}
+
 // GetAdsenseManagement returns the AdsenseManagement field if it's non-nil, zero value otherwise.
 func (c *ConnectionOptionsGoogleOAuth2) GetAdsenseManagement() bool {
 	if c == nil || c.AdsenseManagement == nil {


### PR DESCRIPTION
I'm still wrapping my head around the repo (and golang in general) so thanks for your patience with any simple mistakes 🙏 

### Proposed Changes

* Adds a new connection strategy for `google-apps` connections

#### Acceptance Test Output

I expected the error below to go away after setting up a test tenant and putting the domain in `.env`. Unsure what mistake I'm making here.

```
$ go test ./... -v -run TestUser

testing: warning: no tests to run
PASS
ok      gopkg.in/auth0.v5       (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      gopkg.in/auth0.v5/internal/client       (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      gopkg.in/auth0.v5/internal/tag  (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      gopkg.in/auth0.v5/internal/testing/expect       (cached) [no tests to run]
=== RUN   TestUser
    user_test.go:47: Post "https://api/v2/roles": Post "https:///oauth/token": http: no Host in request URL
--- FAIL: TestUser (0.00s)
=== RUN   TestUserIdentity
=== RUN   TestUserIdentity/MarshalJSON
=== RUN   TestUserIdentity/UnmarshalJSON
--- PASS: TestUserIdentity (0.00s)
    --- PASS: TestUserIdentity/MarshalJSON (0.00s)
    --- PASS: TestUserIdentity/UnmarshalJSON (0.00s)
FAIL
FAIL    gopkg.in/auth0.v5/management    0.018s
FAIL
```

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->