### PR TITLE
Fix JSON encode/decode of lifetime_in_seconds

### DIFF
--- a/management/client_test.go
+++ b/management/client_test.go
@@ -1,11 +1,13 @@
 package management
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 	"time"
 
 	"gopkg.in/auth0.v5"
+	"gopkg.in/auth0.v5/internal/testing/expect"
 )
 
 func TestClient(t *testing.T) {
@@ -77,4 +79,36 @@ func TestClient(t *testing.T) {
 			t.Error(err)
 		}
 	})
+}
+
+func TestJWTConfiguration(t *testing.T) {
+
+	t.Run("MarshalJSON", func(t *testing.T) {
+		for u, expected := range map[*ClientJWTConfiguration]string{
+			{}:                                   `{}`,
+			{LifetimeInSeconds: auth0.Int(1000)}: `{"lifetime_in_seconds":1000}`,
+		} {
+			b, err := json.Marshal(u)
+			if err != nil {
+				t.Error(err)
+			}
+			expect.Expect(t, string(b), expected)
+		}
+	})
+
+	t.Run("UnmarshalJSON", func(t *testing.T) {
+		for b, expected := range map[string]*ClientJWTConfiguration{
+			`{}`:                             {LifetimeInSeconds: nil},
+			`{"lifetime_in_seconds":1000}`:   {LifetimeInSeconds: auth0.Int(1000)},
+			`{"lifetime_in_seconds":"1000"}`: {LifetimeInSeconds: auth0.Int(1000)},
+		} {
+			var jc ClientJWTConfiguration
+			err := json.Unmarshal([]byte(b), &jc)
+			if err != nil {
+				t.Error(err)
+			}
+			expect.Expect(t, jc.GetLifetimeInSeconds(), expected.GetLifetimeInSeconds())
+		}
+	})
+
 }


### PR DESCRIPTION
### Proposed Changes

The Management API returns a `string` for `jwt_configuration.lifetime_in_seconds` instead of an `int` for some old tenants.
This PR implements a custom JSON marshaler and unmarshaler for `ClientJWTConfiguration` that addresses this.

Fixes https://github.com/auth0/auth0-cli/issues/274

#### Acceptance Test Output

```
go test -run TestJWTConfiguration gopkg.in/auth0.v5/management
```

<img width="486" alt="Screen Shot 2021-05-09 at 13 06 29" src="https://user-images.githubusercontent.com/5055789/117579083-c4b35680-b0c7-11eb-9e39-0c5369dfe45a.png">

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request