### PR TITLE
Add CustomText APIs

### DIFF
--- a/management/management.gen.go
+++ b/management/management.gen.go
@@ -4027,6 +4027,460 @@ func (p *Prompt) String() string {
 	return Stringify(p)
 }
 
+// GetConsent returns the Consent field.
+func (p *PromptConsent) GetConsent() *ScreenConsent {
+	if p == nil {
+		return nil
+	}
+	return p.Consent
+}
+
+// String returns a string representation of PromptConsent.
+func (p *PromptConsent) String() string {
+	return Stringify(p)
+}
+
+// GetDeviceCodeActivation returns the DeviceCodeActivation field.
+func (p *PromptDeviceFlow) GetDeviceCodeActivation() *ScreenDeviceCodeActivation {
+	if p == nil {
+		return nil
+	}
+	return p.DeviceCodeActivation
+}
+
+// GetDeviceCodeActivationAllowed returns the DeviceCodeActivationAllowed field.
+func (p *PromptDeviceFlow) GetDeviceCodeActivationAllowed() *ScreenDeviceCodeActivationAllowed {
+	if p == nil {
+		return nil
+	}
+	return p.DeviceCodeActivationAllowed
+}
+
+// GetDeviceCodeActivationDenied returns the DeviceCodeActivationDenied field.
+func (p *PromptDeviceFlow) GetDeviceCodeActivationDenied() *ScreenDeviceCodeActivationDenied {
+	if p == nil {
+		return nil
+	}
+	return p.DeviceCodeActivationDenied
+}
+
+// GetDeviceCodeConfirmation returns the DeviceCodeConfirmation field.
+func (p *PromptDeviceFlow) GetDeviceCodeConfirmation() *ScreenDeviceCodeConfirmation {
+	if p == nil {
+		return nil
+	}
+	return p.DeviceCodeConfirmation
+}
+
+// String returns a string representation of PromptDeviceFlow.
+func (p *PromptDeviceFlow) String() string {
+	return Stringify(p)
+}
+
+// GetEmailOtpChallenge returns the EmailOtpChallenge field.
+func (p *PromptEmailOtpChallenge) GetEmailOtpChallenge() *ScreenEmailOtpChallenge {
+	if p == nil {
+		return nil
+	}
+	return p.EmailOtpChallenge
+}
+
+// String returns a string representation of PromptEmailOtpChallenge.
+func (p *PromptEmailOtpChallenge) String() string {
+	return Stringify(p)
+}
+
+// GetEmailVerificationResult returns the EmailVerificationResult field.
+func (p *PromptEmailVerification) GetEmailVerificationResult() *ScreenEmailVerificationResult {
+	if p == nil {
+		return nil
+	}
+	return p.EmailVerificationResult
+}
+
+// String returns a string representation of PromptEmailVerification.
+func (p *PromptEmailVerification) String() string {
+	return Stringify(p)
+}
+
+// GetAcceptInvitation returns the AcceptInvitation field.
+func (p *PromptInvitation) GetAcceptInvitation() *ScreenAcceptInvitation {
+	if p == nil {
+		return nil
+	}
+	return p.AcceptInvitation
+}
+
+// String returns a string representation of PromptInvitation.
+func (p *PromptInvitation) String() string {
+	return Stringify(p)
+}
+
+// GetLogin returns the Login field.
+func (p *PromptLogin) GetLogin() *ScreenLogin {
+	if p == nil {
+		return nil
+	}
+	return p.Login
+}
+
+// String returns a string representation of PromptLogin.
+func (p *PromptLogin) String() string {
+	return Stringify(p)
+}
+
+// GetLoginEmailVerification returns the LoginEmailVerification field.
+func (p *PromptLoginEmailVerification) GetLoginEmailVerification() *ScreenLoginEmailVerification {
+	if p == nil {
+		return nil
+	}
+	return p.LoginEmailVerification
+}
+
+// String returns a string representation of PromptLoginEmailVerification.
+func (p *PromptLoginEmailVerification) String() string {
+	return Stringify(p)
+}
+
+// GetLoginId returns the LoginId field.
+func (p *PromptLoginId) GetLoginId() *ScreenLoginId {
+	if p == nil {
+		return nil
+	}
+	return p.LoginId
+}
+
+// String returns a string representation of PromptLoginId.
+func (p *PromptLoginId) String() string {
+	return Stringify(p)
+}
+
+// GetLoginPassword returns the LoginPassword field.
+func (p *PromptLoginPassword) GetLoginPassword() *ScreenLoginPassword {
+	if p == nil {
+		return nil
+	}
+	return p.LoginPassword
+}
+
+// String returns a string representation of PromptLoginPassword.
+func (p *PromptLoginPassword) String() string {
+	return Stringify(p)
+}
+
+// GetMfaBeginEnrollOptions returns the MfaBeginEnrollOptions field.
+func (p *PromptMfa) GetMfaBeginEnrollOptions() *ScreenMfaBeginEnrollOptions {
+	if p == nil {
+		return nil
+	}
+	return p.MfaBeginEnrollOptions
+}
+
+// GetMfaEnrollResult returns the MfaEnrollResult field.
+func (p *PromptMfa) GetMfaEnrollResult() *ScreenMfaEnrollResult {
+	if p == nil {
+		return nil
+	}
+	return p.MfaEnrollResult
+}
+
+// GetMfaLoginOptions returns the MfaLoginOptions field.
+func (p *PromptMfa) GetMfaLoginOptions() *ScreenMfaLoginOptions {
+	if p == nil {
+		return nil
+	}
+	return p.MfaLoginOptions
+}
+
+// String returns a string representation of PromptMfa.
+func (p *PromptMfa) String() string {
+	return Stringify(p)
+}
+
+// GetMfaEmailChallenge returns the MfaEmailChallenge field.
+func (p *PromptMfaEmail) GetMfaEmailChallenge() *ScreenMfaEmailChallenge {
+	if p == nil {
+		return nil
+	}
+	return p.MfaEmailChallenge
+}
+
+// GetMfaEmailList returns the MfaEmailList field.
+func (p *PromptMfaEmail) GetMfaEmailList() *ScreenMfaEmailList {
+	if p == nil {
+		return nil
+	}
+	return p.MfaEmailList
+}
+
+// String returns a string representation of PromptMfaEmail.
+func (p *PromptMfaEmail) String() string {
+	return Stringify(p)
+}
+
+// GetMfaOtpEnrollmentChallenge returns the MfaOtpEnrollmentChallenge field.
+func (p *PromptMfaOtp) GetMfaOtpEnrollmentChallenge() *ScreenMfaOtpEnrollmentChallenge {
+	if p == nil {
+		return nil
+	}
+	return p.MfaOtpEnrollmentChallenge
+}
+
+// GetMfaOtpEnrollmentCode returns the MfaOtpEnrollmentCode field.
+func (p *PromptMfaOtp) GetMfaOtpEnrollmentCode() *ScreenMfaOtpEnrollmentCode {
+	if p == nil {
+		return nil
+	}
+	return p.MfaOtpEnrollmentCode
+}
+
+// GetMfaOtpEnrollmentQr returns the MfaOtpEnrollmentQr field.
+func (p *PromptMfaOtp) GetMfaOtpEnrollmentQr() *ScreenMfaOtpEnrollmentQr {
+	if p == nil {
+		return nil
+	}
+	return p.MfaOtpEnrollmentQr
+}
+
+// String returns a string representation of PromptMfaOtp.
+func (p *PromptMfaOtp) String() string {
+	return Stringify(p)
+}
+
+// GetMfaPhoneChallenge returns the MfaPhoneChallenge field.
+func (p *PromptMfaPhone) GetMfaPhoneChallenge() *ScreenMfaPhoneChallenge {
+	if p == nil {
+		return nil
+	}
+	return p.MfaPhoneChallenge
+}
+
+// GetMfaPhoneEnrollment returns the MfaPhoneEnrollment field.
+func (p *PromptMfaPhone) GetMfaPhoneEnrollment() *ScreenMfaPhoneEnrollment {
+	if p == nil {
+		return nil
+	}
+	return p.MfaPhoneEnrollment
+}
+
+// String returns a string representation of PromptMfaPhone.
+func (p *PromptMfaPhone) String() string {
+	return Stringify(p)
+}
+
+// GetMfaPushChallengePush returns the MfaPushChallengePush field.
+func (p *PromptMfaPush) GetMfaPushChallengePush() *ScreenMfaPushChallengePush {
+	if p == nil {
+		return nil
+	}
+	return p.MfaPushChallengePush
+}
+
+// GetMfaPushEnrollmentQr returns the MfaPushEnrollmentQr field.
+func (p *PromptMfaPush) GetMfaPushEnrollmentQr() *ScreenMfaPushEnrollmentQr {
+	if p == nil {
+		return nil
+	}
+	return p.MfaPushEnrollmentQr
+}
+
+// GetMfaPushList returns the MfaPushList field.
+func (p *PromptMfaPush) GetMfaPushList() *ScreenMfaPushList {
+	if p == nil {
+		return nil
+	}
+	return p.MfaPushList
+}
+
+// GetMfaPushWelcome returns the MfaPushWelcome field.
+func (p *PromptMfaPush) GetMfaPushWelcome() *ScreenMfaPushWelcome {
+	if p == nil {
+		return nil
+	}
+	return p.MfaPushWelcome
+}
+
+// String returns a string representation of PromptMfaPush.
+func (p *PromptMfaPush) String() string {
+	return Stringify(p)
+}
+
+// GetMfaRecoveryCodeChallenge returns the MfaRecoveryCodeChallenge field.
+func (p *PromptMfaRecoveryCode) GetMfaRecoveryCodeChallenge() *ScreenMfaRecoveryCodeChallenge {
+	if p == nil {
+		return nil
+	}
+	return p.MfaRecoveryCodeChallenge
+}
+
+// GetMfaRecoveryCodeEnrollment returns the MfaRecoveryCodeEnrollment field.
+func (p *PromptMfaRecoveryCode) GetMfaRecoveryCodeEnrollment() *ScreenMfaRecoveryCodeEnrollment {
+	if p == nil {
+		return nil
+	}
+	return p.MfaRecoveryCodeEnrollment
+}
+
+// String returns a string representation of PromptMfaRecoveryCode.
+func (p *PromptMfaRecoveryCode) String() string {
+	return Stringify(p)
+}
+
+// GetMfaCountryCodes returns the MfaCountryCodes field.
+func (p *PromptMfaSms) GetMfaCountryCodes() *ScreenMfaCountryCodes {
+	if p == nil {
+		return nil
+	}
+	return p.MfaCountryCodes
+}
+
+// GetMfaSmsChallenge returns the MfaSmsChallenge field.
+func (p *PromptMfaSms) GetMfaSmsChallenge() *ScreenMfaSmsChallenge {
+	if p == nil {
+		return nil
+	}
+	return p.MfaSmsChallenge
+}
+
+// GetMfaSmsEnrollment returns the MfaSmsEnrollment field.
+func (p *PromptMfaSms) GetMfaSmsEnrollment() *ScreenMfaSmsEnrollment {
+	if p == nil {
+		return nil
+	}
+	return p.MfaSmsEnrollment
+}
+
+// GetMfaSmsList returns the MfaSmsList field.
+func (p *PromptMfaSms) GetMfaSmsList() *ScreenMfaSmsList {
+	if p == nil {
+		return nil
+	}
+	return p.MfaSmsList
+}
+
+// String returns a string representation of PromptMfaSms.
+func (p *PromptMfaSms) String() string {
+	return Stringify(p)
+}
+
+// GetMfaVoiceChallenge returns the MfaVoiceChallenge field.
+func (p *PromptMfaVoice) GetMfaVoiceChallenge() *ScreenMfaVoiceChallenge {
+	if p == nil {
+		return nil
+	}
+	return p.MfaVoiceChallenge
+}
+
+// GetMfaVoiceEnrollment returns the MfaVoiceEnrollment field.
+func (p *PromptMfaVoice) GetMfaVoiceEnrollment() *ScreenMfaVoiceEnrollment {
+	if p == nil {
+		return nil
+	}
+	return p.MfaVoiceEnrollment
+}
+
+// String returns a string representation of PromptMfaVoice.
+func (p *PromptMfaVoice) String() string {
+	return Stringify(p)
+}
+
+// GetOrganizationSelection returns the OrganizationSelection field.
+func (p *PromptOrganizations) GetOrganizationSelection() *ScreenOrganizationSelection {
+	if p == nil {
+		return nil
+	}
+	return p.OrganizationSelection
+}
+
+// String returns a string representation of PromptOrganizations.
+func (p *PromptOrganizations) String() string {
+	return Stringify(p)
+}
+
+// GetResetPassword returns the ResetPassword field.
+func (p *PromptResetPassword) GetResetPassword() *ScreenResetPassword {
+	if p == nil {
+		return nil
+	}
+	return p.ResetPassword
+}
+
+// GetResetPasswordEmail returns the ResetPasswordEmail field.
+func (p *PromptResetPassword) GetResetPasswordEmail() *ScreenResetPasswordEmail {
+	if p == nil {
+		return nil
+	}
+	return p.ResetPasswordEmail
+}
+
+// GetResetPasswordError returns the ResetPasswordError field.
+func (p *PromptResetPassword) GetResetPasswordError() *ScreenResetPasswordError {
+	if p == nil {
+		return nil
+	}
+	return p.ResetPasswordError
+}
+
+// GetResetPasswordRequest returns the ResetPasswordRequest field.
+func (p *PromptResetPassword) GetResetPasswordRequest() *ScreenResetPasswordRequest {
+	if p == nil {
+		return nil
+	}
+	return p.ResetPasswordRequest
+}
+
+// GetResetPasswordSuccess returns the ResetPasswordSuccess field.
+func (p *PromptResetPassword) GetResetPasswordSuccess() *ScreenResetPasswordSuccess {
+	if p == nil {
+		return nil
+	}
+	return p.ResetPasswordSuccess
+}
+
+// String returns a string representation of PromptResetPassword.
+func (p *PromptResetPassword) String() string {
+	return Stringify(p)
+}
+
+// GetSignup returns the Signup field.
+func (p *PromptSignup) GetSignup() *ScreenSignup {
+	if p == nil {
+		return nil
+	}
+	return p.Signup
+}
+
+// String returns a string representation of PromptSignup.
+func (p *PromptSignup) String() string {
+	return Stringify(p)
+}
+
+// GetSignupId returns the SignupId field.
+func (p *PromptSignupId) GetSignupId() *ScreenSignupId {
+	if p == nil {
+		return nil
+	}
+	return p.SignupId
+}
+
+// String returns a string representation of PromptSignupId.
+func (p *PromptSignupId) String() string {
+	return Stringify(p)
+}
+
+// GetSignupPassword returns the SignupPassword field.
+func (p *PromptSignupPassword) GetSignupPassword() *ScreenSignupPassword {
+	if p == nil {
+		return nil
+	}
+	return p.SignupPassword
+}
+
+// String returns a string representation of PromptSignupPassword.
+func (p *PromptSignupPassword) String() string {
+	return Stringify(p)
+}
+
 // GetAllowOfflineAccess returns the AllowOfflineAccess field if it's non-nil, zero value otherwise.
 func (r *ResourceServer) GetAllowOfflineAccess() bool {
 	if r == nil || r.AllowOfflineAccess == nil {
@@ -4257,6 +4711,221 @@ func (r *RuleConfig) String() string {
 // String returns a string representation of RuleList.
 func (r *RuleList) String() string {
 	return Stringify(r)
+}
+
+// String returns a string representation of ScreenAcceptInvitation.
+func (s *ScreenAcceptInvitation) String() string {
+	return Stringify(s)
+}
+
+// String returns a string representation of ScreenConsent.
+func (s *ScreenConsent) String() string {
+	return Stringify(s)
+}
+
+// String returns a string representation of ScreenDeviceCodeActivation.
+func (s *ScreenDeviceCodeActivation) String() string {
+	return Stringify(s)
+}
+
+// String returns a string representation of ScreenDeviceCodeActivationAllowed.
+func (s *ScreenDeviceCodeActivationAllowed) String() string {
+	return Stringify(s)
+}
+
+// String returns a string representation of ScreenDeviceCodeActivationDenied.
+func (s *ScreenDeviceCodeActivationDenied) String() string {
+	return Stringify(s)
+}
+
+// String returns a string representation of ScreenDeviceCodeConfirmation.
+func (s *ScreenDeviceCodeConfirmation) String() string {
+	return Stringify(s)
+}
+
+// String returns a string representation of ScreenEmailOtpChallenge.
+func (s *ScreenEmailOtpChallenge) String() string {
+	return Stringify(s)
+}
+
+// String returns a string representation of ScreenEmailVerificationResult.
+func (s *ScreenEmailVerificationResult) String() string {
+	return Stringify(s)
+}
+
+// String returns a string representation of ScreenLogin.
+func (s *ScreenLogin) String() string {
+	return Stringify(s)
+}
+
+// String returns a string representation of ScreenLoginEmailVerification.
+func (s *ScreenLoginEmailVerification) String() string {
+	return Stringify(s)
+}
+
+// String returns a string representation of ScreenLoginId.
+func (s *ScreenLoginId) String() string {
+	return Stringify(s)
+}
+
+// String returns a string representation of ScreenLoginPassword.
+func (s *ScreenLoginPassword) String() string {
+	return Stringify(s)
+}
+
+// String returns a string representation of ScreenMfaBeginEnrollOptions.
+func (s *ScreenMfaBeginEnrollOptions) String() string {
+	return Stringify(s)
+}
+
+// String returns a string representation of ScreenMfaCountryCodes.
+func (s *ScreenMfaCountryCodes) String() string {
+	return Stringify(s)
+}
+
+// String returns a string representation of ScreenMfaEmailChallenge.
+func (s *ScreenMfaEmailChallenge) String() string {
+	return Stringify(s)
+}
+
+// String returns a string representation of ScreenMfaEmailList.
+func (s *ScreenMfaEmailList) String() string {
+	return Stringify(s)
+}
+
+// String returns a string representation of ScreenMfaEnrollResult.
+func (s *ScreenMfaEnrollResult) String() string {
+	return Stringify(s)
+}
+
+// String returns a string representation of ScreenMfaLoginOptions.
+func (s *ScreenMfaLoginOptions) String() string {
+	return Stringify(s)
+}
+
+// String returns a string representation of ScreenMfaOtpEnrollmentChallenge.
+func (s *ScreenMfaOtpEnrollmentChallenge) String() string {
+	return Stringify(s)
+}
+
+// String returns a string representation of ScreenMfaOtpEnrollmentCode.
+func (s *ScreenMfaOtpEnrollmentCode) String() string {
+	return Stringify(s)
+}
+
+// String returns a string representation of ScreenMfaOtpEnrollmentQr.
+func (s *ScreenMfaOtpEnrollmentQr) String() string {
+	return Stringify(s)
+}
+
+// String returns a string representation of ScreenMfaPhoneChallenge.
+func (s *ScreenMfaPhoneChallenge) String() string {
+	return Stringify(s)
+}
+
+// String returns a string representation of ScreenMfaPhoneEnrollment.
+func (s *ScreenMfaPhoneEnrollment) String() string {
+	return Stringify(s)
+}
+
+// String returns a string representation of ScreenMfaPushChallengePush.
+func (s *ScreenMfaPushChallengePush) String() string {
+	return Stringify(s)
+}
+
+// String returns a string representation of ScreenMfaPushEnrollmentQr.
+func (s *ScreenMfaPushEnrollmentQr) String() string {
+	return Stringify(s)
+}
+
+// String returns a string representation of ScreenMfaPushList.
+func (s *ScreenMfaPushList) String() string {
+	return Stringify(s)
+}
+
+// String returns a string representation of ScreenMfaPushWelcome.
+func (s *ScreenMfaPushWelcome) String() string {
+	return Stringify(s)
+}
+
+// String returns a string representation of ScreenMfaRecoveryCodeChallenge.
+func (s *ScreenMfaRecoveryCodeChallenge) String() string {
+	return Stringify(s)
+}
+
+// String returns a string representation of ScreenMfaRecoveryCodeEnrollment.
+func (s *ScreenMfaRecoveryCodeEnrollment) String() string {
+	return Stringify(s)
+}
+
+// String returns a string representation of ScreenMfaSmsChallenge.
+func (s *ScreenMfaSmsChallenge) String() string {
+	return Stringify(s)
+}
+
+// String returns a string representation of ScreenMfaSmsEnrollment.
+func (s *ScreenMfaSmsEnrollment) String() string {
+	return Stringify(s)
+}
+
+// String returns a string representation of ScreenMfaSmsList.
+func (s *ScreenMfaSmsList) String() string {
+	return Stringify(s)
+}
+
+// String returns a string representation of ScreenMfaVoiceChallenge.
+func (s *ScreenMfaVoiceChallenge) String() string {
+	return Stringify(s)
+}
+
+// String returns a string representation of ScreenMfaVoiceEnrollment.
+func (s *ScreenMfaVoiceEnrollment) String() string {
+	return Stringify(s)
+}
+
+// String returns a string representation of ScreenOrganizationSelection.
+func (s *ScreenOrganizationSelection) String() string {
+	return Stringify(s)
+}
+
+// String returns a string representation of ScreenResetPassword.
+func (s *ScreenResetPassword) String() string {
+	return Stringify(s)
+}
+
+// String returns a string representation of ScreenResetPasswordEmail.
+func (s *ScreenResetPasswordEmail) String() string {
+	return Stringify(s)
+}
+
+// String returns a string representation of ScreenResetPasswordError.
+func (s *ScreenResetPasswordError) String() string {
+	return Stringify(s)
+}
+
+// String returns a string representation of ScreenResetPasswordRequest.
+func (s *ScreenResetPasswordRequest) String() string {
+	return Stringify(s)
+}
+
+// String returns a string representation of ScreenResetPasswordSuccess.
+func (s *ScreenResetPasswordSuccess) String() string {
+	return Stringify(s)
+}
+
+// String returns a string representation of ScreenSignup.
+func (s *ScreenSignup) String() string {
+	return Stringify(s)
+}
+
+// String returns a string representation of ScreenSignupId.
+func (s *ScreenSignupId) String() string {
+	return Stringify(s)
+}
+
+// String returns a string representation of ScreenSignupPassword.
+func (s *ScreenSignupPassword) String() string {
+	return Stringify(s)
 }
 
 // GetCert returns the Cert field if it's non-nil, zero value otherwise.

--- a/management/management.go
+++ b/management/management.go
@@ -150,6 +150,9 @@ type Management struct {
 	// Prompt manages your prompt settings.
 	Prompt *PromptManager
 
+	// CustomText manages your custom text settings.
+	CustomText *CustomTextManager
+
 	// Blacklist manages the auth0 blacklists
 	Blacklist *BlacklistManager
 
@@ -221,6 +224,7 @@ func New(domain string, options ...ManagementOption) (*Management, error) {
 	m.Branding = newBrandingManager(m)
 	m.Guardian = newGuardianManager(m)
 	m.Prompt = newPromptManager(m)
+	m.CustomText = newCustomTextManager(m)
 	m.Blacklist = newBlacklistManager(m)
 	m.SigningKey = newSigningKeyManager(m)
 

--- a/management/prompt.go
+++ b/management/prompt.go
@@ -263,30 +263,30 @@ type ScreenLogin struct {
 	//Documented but not supported
 	//CaptchaCodePlaceholder        string `json:"captchaCodePlaceholder,omitempty"`
 	//CaptchaMatchExprPlaceholder   string `json:"captchaMatchExprPlaceholder,omitempty"`
-	EmailPlaceholder              string `json:"emailPlaceholder,omitempty"`
-	EditEmailText                 string `json:"editEmailText,omitempty"`
-	AlertListTitle                string `json:"alertListTitle,omitempty"`
-	InvitationTitle               string `json:"invitationTitle,omitempty"`
-	InvitationDescription         string `json:"invitationDescription,omitempty"`
-	WrongCredentials              string `json:"wrong-credentials,omitempty"`
+	EmailPlaceholder      string `json:"emailPlaceholder,omitempty"`
+	EditEmailText         string `json:"editEmailText,omitempty"`
+	AlertListTitle        string `json:"alertListTitle,omitempty"`
+	InvitationTitle       string `json:"invitationTitle,omitempty"`
+	InvitationDescription string `json:"invitationDescription,omitempty"`
+	WrongCredentials      string `json:"wrong-credentials,omitempty"`
 	//Documented but not supported
 	//WrongCaptcha                  string `json:"wrong-captcha,omitempty"`
-	InvalidCode                   string `json:"invalid-code,omitempty"`
-	InvalidExpiredCode            string `json:"invalid-expired-code,omitempty"`
-	InvalidEmailFormat            string `json:"invalid-email-format,omitempty"`
-	WrongEmailCredentials         string `json:"wrong-email-credentials,omitempty"`
-	CustomScriptErrorCode         string `json:"custom-script-error-code,omitempty"`
-	Auth0UsersValidation          string `json:"auth0-users-validation,omitempty"`
-	AuthenticationFailure         string `json:"authentication-failure,omitempty"`
-	InvalidConnection             string `json:"invalid-connection,omitempty"`
-	IpBlocked                     string `json:"ip-blocked,omitempty"`
-	NoDbConnection                string `json:"no-db-connection,omitempty"`
-	PasswordBreached              string `json:"password-breached,omitempty"`
-	UserBlocked                   string `json:"user-blocked,omitempty"`
-	SameUserLogin                 string `json:"same-user-login,omitempty"`
-	NoEmail                       string `json:"no-email,omitempty"`
-	NoPassword                    string `json:"no-password,omitempty"`
-	NoUsername                    string `json:"no-username,omitempty"`
+	InvalidCode           string `json:"invalid-code,omitempty"`
+	InvalidExpiredCode    string `json:"invalid-expired-code,omitempty"`
+	InvalidEmailFormat    string `json:"invalid-email-format,omitempty"`
+	WrongEmailCredentials string `json:"wrong-email-credentials,omitempty"`
+	CustomScriptErrorCode string `json:"custom-script-error-code,omitempty"`
+	Auth0UsersValidation  string `json:"auth0-users-validation,omitempty"`
+	AuthenticationFailure string `json:"authentication-failure,omitempty"`
+	InvalidConnection     string `json:"invalid-connection,omitempty"`
+	IpBlocked             string `json:"ip-blocked,omitempty"`
+	NoDbConnection        string `json:"no-db-connection,omitempty"`
+	PasswordBreached      string `json:"password-breached,omitempty"`
+	UserBlocked           string `json:"user-blocked,omitempty"`
+	SameUserLogin         string `json:"same-user-login,omitempty"`
+	NoEmail               string `json:"no-email,omitempty"`
+	NoPassword            string `json:"no-password,omitempty"`
+	NoUsername            string `json:"no-username,omitempty"`
 }
 
 type PromptLogin struct {
@@ -597,12 +597,12 @@ type ScreenMfaOtpEnrollmentQr struct {
 	Placeholder           string `json:"placeholder,omitempty"`
 	//Documented but not supported
 	//SeparatorText         string `json:"separatorText,omitempty"`
-	InvalidOtpCodeFormat  string `json:"invalid-otp-code-format,omitempty"`
-	InvalidCode           string `json:"invalid-code,omitempty"`
-	InvalidExpiredCode    string `json:"invalid-expired-code,omitempty"`
-	TooManyFailures       string `json:"too-many-failures,omitempty"`
-	TransactionNotFound   string `json:"transaction-not-found,omitempty"`
-	UserAlreadyEnrolled   string `json:"user-already-enrolled,omitempty"`
+	InvalidOtpCodeFormat string `json:"invalid-otp-code-format,omitempty"`
+	InvalidCode          string `json:"invalid-code,omitempty"`
+	InvalidExpiredCode   string `json:"invalid-expired-code,omitempty"`
+	TooManyFailures      string `json:"too-many-failures,omitempty"`
+	TransactionNotFound  string `json:"transaction-not-found,omitempty"`
+	UserAlreadyEnrolled  string `json:"user-already-enrolled,omitempty"`
 }
 
 type ScreenMfaOtpEnrollmentCode struct {
@@ -739,9 +739,9 @@ type ScreenMfaPushEnrollmentQr struct {
 }
 
 type ScreenMfaPushChallengePush struct {
-	PageTitle                          string `json:"pageTitle,omitempty"`
-	Title                              string `json:"title,omitempty"`
-	Description                        string `json:"description,omitempty"`
+	PageTitle   string `json:"pageTitle,omitempty"`
+	Title       string `json:"title,omitempty"`
+	Description string `json:"description,omitempty"`
 	//Documented but not supported
 	//AwaitingConfirmation               string `json:"awaitingConfirmation,omitempty"`
 	ButtonText                         string `json:"buttonText,omitempty"`
@@ -986,14 +986,14 @@ func (m *CustomTextManager) SetMfaVoice(language string, p *PromptMfaVoice, opts
 // See: https://auth0.com/docs/universal-login/prompt-organization-selection
 
 type ScreenOrganizationSelection struct {
-	PageTitle                string `json:"pageTitle,omitempty"`
-	Title                    string `json:"title,omitempty"`
-	Description              string `json:"description,omitempty"`
-	ButtonText               string `json:"buttonText,omitempty"`
-	Placeholder              string `json:"placeholder,omitempty"`
+	PageTitle   string `json:"pageTitle,omitempty"`
+	Title       string `json:"title,omitempty"`
+	Description string `json:"description,omitempty"`
+	ButtonText  string `json:"buttonText,omitempty"`
+	Placeholder string `json:"placeholder,omitempty"`
 	//Documented but not supported
 	//ErrorInvalidOrganization string `json:"error_invalid-organization,omitempty"`
-	LogoAltText              string `json:"logoAltText,omitempty"`
+	LogoAltText string `json:"logoAltText,omitempty"`
 }
 
 type PromptOrganizations struct {
@@ -1040,10 +1040,10 @@ type ScreenResetPasswordRequest struct {
 }
 
 type ScreenResetPasswordEmail struct {
-	PageTitle           string `json:"pageTitle,omitempty"`
-	Title               string `json:"title,omitempty"`
-	EmailDescription    string `json:"emailDescription,omitempty"`
-	ResendLinkText      string `json:"resendLinkText,omitempty"`
+	PageTitle        string `json:"pageTitle,omitempty"`
+	Title            string `json:"title,omitempty"`
+	EmailDescription string `json:"emailDescription,omitempty"`
+	ResendLinkText   string `json:"resendLinkText,omitempty"`
 	//Documented but not supported
 	//ResendText          string `json:"resendText,omitempty"`
 	UsernameDescription string `json:"usernameDescription,omitempty"`
@@ -1232,15 +1232,15 @@ func (m *CustomTextManager) SetSignupId(language string, p *PromptSignupId, opts
 // See: https://auth0.com/docs/universal-login/prompt-signup-password
 
 type ScreenSignupPassword struct {
-	PageTitle                        string `json:"pageTitle,omitempty"`
-	Title                            string `json:"title,omitempty"`
-	Description                      string `json:"description,omitempty"`
-	SeparatorText                    string `json:"separatorText,omitempty"`
-	ButtonText                       string `json:"buttonText,omitempty"`
-	EmailPlaceholder                 string `json:"emailPlaceholder,omitempty"`
-	FederatedConnectionButtonText    string `json:"federatedConnectionButtonText,omitempty"`
-	LoginActionLinkText              string `json:"loginActionLinkText,omitempty"`
-	LoginActionText                  string `json:"loginActionText,omitempty"`
+	PageTitle                     string `json:"pageTitle,omitempty"`
+	Title                         string `json:"title,omitempty"`
+	Description                   string `json:"description,omitempty"`
+	SeparatorText                 string `json:"separatorText,omitempty"`
+	ButtonText                    string `json:"buttonText,omitempty"`
+	EmailPlaceholder              string `json:"emailPlaceholder,omitempty"`
+	FederatedConnectionButtonText string `json:"federatedConnectionButtonText,omitempty"`
+	LoginActionLinkText           string `json:"loginActionLinkText,omitempty"`
+	LoginActionText               string `json:"loginActionText,omitempty"`
 	//Documented but not supported
 	//LoginLinkText                    string `json:"loginLinkText,omitempty"`
 	InvitationTitle                  string `json:"invitationTitle,omitempty"`

--- a/management/prompt.go
+++ b/management/prompt.go
@@ -1,5 +1,9 @@
 package management
 
+////////////////////////////////////////////////
+// Get prompts settings, Update prompts settings
+//
+
 type Prompt struct {
 	// Which login experience to use. Can be `new` or `classic`.
 	UniversalLoginExperience string `json:"universal_login_experience,omitempty"`
@@ -29,4 +33,1261 @@ func (m *PromptManager) Read(opts ...RequestOption) (p *Prompt, err error) {
 // See: https://auth0.com/docs/api/management/v2#!/Prompts/patch_prompts
 func (m *PromptManager) Update(p *Prompt, opts ...RequestOption) error {
 	return m.Request("PATCH", m.URI("prompts"), p, opts...)
+}
+
+//////////////////////////////////////////////////////////////////////
+// Get custom text for a prompt, Set custom text for a specific prompt
+//
+
+type CustomTextManager struct {
+	*Management
+}
+
+func newCustomTextManager(m *Management) *CustomTextManager {
+	return &CustomTextManager{m}
+}
+
+// prompt: consent
+// See: https://auth0.com/docs/universal-login/prompt-consent
+
+type ScreenConsent struct {
+	PageTitle              string `json:"pageTitle,omitempty"`
+	Title                  string `json:"title,omitempty"`
+	PickerTitle            string `json:"pickerTitle,omitempty"`
+	MessageMultipleTenants string `json:"messageMultipleTenants,omitempty"`
+	AudiencePickerAltText  string `json:"audiencePickerAltText,omitempty"`
+	MessageSingleTenant    string `json:"messageSingleTenant,omitempty"`
+	AcceptButtonText       string `json:"acceptButtonText,omitempty"`
+	DeclineButtonText      string `json:"declineButtonText,omitempty"`
+	InvalidAction          string `json:"invalid-action,omitempty"`
+	InvalidAudience        string `json:"invalid-audience,omitempty"`
+	InvalidScope           string `json:"invalid-scope,omitempty"`
+}
+
+type PromptConsent struct {
+	Consent ScreenConsent `json:"consent"`
+}
+
+// ReadConsent reads consent custom text
+//
+// See: https://auth0.com/docs/api/management/v2#!/Prompts/get_custom_text_by_language
+func (m *CustomTextManager) ReadConsent(language string, opts ...RequestOption) (p *PromptConsent, err error) {
+	err = m.Request("GET", m.URI("prompts", "consent", "custom-text", language), &p, opts...)
+	return
+}
+
+// SetConsent sets consent custom text
+//
+// See: https://auth0.com/docs/api/management/v2#!/Prompts/put_custom_text_by_language
+func (m *CustomTextManager) SetConsent(language string, p *PromptConsent, opts ...RequestOption) error {
+	return m.Request("PUT", m.URI("prompts", "consent", "custom-text", language), p, opts...)
+}
+
+// prompt: device-flow
+// See: https://auth0.com/docs/universal-login/prompt-device-flow
+
+type ScreenDeviceCodeActivation struct {
+	PageTitle          string `json:"pageTitle,omitempty"`
+	ButtonText         string `json:"buttonText,omitempty"`
+	Description        string `json:"description,omitempty"`
+	Placeholder        string `json:"placeholder,omitempty"`
+	Title              string `json:"title,omitempty"`
+	InvalidExpiredCode string `json:"invalid-expired-code,omitempty"`
+	NoCode             string `json:"no-code,omitempty"`
+	InvalidCode        string `json:"invalid-code,omitempty"`
+}
+
+type ScreenDeviceCodeActivationAllowed struct {
+	PageTitle   string `json:"pageTitle,omitempty"`
+	Description string `json:"description,omitempty"`
+	EventTitle  string `json:"eventTitle,omitempty"`
+}
+
+type ScreenDeviceCodeActivationDenied struct {
+	PageTitle   string `json:"pageTitle,omitempty"`
+	Description string `json:"description,omitempty"`
+	EventTitle  string `json:"eventTitle,omitempty"`
+}
+
+type ScreenDeviceCodeConfirmation struct {
+	PageTitle         string `json:"pageTitle,omitempty"`
+	Description       string `json:"description,omitempty"`
+	InputCodeLabel    string `json:"inputCodeLabel,omitempty"`
+	Title             string `json:"title,omitempty"`
+	ConfirmButtonText string `json:"confirmButtonText,omitempty"`
+	CancelButtonText  string `json:"cancelButtonText,omitempty"`
+	ConfirmationText  string `json:"confirmationText,omitempty"`
+}
+
+type PromptDeviceFlow struct {
+	DeviceCodeActivation        ScreenDeviceCodeActivation        `json:"device-code-activation,omitempty"`
+	DeviceCodeActivationAllowed ScreenDeviceCodeActivationAllowed `json:"device-code-activation-allowed,omitempty"`
+	DeviceCodeActivationDenied  ScreenDeviceCodeActivationDenied  `json:"device-code-activation-denied,omitempty"`
+	DeviceCodeConfirmation      ScreenDeviceCodeConfirmation      `json:"device-code-confirmation"`
+}
+
+// ReadDeviceFlow reads device-flow custom text
+//
+// See: https://auth0.com/docs/api/management/v2#!/Prompts/get_custom_text_by_language
+func (m *CustomTextManager) ReadDeviceFlow(language string, opts ...RequestOption) (p *PromptDeviceFlow, err error) {
+	err = m.Request("GET", m.URI("prompts", "device-flow", "custom-text", language), &p, opts...)
+	return
+}
+
+// SetDeviceFlow sets device-flow custom text
+//
+// See: https://auth0.com/docs/api/management/v2#!/Prompts/put_custom_text_by_language
+func (m *CustomTextManager) SetDeviceFlow(language string, p *PromptDeviceFlow, opts ...RequestOption) error {
+	return m.Request("PUT", m.URI("prompts", "device-flow", "custom-text", language), p, opts...)
+}
+
+// prompt: email-otp-challenge
+// See: https://auth0.com/docs/universal-login/prompt-email-otp-challenge
+
+type ScreenEmailOtpChallenge struct {
+	PageTitle            string `json:"pageTitle,omitempty"`
+	ButtonText           string `json:"buttonText,omitempty"`
+	Description          string `json:"description,omitempty"`
+	Placeholder          string `json:"placeholder,omitempty"`
+	ResendActionText     string `json:"resendActionText,omitempty"`
+	ResendText           string `json:"resendText,omitempty"`
+	Title                string `json:"title,omitempty"`
+	InvalidOtpCodeFormat string `json:"invalid-otp-code-format,omitempty"`
+	InvalidCode          string `json:"invalid-code,omitempty"`
+	InvalidExpiredCode   string `json:"invalid-expired-code,omitempty"`
+	AuthenticatorError   string `json:"authenticator-error,omitempty"`
+	TooManyEmail         string `json:"too-many-email,omitempty"`
+}
+
+type PromptEmailOtpChallenge struct {
+	EmailOtpChallenge ScreenEmailOtpChallenge `json:"email-otp-challenge"`
+}
+
+// ReadEmailOtpChallenge reads email-otp-challenge custom text
+//
+// See: https://auth0.com/docs/api/management/v2#!/Prompts/get_custom_text_by_language
+func (m *CustomTextManager) ReadEmailOtpChallenge(language string, opts ...RequestOption) (p *PromptEmailOtpChallenge, err error) {
+	err = m.Request("GET", m.URI("prompts", "email-otp-challenge", "custom-text", language), &p, opts...)
+	return
+}
+
+// SetEmailOtpChallenge sets email-otp-challenge custom text
+//
+// See: https://auth0.com/docs/api/management/v2#!/Prompts/put_custom_text_by_language
+func (m *CustomTextManager) SetEmailOtpChallenge(language string, p *PromptEmailOtpChallenge, opts ...RequestOption) error {
+	return m.Request("PUT", m.URI("prompts", "email-otp-challenge", "custom-text", language), p, opts...)
+}
+
+// prompt: email-verification
+// See: https://auth0.com/docs/universal-login/prompt-email-verification
+
+type ScreenEmailVerificationResult struct {
+	PageTitle                       string `json:"pageTitle,omitempty"`
+	VerifiedTitle                   string `json:"verifiedTitle,omitempty"`
+	ErrorTitle                      string `json:"errorTitle,omitempty"`
+	VerifiedDescription             string `json:"verifiedDescription,omitempty"`
+	AlreadyVerifiedDescription      string `json:"alreadyVerifiedDescription,omitempty"`
+	InvalidAccountOrCodeDescription string `json:"invalidAccountOrCodeDescription,omitempty"`
+	UnknownErrorDescription         string `json:"unknownErrorDescription,omitempty"`
+	ButtonText                      string `json:"buttonText,omitempty"`
+	Auth0UsersExpiredTicket         string `json:"auth0-users-expired-ticket,omitempty"`
+	CustomScriptErrorCode           string `json:"custom-script-error-code,omitempty"`
+	Auth0UsersUsedTicket            string `json:"auth0-users-used-ticket,omitempty"`
+	Auth0UsersValidation            string `json:"auth0-users-validation,omitempty"`
+}
+
+type PromptEmailVerification struct {
+	EmailVerificationResult ScreenEmailVerificationResult `json:"email-verification-result"`
+}
+
+// ReadEmailVerification reads email-verification custom text
+//
+// See: https://auth0.com/docs/api/management/v2#!/Prompts/get_custom_text_by_language
+func (m *CustomTextManager) ReadEmailVerification(language string, opts ...RequestOption) (p *PromptEmailVerification, err error) {
+	err = m.Request("GET", m.URI("prompts", "email-verification", "custom-text", language), &p, opts...)
+	return
+}
+
+// SetEmailVerification sets email-verification custom text
+//
+// See: https://auth0.com/docs/api/management/v2#!/Prompts/put_custom_text_by_language
+func (m *CustomTextManager) SetEmailVerification(language string, p *PromptEmailVerification, opts ...RequestOption) error {
+	return m.Request("PUT", m.URI("prompts", "email-verification", "custom-text", language), p, opts...)
+}
+
+// prompt: invitation
+// See: https://auth0.com/docs/universal-login/prompt-accept-invitation
+
+type ScreenAcceptInvitation struct {
+	PageTitle   string `json:"pageTitle,omitempty"`
+	Title       string `json:"title,omitempty"`
+	Description string `json:"description,omitempty"`
+	ButtonText  string `json:"buttonText,omitempty"`
+	LogoAltText string `json:"logoAltText,omitempty"`
+}
+
+type PromptInvitation struct {
+	AcceptInvitation ScreenAcceptInvitation `json:"accept-invitation"`
+}
+
+// ReadInvitation reads invitation custom text
+//
+// See: https://auth0.com/docs/api/management/v2#!/Prompts/get_custom_text_by_language
+func (m *CustomTextManager) ReadInvitation(language string, opts ...RequestOption) (p *PromptInvitation, err error) {
+	err = m.Request("GET", m.URI("prompts", "invitation", "custom-text", language), &p, opts...)
+	return
+}
+
+// SetInvitation sets invitation custom text
+//
+// See: https://auth0.com/docs/api/management/v2#!/Prompts/put_custom_text_by_language
+func (m *CustomTextManager) SetInvitation(language string, p *PromptInvitation, opts ...RequestOption) error {
+	return m.Request("PUT", m.URI("prompts", "invitation", "custom-text", language), p, opts...)
+}
+
+// prompt: login
+// See: https://auth0.com/docs/universal-login/prompt-login
+
+type ScreenLogin struct {
+	PageTitle                     string `json:"pageTitle,omitempty"`
+	Title                         string `json:"title,omitempty"`
+	Description                   string `json:"description,omitempty"`
+	SeparatorText                 string `json:"separatorText,omitempty"`
+	ButtonText                    string `json:"buttonText,omitempty"`
+	FederatedConnectionButtonText string `json:"federatedConnectionButtonText,omitempty"`
+	SignupActionLinkText          string `json:"signupActionLinkText,omitempty"`
+	SignupActionText              string `json:"signupActionText,omitempty"`
+	ForgotPasswordText            string `json:"forgotPasswordText,omitempty"`
+	PasswordPlaceholder           string `json:"passwordPlaceholder,omitempty"`
+	UsernamePlaceholder           string `json:"usernamePlaceholder,omitempty"`
+	//Documented but not supported
+	//CaptchaCodePlaceholder        string `json:"captchaCodePlaceholder,omitempty"`
+	//CaptchaMatchExprPlaceholder   string `json:"captchaMatchExprPlaceholder,omitempty"`
+	EmailPlaceholder              string `json:"emailPlaceholder,omitempty"`
+	EditEmailText                 string `json:"editEmailText,omitempty"`
+	AlertListTitle                string `json:"alertListTitle,omitempty"`
+	InvitationTitle               string `json:"invitationTitle,omitempty"`
+	InvitationDescription         string `json:"invitationDescription,omitempty"`
+	WrongCredentials              string `json:"wrong-credentials,omitempty"`
+	//Documented but not supported
+	//WrongCaptcha                  string `json:"wrong-captcha,omitempty"`
+	InvalidCode                   string `json:"invalid-code,omitempty"`
+	InvalidExpiredCode            string `json:"invalid-expired-code,omitempty"`
+	InvalidEmailFormat            string `json:"invalid-email-format,omitempty"`
+	WrongEmailCredentials         string `json:"wrong-email-credentials,omitempty"`
+	CustomScriptErrorCode         string `json:"custom-script-error-code,omitempty"`
+	Auth0UsersValidation          string `json:"auth0-users-validation,omitempty"`
+	AuthenticationFailure         string `json:"authentication-failure,omitempty"`
+	InvalidConnection             string `json:"invalid-connection,omitempty"`
+	IpBlocked                     string `json:"ip-blocked,omitempty"`
+	NoDbConnection                string `json:"no-db-connection,omitempty"`
+	PasswordBreached              string `json:"password-breached,omitempty"`
+	UserBlocked                   string `json:"user-blocked,omitempty"`
+	SameUserLogin                 string `json:"same-user-login,omitempty"`
+	NoEmail                       string `json:"no-email,omitempty"`
+	NoPassword                    string `json:"no-password,omitempty"`
+	NoUsername                    string `json:"no-username,omitempty"`
+}
+
+type PromptLogin struct {
+	Login ScreenLogin `json:"login"`
+}
+
+// ReadLogin reads login custom text
+//
+// See: https://auth0.com/docs/api/management/v2#!/Prompts/get_custom_text_by_language
+func (m *CustomTextManager) ReadLogin(language string, opts ...RequestOption) (p *PromptLogin, err error) {
+	err = m.Request("GET", m.URI("prompts", "login", "custom-text", language), &p, opts...)
+	return
+}
+
+// SetLogin sets login custom text
+//
+// See: https://auth0.com/docs/api/management/v2#!/Prompts/put_custom_text_by_language
+func (m *CustomTextManager) SetLogin(language string, p *PromptLogin, opts ...RequestOption) error {
+	return m.Request("PUT", m.URI("prompts", "login", "custom-text", language), p, opts...)
+}
+
+// prompt: login-id
+// See: https://auth0.com/docs/universal-login/prompt-login-id
+
+type ScreenLoginId struct {
+	PageTitle                     string `json:"pageTitle,omitempty"`
+	Title                         string `json:"title,omitempty"`
+	Description                   string `json:"description,omitempty"`
+	SeparatorText                 string `json:"separatorText,omitempty"`
+	ButtonText                    string `json:"buttonText,omitempty"`
+	FederatedConnectionButtonText string `json:"federatedConnectionButtonText,omitempty"`
+	SignupActionLinkText          string `json:"signupActionLinkText,omitempty"`
+	SignupActionText              string `json:"signupActionText,omitempty"`
+	PasswordPlaceholder           string `json:"passwordPlaceholder,omitempty"`
+	UsernamePlaceholder           string `json:"usernamePlaceholder,omitempty"`
+	EmailPlaceholder              string `json:"emailPlaceholder,omitempty"`
+	EditEmailText                 string `json:"editEmailText,omitempty"`
+	AlertListTitle                string `json:"alertListTitle,omitempty"`
+	LogoAltText                   string `json:"logoAltText,omitempty"`
+	WrongCredentials              string `json:"wrong-credentials,omitempty"`
+	InvalidCode                   string `json:"invalid-code,omitempty"`
+	InvalidExpiredCode            string `json:"invalid-expired-code,omitempty"`
+	InvalidEmailFormat            string `json:"invalid-email-format,omitempty"`
+	WrongEmailCredentials         string `json:"wrong-email-credentials,omitempty"`
+	CustomScriptErrorCode         string `json:"custom-script-error-code,omitempty"`
+	Auth0UsersValidation          string `json:"auth0-users-validation,omitempty"`
+	AuthenticationFailure         string `json:"authentication-failure,omitempty"`
+	InvalidConnection             string `json:"invalid-connection,omitempty"`
+	IpBlocked                     string `json:"ip-blocked,omitempty"`
+	NoDbConnection                string `json:"no-db-connection,omitempty"`
+	NoHrdConnection               string `json:"no-hrd-connection,omitempty"`
+	PasswordBreached              string `json:"password-breached,omitempty"`
+	UserBlocked                   string `json:"user-blocked,omitempty"`
+	SameUserLogin                 string `json:"same-user-login,omitempty"`
+	NoEmail                       string `json:"no-email,omitempty"`
+	NoPassword                    string `json:"no-password,omitempty"`
+	NoUsername                    string `json:"no-username,omitempty"`
+}
+
+type PromptLoginId struct {
+	LoginId ScreenLoginId `json:"login-id"`
+}
+
+// ReadLoginId reads login-id custom text
+//
+// See: https://auth0.com/docs/api/management/v2#!/Prompts/get_custom_text_by_language
+func (m *CustomTextManager) ReadLoginId(language string, opts ...RequestOption) (p *PromptLoginId, err error) {
+	err = m.Request("GET", m.URI("prompts", "login-id", "custom-text", language), &p, opts...)
+	return
+}
+
+// SetLoginId sets login-id custom text
+//
+// See: https://auth0.com/docs/api/management/v2#!/Prompts/put_custom_text_by_language
+func (m *CustomTextManager) SetLoginId(language string, p *PromptLoginId, opts ...RequestOption) error {
+	return m.Request("PUT", m.URI("prompts", "login-id", "custom-text", language), p, opts...)
+}
+
+// prompt: login-password
+// See: https://auth0.com/docs/universal-login/prompt-login-password
+
+type ScreenLoginPassword struct {
+	PageTitle                     string `json:"pageTitle,omitempty"`
+	Title                         string `json:"title,omitempty"`
+	Description                   string `json:"description,omitempty"`
+	SeparatorText                 string `json:"separatorText,omitempty"`
+	ButtonText                    string `json:"buttonText,omitempty"`
+	FederatedConnectionButtonText string `json:"federatedConnectionButtonText,omitempty"`
+	SignupActionLinkText          string `json:"signupActionLinkText,omitempty"`
+	SignupActionText              string `json:"signupActionText,omitempty"`
+	ForgotPasswordText            string `json:"forgotPasswordText,omitempty"`
+	PasswordPlaceholder           string `json:"passwordPlaceholder,omitempty"`
+	UsernamePlaceholder           string `json:"usernamePlaceholder,omitempty"`
+	EmailPlaceholder              string `json:"emailPlaceholder,omitempty"`
+	EditEmailText                 string `json:"editEmailText,omitempty"`
+	AlertListTitle                string `json:"alertListTitle,omitempty"`
+	InvitationTitle               string `json:"invitationTitle,omitempty"`
+	InvitationDescription         string `json:"invitationDescription,omitempty"`
+	LogoAltText                   string `json:"logoAltText,omitempty"`
+	WrongCredentials              string `json:"wrong-credentials,omitempty"`
+	InvalidCode                   string `json:"invalid-code,omitempty"`
+	InvalidExpiredCode            string `json:"invalid-expired-code,omitempty"`
+	InvalidEmailFormat            string `json:"invalid-email-format,omitempty"`
+	WrongEmailCredentials         string `json:"wrong-email-credentials,omitempty"`
+	CustomScriptErrorCode         string `json:"custom-script-error-code,omitempty"`
+	Auth0UsersValidation          string `json:"auth0-users-validation,omitempty"`
+	AuthenticationFailure         string `json:"authentication-failure,omitempty"`
+	InvalidConnection             string `json:"invalid-connection,omitempty"`
+	IpBlocked                     string `json:"ip-blocked,omitempty"`
+	NoDbConnection                string `json:"no-db-connection,omitempty"`
+	PasswordBreached              string `json:"password-breached,omitempty"`
+	UserBlocked                   string `json:"user-blocked,omitempty"`
+	SameUserLogin                 string `json:"same-user-login,omitempty"`
+	NoEmail                       string `json:"no-email,omitempty"`
+	NoPassword                    string `json:"no-password,omitempty"`
+	NoUsername                    string `json:"no-username,omitempty"`
+}
+
+type PromptLoginPassword struct {
+	LoginPassword ScreenLoginPassword `json:"login-password"`
+}
+
+// ReadLoginPassword reads login-password custom text
+//
+// See: https://auth0.com/docs/api/management/v2#!/Prompts/get_custom_text_by_language
+func (m *CustomTextManager) ReadLoginPassword(language string, opts ...RequestOption) (p *PromptLoginPassword, err error) {
+	err = m.Request("GET", m.URI("prompts", "login-password", "custom-text", language), &p, opts...)
+	return
+}
+
+// SetLoginPassword sets login-password custom text
+//
+// See: https://auth0.com/docs/api/management/v2#!/Prompts/put_custom_text_by_language
+func (m *CustomTextManager) SetLoginPassword(language string, p *PromptLoginPassword, opts ...RequestOption) error {
+	return m.Request("PUT", m.URI("prompts", "login-password", "custom-text", language), p, opts...)
+}
+
+// prompt: login-email-verification
+// See: https://auth0.com/docs/universal-login/prompt-login-email-verification
+
+type ScreenLoginEmailVerification struct {
+	PageTitle            string `json:"pageTitle,omitempty"`
+	ButtonText           string `json:"buttonText,omitempty"`
+	Description          string `json:"description,omitempty"`
+	Placeholder          string `json:"placeholder,omitempty"`
+	ResendActionText     string `json:"resendActionText,omitempty"`
+	ResendText           string `json:"resendText,omitempty"`
+	Title                string `json:"title,omitempty"`
+	InvalidOtpCodeFormat string `json:"invalid-otp-code-format,omitempty"`
+	InvalidCode          string `json:"invalid-code,omitempty"`
+	InvalidExpiredCode   string `json:"invalid-expired-code,omitempty"`
+	AuthenticatorError   string `json:"authenticator-error,omitempty"`
+	TooManyEmail         string `json:"too-many-email,omitempty"`
+}
+
+type PromptLoginEmailVerification struct {
+	LoginEmailVerification ScreenLoginEmailVerification `json:"login-email-verification"`
+}
+
+// ReadLoginEmailVerification reads login-email-verification custom text
+//
+// See: https://auth0.com/docs/api/management/v2#!/Prompts/get_custom_text_by_language
+func (m *CustomTextManager) ReadLoginEmailVerification(language string, opts ...RequestOption) (p *PromptLoginEmailVerification, err error) {
+	err = m.Request("GET", m.URI("prompts", "login-email-verification", "custom-text", language), &p, opts...)
+	return
+}
+
+// SetLoginEmailVerification sets login-email-verification custom text
+//
+// See: https://auth0.com/docs/api/management/v2#!/Prompts/put_custom_text_by_language
+func (m *CustomTextManager) SetLoginEmailVerification(language string, p *PromptLoginEmailVerification, opts ...RequestOption) error {
+	return m.Request("PUT", m.URI("prompts", "login-email-verification", "custom-text", language), p, opts...)
+}
+
+// prompt: mfa
+// See: https://auth0.com/docs/universal-login/prompt-mfa
+
+type ScreenMfaEnrollResult struct {
+	PageTitle                  string `json:"pageTitle,omitempty"`
+	EnrolledTitle              string `json:"enrolledTitle,omitempty"`
+	EnrolledDescription        string `json:"enrolledDescription,omitempty"`
+	InvalidTicketTitle         string `json:"invalidTicketTitle,omitempty"`
+	InvalidTicketDescription   string `json:"invalidTicketDescription,omitempty"`
+	ExpiredTicketTitle         string `json:"expiredTicketTitle,omitempty"`
+	ExpiredTicketDescription   string `json:"expiredTicketDescription,omitempty"`
+	AlreadyUsedTitle           string `json:"alreadyUsedTitle,omitempty"`
+	AlreadyUsedDescription     string `json:"alreadyUsedDescription,omitempty"`
+	AlreadyEnrolledDescription string `json:"alreadyEnrolledDescription,omitempty"`
+	GenericError               string `json:"genericError,omitempty"`
+}
+
+type ScreenMfaLoginOptions struct {
+	PageTitle                          string `json:"pageTitle,omitempty"`
+	BackText                           string `json:"backText,omitempty"`
+	Title                              string `json:"title,omitempty"`
+	AuthenticatorNamesSMS              string `json:"authenticatorNamesSMS,omitempty"`
+	AuthenticatorNamesPhone            string `json:"authenticatorNamesPhone,omitempty"`
+	AuthenticatorNamesVoice            string `json:"authenticatorNamesVoice,omitempty"`
+	AuthenticatorNamesPushNotification string `json:"authenticatorNamesPushNotification,omitempty"`
+	AuthenticatorNamesEmail            string `json:"authenticatorNamesEmail,omitempty"`
+	AuthenticatorNamesRecoveryCode     string `json:"authenticatorNamesRecoveryCode,omitempty"`
+	AuthenticatorNamesDUO              string `json:"authenticatorNamesDUO,omitempty"`
+	AuthenticatorNamesWebauthnRoaming  string `json:"authenticatorNamesWebauthnRoaming,omitempty"`
+	//Documented but not supported
+	//AuthenticatorNamesWebauthnPlatform string `json:"authenticatorNamesWebauthnPlatform,omitempty"`
+}
+
+type ScreenMfaBeginEnrollOptions struct {
+	PageTitle                          string `json:"pageTitle,omitempty"`
+	BackText                           string `json:"backText,omitempty"`
+	Title                              string `json:"title,omitempty"`
+	Description                        string `json:"description,omitempty"`
+	LogoAltText                        string `json:"logoAltText,omitempty"`
+	AuthenticatorNamesSms              string `json:"authenticatorNamesSMS,omitempty"`
+	AuthenticatorNamesVoice            string `json:"authenticatorNamesVoice,omitempty"`
+	AuthenticatorNamesPhone            string `json:"authenticatorNamesPhone,omitempty"`
+	AuthenticatorNamesPushNotification string `json:"authenticatorNamesPushNotification,omitempty"`
+	AuthenticatorNamesOtp              string `json:"authenticatorNamesOTP,omitempty"`
+	AuthenticatorNamesEmail            string `json:"authenticatorNamesEmail,omitempty"`
+	AuthenticatorNamesRecoveryCode     string `json:"authenticatorNamesRecoveryCode,omitempty"`
+	AuthenticatorNamesDUO              string `json:"authenticatorNamesDUO,omitempty"`
+	AuthenticatorNamesWebauthnRoaming  string `json:"authenticatorNamesWebauthnRoaming,omitempty"`
+	//Documented but not supported
+	//AuthenticatorNamesWebauthnPlatform string `json:"authenticatorNamesWebauthnPlatform,omitempty"`
+}
+
+type PromptMfa struct {
+	MfaEnrollResult ScreenMfaEnrollResult `json:"mfa-enroll-result"`
+	MfaLoginOptions ScreenMfaLoginOptions `json:"mfa-login-options"`
+	MfaBeginEnrollOptions ScreenMfaBeginEnrollOptions `json:"mfa-begin-enroll-options"`
+}
+
+// ReadMfa reads mfa custom text
+//
+// See: https://auth0.com/docs/api/management/v2#!/Prompts/get_custom_text_by_language
+func (m *CustomTextManager) ReadMfa(language string, opts ...RequestOption) (p *PromptMfa, err error) {
+	err = m.Request("GET", m.URI("prompts", "mfa", "custom-text", language), &p, opts...)
+	return
+}
+
+// SetMfa sets mfa custom text
+//
+// See: https://auth0.com/docs/api/management/v2#!/Prompts/put_custom_text_by_language
+func (m *CustomTextManager) SetMfa(language string, p *PromptMfa, opts ...RequestOption) error {
+	return m.Request("PUT", m.URI("prompts", "mfa", "custom-text", language), p, opts...)
+}
+
+// prompt: mfa-email
+// See: https://auth0.com/docs/universal-login/prompt-mfa-email
+
+type ScreenMfaEmailChallenge struct {
+	PageTitle                           string `json:"pageTitle,omitempty"`
+	BackText                            string `json:"backText,omitempty"`
+	ButtonText                          string `json:"buttonText,omitempty"`
+	Description                         string `json:"description,omitempty"`
+	PickAuthenticatorText               string `json:"pickAuthenticatorText,omitempty"`
+	Placeholder                         string `json:"placeholder,omitempty"`
+	RememberMeText                      string `json:"rememberMeText,omitempty"`
+	ResendActionText                    string `json:"resendActionText,omitempty"`
+	ResendText                          string `json:"resendText,omitempty"`
+	Title                               string `json:"title,omitempty"`
+	InvalidOtpCodeFormat                string `json:"invalid-otp-code-format,omitempty"`
+	InvalidCode                         string `json:"invalid-code,omitempty"`
+	InvalidExpiredCode                  string `json:"invalid-expired-code,omitempty"`
+	AuthenticatorError                  string `json:"authenticator-error,omitempty"`
+	NoTransactionInProgress             string `json:"no-transaction-in-progress,omitempty"`
+	TooManyEmail                        string `json:"too-many-email,omitempty"`
+	TransactionNotFound                 string `json:"transaction-not-found,omitempty"`
+	MfaEmailChallengeAuthenticatorError string `json:"mfa-email-challenge-authenticator-error,omitempty"`
+}
+
+type ScreenMfaEmailList struct {
+	PageTitle string `json:"pageTitle,omitempty"`
+	BackText  string `json:"backText,omitempty"`
+	Title     string `json:"title,omitempty"`
+}
+
+type PromptMfaEmail struct {
+	MfaEmailChallenge ScreenMfaEmailChallenge `json:"mfa-email-challenge"`
+	MfaEmailList      ScreenMfaEmailList      `json:"mfa-email-list"`
+}
+
+// ReadMfaEmail reads mfa-email custom text
+//
+// See: https://auth0.com/docs/api/management/v2#!/Prompts/get_custom_text_by_language
+func (m *CustomTextManager) ReadMfaEmail(language string, opts ...RequestOption) (p *PromptMfaEmail, err error) {
+	err = m.Request("GET", m.URI("prompts", "mfa-email", "custom-text", language), &p, opts...)
+	return
+}
+
+// SetMfaEmail sets mfa-email custom text
+//
+// See: https://auth0.com/docs/api/management/v2#!/Prompts/put_custom_text_by_language
+func (m *CustomTextManager) SetMfaEmail(language string, p *PromptMfaEmail, opts ...RequestOption) error {
+	return m.Request("PUT", m.URI("prompts", "mfa-email", "custom-text", language), p, opts...)
+}
+
+// prompt: mfa-otp
+// See: https://auth0.com/docs/universal-login/prompt-mfa-otp
+
+type ScreenMfaOtpEnrollmentQr struct {
+	PageTitle             string `json:"pageTitle,omitempty"`
+	Title                 string `json:"title,omitempty"`
+	Description           string `json:"description,omitempty"`
+	ButtonText            string `json:"buttonText,omitempty"`
+	CodeEnrollmentText    string `json:"codeEnrollmentText,omitempty"`
+	PickAuthenticatorText string `json:"pickAuthenticatorText,omitempty"`
+	Placeholder           string `json:"placeholder,omitempty"`
+	//Documented but not supported
+	//SeparatorText         string `json:"separatorText,omitempty"`
+	InvalidOtpCodeFormat  string `json:"invalid-otp-code-format,omitempty"`
+	InvalidCode           string `json:"invalid-code,omitempty"`
+	InvalidExpiredCode    string `json:"invalid-expired-code,omitempty"`
+	TooManyFailures       string `json:"too-many-failures,omitempty"`
+	TransactionNotFound   string `json:"transaction-not-found,omitempty"`
+	UserAlreadyEnrolled   string `json:"user-already-enrolled,omitempty"`
+}
+
+type ScreenMfaOtpEnrollmentCode struct {
+	PageTitle             string `json:"pageTitle,omitempty"`
+	BackText              string `json:"backText,omitempty"`
+	ButtonText            string `json:"buttonText,omitempty"`
+	AltText               string `json:"altText,omitempty"`
+	CopyCodeButtonText    string `json:"copyCodeButtonText,omitempty"`
+	Description           string `json:"description,omitempty"`
+	PickAuthenticatorText string `json:"pickAuthenticatorText,omitempty"`
+	Placeholder           string `json:"placeholder,omitempty"`
+	Title                 string `json:"title,omitempty"`
+	TooManyFailures       string `json:"too-many-failures,omitempty"`
+	TransactionNotFound   string `json:"transaction-not-found,omitempty"`
+}
+
+type ScreenMfaOtpEnrollmentChallenge struct {
+	PageTitle             string `json:"pageTitle,omitempty"`
+	Title                 string `json:"title,omitempty"`
+	Description           string `json:"description,omitempty"`
+	ButtonText            string `json:"buttonText,omitempty"`
+	PickAuthenticatorText string `json:"pickAuthenticatorText,omitempty"`
+	Placeholder           string `json:"placeholder,omitempty"`
+	RememberMeText        string `json:"rememberMeText,omitempty"`
+	AuthenticatorError    string `json:"authenticator-error,omitempty"`
+	TooManyFailures       string `json:"too-many-failures,omitempty"`
+	TransactionNotFound   string `json:"transaction-not-found,omitempty"`
+}
+
+type PromptMfaOtp struct {
+	MfaOtpEnrollmentQr ScreenMfaOtpEnrollmentQr `json:"mfa-otp-enrollment-qr"`
+	MfaOtpEnrollmentCode ScreenMfaOtpEnrollmentCode `json:"mfa-otp-enrollment-code"`
+	MfaOtpEnrollmentChallenge ScreenMfaOtpEnrollmentChallenge `json:"mfa-otp-challenge"`
+}
+
+// ReadMfaOtp reads mfa-otp custom text
+//
+// See: https://auth0.com/docs/api/management/v2#!/Prompts/get_custom_text_by_language
+func (m *CustomTextManager) ReadMfaOtp(language string, opts ...RequestOption) (p *PromptMfaOtp, err error) {
+	err = m.Request("GET", m.URI("prompts", "mfa-otp", "custom-text", language), &p, opts...)
+	return
+}
+
+// SetMfaOtp sets mfa-otp custom text
+//
+// See: https://auth0.com/docs/api/management/v2#!/Prompts/put_custom_text_by_language
+func (m *CustomTextManager) SetMfaOtp(language string, p *PromptMfaOtp, opts ...RequestOption) error {
+	return m.Request("PUT", m.URI("prompts", "mfa-otp", "custom-text", language), p, opts...)
+}
+
+// prompt: mfa-phone
+// See: https://auth0.com/docs/universal-login/prompt-mfa-phone
+
+type ScreenMfaPhoneChallenge struct {
+	PageTitle             string `json:"pageTitle,omitempty"`
+	Title                 string `json:"title,omitempty"`
+	Description           string `json:"description,omitempty"`
+	ContinueButtonText    string `json:"continueButtonText,omitempty"`
+	SmsButtonText         string `json:"smsButtonText,omitempty"`
+	VoiceButtonText       string `json:"voiceButtonText,omitempty"`
+	ChooseMessageTypeText string `json:"chooseMessageTypeText,omitempty"`
+	PickAuthenticatorText string `json:"pickAuthenticatorText,omitempty"`
+	Placeholder           string `json:"placeholder,omitempty"`
+	SendSmsFailed         string `json:"send-sms-failed,omitempty"`
+	SendVoiceFailed       string `json:"send-voice-failed,omitempty"`
+	InvalidPhoneFormat    string `json:"invalid-phone-format,omitempty"`
+	InvalidPhone          string `json:"invalid-phone,omitempty"`
+	TooManySms            string `json:"too-many-sms,omitempty"`
+	TooManyVoice          string `json:"too-many-voice,omitempty"`
+	TransactionNotFound   string `json:"transaction-not-found,omitempty"`
+	NoPhone               string `json:"no-phone,omitempty"`
+}
+
+type ScreenMfaPhoneEnrollment struct {
+	PageTitle             string `json:"pageTitle,omitempty"`
+	Title                 string `json:"title,omitempty"`
+	Description           string `json:"description,omitempty"`
+	ContinueButtonText    string `json:"continueButtonText,omitempty"`
+	SmsButtonText         string `json:"smsButtonText,omitempty"`
+	VoiceButtonText       string `json:"voiceButtonText,omitempty"`
+	ChooseMessageTypeText string `json:"chooseMessageTypeText,omitempty"`
+	PickAuthenticatorText string `json:"pickAuthenticatorText,omitempty"`
+	Placeholder           string `json:"placeholder,omitempty"`
+	SendSmsFailed         string `json:"send-sms-failed,omitempty"`
+	SendVoiceFailed       string `json:"send-voice-failed,omitempty"`
+	InvalidPhoneFormat    string `json:"invalid-phone-format,omitempty"`
+	InvalidPhone          string `json:"invalid-phone,omitempty"`
+	TooManySms            string `json:"too-many-sms,omitempty"`
+	TooManyVoice          string `json:"too-many-voice,omitempty"`
+	TransactionNotFound   string `json:"transaction-not-found,omitempty"`
+	NoPhone               string `json:"no-phone,omitempty"`
+}
+
+type PromptMfaPhone struct {
+	MfaPhoneChallenge ScreenMfaPhoneChallenge `json:"mfa-phone-challenge"`
+	MfaPhoneEnrollment ScreenMfaPhoneEnrollment `json:"mfa-phone-enrollment"`
+}
+
+// ReadMfaPhone reads mfa-phone custom text
+//
+// See: https://auth0.com/docs/api/management/v2#!/Prompts/get_custom_text_by_language
+func (m *CustomTextManager) ReadMfaPhone(language string, opts ...RequestOption) (p *PromptMfaPhone, err error) {
+	err = m.Request("GET", m.URI("prompts", "mfa-phone", "custom-text", language), &p, opts...)
+	return
+}
+
+// SetMfaPhone sets mfa-phone custom text
+//
+// See: https://auth0.com/docs/api/management/v2#!/Prompts/put_custom_text_by_language
+func (m *CustomTextManager) SetMfaPhone(language string, p *PromptMfaPhone, opts ...RequestOption) error {
+	return m.Request("PUT", m.URI("prompts", "mfa-phone", "custom-text", language), p, opts...)
+}
+
+// prompt: mfa-push
+// See: https://auth0.com/docs/universal-login/prompt-mfa-push
+
+type ScreenMfaPushWelcome struct {
+	PageTitle             string `json:"pageTitle,omitempty"`
+	Title                 string `json:"title,omitempty"`
+	Description           string `json:"description,omitempty"`
+	AndroidButtonText     string `json:"androidButtonText,omitempty"`
+	ButtonText            string `json:"buttonText,omitempty"`
+	IosButtonText         string `json:"iosButtonText,omitempty"`
+	PickAuthenticatorText string `json:"pickAuthenticatorText,omitempty"`
+}
+
+type ScreenMfaPushEnrollmentQr struct {
+	PageTitle                    string `json:"pageTitle,omitempty"`
+	Title                        string `json:"title,omitempty"`
+	Description                  string `json:"description,omitempty"`
+	PickAuthenticatorText        string `json:"pickAuthenticatorText,omitempty"`
+	ButtonText                   string `json:"buttonText,omitempty"`
+	EnrollmentTransactionPending string `json:"enrollment-transaction-pending,omitempty"`
+}
+
+type ScreenMfaPushChallengePush struct {
+	PageTitle                          string `json:"pageTitle,omitempty"`
+	Title                              string `json:"title,omitempty"`
+	Description                        string `json:"description,omitempty"`
+	//Documented but not supported
+	//AwaitingConfirmation               string `json:"awaitingConfirmation,omitempty"`
+	ButtonText                         string `json:"buttonText,omitempty"`
+	PickAuthenticatorText              string `json:"pickAuthenticatorText,omitempty"`
+	RememberMeText                     string `json:"rememberMeText,omitempty"`
+	ResendActionText                   string `json:"resendActionText,omitempty"`
+	ResendText                         string `json:"resendText,omitempty"`
+	EnterOtpCode                       string `json:"enterOtpCode,omitempty"`
+	SeparatorText                      string `json:"separatorText,omitempty"`
+	ChallengeTransactionPending        string `json:"challenge-transaction-pending,omitempty"`
+	PollingIntervalExceeded            string `json:"polling-interval-exceeded,omitempty"`
+	TooManyPush                        string `json:"too-many-push,omitempty"`
+	TransactionNotFound                string `json:"transaction-not-found,omitempty"`
+	MfaPushVerifyTransactionPending    string `json:"mfa-push-verify-transaction-pending,omitempty"`
+	MfaPushVerifyAuthenticatorError    string `json:"mfa-push-verify-authenticator-error,omitempty"`
+	MfaPushChallengeAuthenticatorError string `json:"mfa-push-challenge-authenticator-error,omitempty"`
+	TransactionRejected                string `json:"transaction-rejected,omitempty"`
+}
+
+type ScreenMfaPushList struct {
+	PageTitle string `json:"pageTitle,omitempty"`
+	BackText  string `json:"backText,omitempty"`
+	Title     string `json:"title,omitempty"`
+}
+
+type PromptMfaPush struct {
+	MfaPushWelcome ScreenMfaPushWelcome `json:"mfa-push-welcome"`
+	MfaPushEnrollmentQr ScreenMfaPushEnrollmentQr `json:"mfa-push-enrollment-qr"`
+	MfaPushChallengePush ScreenMfaPushChallengePush `json:"mfa-push-challenge-push"`
+	MfaPushList ScreenMfaPushList `json:"mfa-push-list"`
+}
+
+// ReadMfaPush reads mfa-push custom text
+//
+// See: https://auth0.com/docs/api/management/v2#!/Prompts/get_custom_text_by_language
+func (m *CustomTextManager) ReadMfaPush(language string, opts ...RequestOption) (p *PromptMfaPush, err error) {
+	err = m.Request("GET", m.URI("prompts", "mfa-push", "custom-text", language), &p, opts...)
+	return
+}
+
+// SetMfaPush sets mfa-push custom text
+//
+// See: https://auth0.com/docs/api/management/v2#!/Prompts/put_custom_text_by_language
+func (m *CustomTextManager) SetMfaPush(language string, p *PromptMfaPush, opts ...RequestOption) error {
+	return m.Request("PUT", m.URI("prompts", "mfa-push", "custom-text", language), p, opts...)
+}
+
+// prompt: mfa-recovery-code
+// See: https://auth0.com/docs/universal-login/prompt-mfa-recovery-code
+
+type ScreenMfaRecoveryCodeEnrollment struct {
+	PageTitle          string `json:"pageTitle,omitempty"`
+	Title              string `json:"title,omitempty"`
+	Description        string `json:"description,omitempty"`
+	AltText            string `json:"altText,omitempty"`
+	ButtonText         string `json:"buttonText,omitempty"`
+	CheckboxText       string `json:"checkboxText,omitempty"`
+	CopyCodeButtonText string `json:"copyCodeButtonText,omitempty"`
+	NoConfirmation     string `json:"no-confirmation,omitempty"`
+}
+
+type ScreenMfaRecoveryCodeChallenge struct {
+	PageTitle             string `json:"pageTitle,omitempty"`
+	Title                 string `json:"title,omitempty"`
+	Description           string `json:"description,omitempty"`
+	ButtonText            string `json:"buttonText,omitempty"`
+	PickAuthenticatorText string `json:"pickAuthenticatorText,omitempty"`
+	Placeholder           string `json:"placeholder,omitempty"`
+	InvalidCode           string `json:"invalid-code,omitempty"`
+	InvalidCodeFormat     string `json:"invalid-code-format,omitempty"`
+	InvalidExpiredCode    string `json:"invalid-expired-code,omitempty"`
+	AuthenticatorError    string `json:"authenticator-error,omitempty"`
+	NoConfirmation        string `json:"no-confirmation,omitempty"`
+	TooManyFailures       string `json:"too-many-failures,omitempty"`
+	TransactionNotFound   string `json:"transaction-not-found,omitempty"`
+}
+
+type PromptMfaRecoveryCode struct {
+	MfaRecoveryCodeEnrollment ScreenMfaRecoveryCodeEnrollment `json:"mfa-recovery-code-enrollment"`
+	MfaRecoveryCodeChallenge ScreenMfaRecoveryCodeChallenge `json:"mfa-recovery-code-challenge"`
+}
+
+// ReadMfaRecoveryCode reads mfa-recovery-code custom text
+//
+// See: https://auth0.com/docs/api/management/v2#!/Prompts/get_custom_text_by_language
+func (m *CustomTextManager) ReadMfaRecoveryCode(language string, opts ...RequestOption) (p *PromptMfaRecoveryCode, err error) {
+	err = m.Request("GET", m.URI("prompts", "mfa-recovery-code", "custom-text", language), &p, opts...)
+	return
+}
+
+// SetMfaRecoveryCode sets mfa-recovery-code custom text
+//
+// See: https://auth0.com/docs/api/management/v2#!/Prompts/put_custom_text_by_language
+func (m *CustomTextManager) SetMfaRecoveryCode(language string, p *PromptMfaRecoveryCode, opts ...RequestOption) error {
+	return m.Request("PUT", m.URI("prompts", "mfa-recovery-code", "custom-text", language), p, opts...)
+}
+
+// prompt: mfa-sms
+// See: https://auth0.com/docs/universal-login/prompt-mfa-sms
+
+type ScreenMfaCountryCodes struct {
+	PageTitle string `json:"pageTitle,omitempty"`
+	BackText  string `json:"backText,omitempty"`
+	Title     string `json:"title,omitempty"`
+}
+
+type ScreenMfaSmsEnrollment struct {
+	PageTitle             string `json:"pageTitle,omitempty"`
+	Title                 string `json:"title,omitempty"`
+	Description           string `json:"description,omitempty"`
+	ButtonText            string `json:"buttonText,omitempty"`
+	PickAuthenticatorText string `json:"pickAuthenticatorText,omitempty"`
+	Placeholder           string `json:"placeholder,omitempty"`
+	SendSmsFailed         string `json:"send-sms-failed,omitempty"`
+	InvalidPhoneFormat    string `json:"invalid-phone-format,omitempty"`
+	InvalidPhone          string `json:"invalid-phone,omitempty"`
+	TooManySms            string `json:"too-many-sms,omitempty"`
+	TransactionNotFound   string `json:"transaction-not-found,omitempty"`
+	NoPhone               string `json:"no-phone,omitempty"`
+}
+
+type ScreenMfaSmsChallenge struct {
+	PageTitle                            string `json:"pageTitle,omitempty"`
+	Title                                string `json:"title,omitempty"`
+	Description                          string `json:"description,omitempty"`
+	ButtonText                           string `json:"buttonText,omitempty"`
+	EditText                             string `json:"editText,omitempty"`
+	PickAuthenticatorText                string `json:"pickAuthenticatorText,omitempty"`
+	Placeholder                          string `json:"placeholder,omitempty"`
+	RememberMeText                       string `json:"rememberMeText,omitempty"`
+	ResendActionText                     string `json:"resendActionText,omitempty"`
+	ResendText                           string `json:"resendText,omitempty"`
+	ResendVoiceActionSeparatorTextBefore string `json:"resendVoiceActionSeparatorTextBefore,omitempty"`
+	ResendVoiceActionText                string `json:"resendVoiceActionText,omitempty"`
+	ResendVoiceActionSeparatorTextAfter  string `json:"resendVoiceActionSeparatorTextAfter,omitempty"`
+	InvalidOtpCodeFormat                 string `json:"invalid-otp-code-format,omitempty"`
+	InvalidCode                          string `json:"invalid-code,omitempty"`
+	InvalidExpiredCode                   string `json:"invalid-expired-code,omitempty"`
+	SendSmsFailed                        string `json:"send-sms-failed,omitempty"`
+	AuthenticatorError                   string `json:"authenticator-error,omitempty"`
+	SmsAuthenticatorError                string `json:"sms-authenticator-error,omitempty"`
+	NoTransactionInProgress              string `json:"no-transaction-in-progress,omitempty"`
+	TooManyFailures                      string `json:"too-many-failures,omitempty"`
+	TooManySms                           string `json:"too-many-sms,omitempty"`
+	TransactionNotFound                  string `json:"transaction-not-found,omitempty"`
+}
+
+type ScreenMfaSmsList struct {
+	PageTitle string `json:"pageTitle,omitempty"`
+	BackText  string `json:"backText,omitempty"`
+	Title     string `json:"title,omitempty"`
+}
+
+type PromptMfaSms struct {
+	MfaCountryCodes  ScreenMfaCountryCodes  `json:"mfa-country-codes"`
+	MfaSmsEnrollment ScreenMfaSmsEnrollment `json:"mfa-sms-enrollment"`
+	MfaSmsChallenge  ScreenMfaSmsChallenge  `json:"mfa-sms-challenge"`
+	MfaSmsList       ScreenMfaSmsList       `json:"mfa-sms-list"`
+}
+
+// ReadMfaSms reads mfa-sms custom text
+//
+// See: https://auth0.com/docs/api/management/v2#!/Prompts/get_custom_text_by_language
+func (m *CustomTextManager) ReadMfaSms(language string, opts ...RequestOption) (p *PromptMfaSms, err error) {
+	err = m.Request("GET", m.URI("prompts", "mfa-sms", "custom-text", language), &p, opts...)
+	return
+}
+
+// SetMfaSms sets mfa-sms custom text
+//
+// See: https://auth0.com/docs/api/management/v2#!/Prompts/put_custom_text_by_language
+func (m *CustomTextManager) SetMfaSms(language string, p *PromptMfaSms, opts ...RequestOption) error {
+	return m.Request("PUT", m.URI("prompts", "mfa-sms", "custom-text", language), p, opts...)
+}
+
+// prompt: mfa-voice
+// See: https://auth0.com/docs/universal-login/prompt-mfa-voice
+
+type ScreenMfaVoiceEnrollment struct {
+	PageTitle             string `json:"pageTitle,omitempty"`
+	Title                 string `json:"title,omitempty"`
+	Description           string `json:"description,omitempty"`
+	ButtonText            string `json:"buttonText,omitempty"`
+	PickAuthenticatorText string `json:"pickAuthenticatorText,omitempty"`
+	Placeholder           string `json:"placeholder,omitempty"`
+	SendSmsFailed         string `json:"send-sms-failed,omitempty"`
+	InvalidPhoneFormat    string `json:"invalid-phone-format,omitempty"`
+	InvalidPhone          string `json:"invalid-phone,omitempty"`
+	TooManySms            string `json:"too-many-sms,omitempty"`
+	TransactionNotFound   string `json:"transaction-not-found,omitempty"`
+	NoPhone               string `json:"no-phone,omitempty"`
+}
+
+type ScreenMfaVoiceChallenge struct {
+	PageTitle                          string `json:"pageTitle,omitempty"`
+	Title                              string `json:"title,omitempty"`
+	Description                        string `json:"description,omitempty"`
+	ButtonText                         string `json:"buttonText,omitempty"`
+	EditText                           string `json:"editText,omitempty"`
+	PickAuthenticatorText              string `json:"pickAuthenticatorText,omitempty"`
+	Placeholder                        string `json:"placeholder,omitempty"`
+	RememberMeText                     string `json:"rememberMeText,omitempty"`
+	ResendActionText                   string `json:"resendActionText,omitempty"`
+	ResendText                         string `json:"resendText,omitempty"`
+	ResendSmsActionSeparatorTextBefore string `json:"resendSmsActionSeparatorTextBefore,omitempty"`
+	ResendSmsActionText                string `json:"resendSmsActionText,omitempty"`
+	ResendSmsActionSeparatorTextAfter  string `json:"resendSmsActionSeparatorTextAfter,omitempty"`
+	InvalidOtpCodeFormat               string `json:"invalid-otp-code-format,omitempty"`
+	InvalidCode                        string `json:"invalid-code,omitempty"`
+	InvalidExpiredCode                 string `json:"invalid-expired-code,omitempty"`
+	SendVoiceFailed                    string `json:"send-voice-failed,omitempty"`
+	AuthenticatorError                 string `json:"authenticator-error,omitempty"`
+	VoiceAuthenticatorError            string `json:"voice-authenticator-error,omitempty"`
+	NoTransactionInProgress            string `json:"no-transaction-in-progress,omitempty"`
+	TooManyFailures                    string `json:"too-many-failures,omitempty"`
+	TooManyVoice                       string `json:"too-many-voice,omitempty"`
+	TransactionNotFound                string `json:"transaction-not-found,omitempty"`
+	NoPhone                            string `json:"no-phone,omitempty"`
+}
+
+type PromptMfaVoice struct {
+	MfaVoiceEnrollment ScreenMfaVoiceEnrollment `json:"mfa-voice-enrollment"`
+	MfaVoiceChallenge  ScreenMfaVoiceChallenge  `json:"mfa-voice-challenge"`
+}
+
+// ReadMfaVoice reads mfa-voice custom text
+//
+// See: https://auth0.com/docs/api/management/v2#!/Prompts/get_custom_text_by_language
+func (m *CustomTextManager) ReadMfaVoice(language string, opts ...RequestOption) (p *PromptMfaVoice, err error) {
+	err = m.Request("GET", m.URI("prompts", "mfa-voice", "custom-text", language), &p, opts...)
+	return
+}
+
+// SetMfaVoice sets mfa-voice custom text
+//
+// See: https://auth0.com/docs/api/management/v2#!/Prompts/put_custom_text_by_language
+func (m *CustomTextManager) SetMfaVoice(language string, p *PromptMfaVoice, opts ...RequestOption) error {
+	return m.Request("PUT", m.URI("prompts", "mfa-voice", "custom-text", language), p, opts...)
+}
+
+// prompt: organizations
+// See: https://auth0.com/docs/universal-login/prompt-organization-selection
+
+type ScreenOrganizationSelection struct {
+	PageTitle                string `json:"pageTitle,omitempty"`
+	Title                    string `json:"title,omitempty"`
+	Description              string `json:"description,omitempty"`
+	ButtonText               string `json:"buttonText,omitempty"`
+	Placeholder              string `json:"placeholder,omitempty"`
+	//Documented but not supported
+	//ErrorInvalidOrganization string `json:"error_invalid-organization,omitempty"`
+	LogoAltText              string `json:"logoAltText,omitempty"`
+}
+
+type PromptOrganizations struct {
+	OrganizationSelection ScreenOrganizationSelection `json:"organization-selection"`
+}
+
+// ReadOrganizations reads organizations custom text
+//
+// See: https://auth0.com/docs/api/management/v2#!/Prompts/get_custom_text_by_language
+func (m *CustomTextManager) ReadOrganizations(language string, opts ...RequestOption) (p *PromptOrganizations, err error) {
+	err = m.Request("GET", m.URI("prompts", "organizations", "custom-text", language), &p, opts...)
+	return
+}
+
+// SetOrganizations sets organizations custom text
+//
+// See: https://auth0.com/docs/api/management/v2#!/Prompts/put_custom_text_by_language
+func (m *CustomTextManager) SetOrganizations(language string, p *PromptOrganizations, opts ...RequestOption) error {
+	return m.Request("PUT", m.URI("prompts", "organizations", "custom-text", language), p, opts...)
+}
+
+// prompt: reset-password
+// See: https://auth0.com/docs/universal-login/prompt-reset-password
+
+type ScreenResetPasswordRequest struct {
+	PageTitle               string `json:"pageTitle,omitempty"`
+	Title                   string `json:"title,omitempty"`
+	BackToLoginLinkText     string `json:"backToLoginLinkText,omitempty"`
+	ButtonText              string `json:"buttonText,omitempty"`
+	DescriptionEmail        string `json:"descriptionEmail,omitempty"`
+	DescriptionUsername     string `json:"descriptionUsername,omitempty"`
+	PlaceholderEmail        string `json:"placeholderEmail,omitempty"`
+	PlaceholderUsername     string `json:"placeholderUsername,omitempty"`
+	InvalidEmailFormat      string `json:"invalid-email-format,omitempty"`
+	Auth0UsersExpiredTicket string `json:"auth0-users-expired-ticket,omitempty"`
+	CustomScriptErrorCode   string `json:"custom-script-error-code,omitempty"`
+	Auth0UsersUsedTicket    string `json:"auth0-users-used-ticket,omitempty"`
+	Auth0UsersValidation    string `json:"auth0-users-validation,omitempty"`
+	ResetPasswordError      string `json:"reset-password-error,omitempty"`
+	TooManyEmail            string `json:"too-many-email,omitempty"`
+	TooManyRequests         string `json:"too-many-requests,omitempty"`
+	NoEmail                 string `json:"no-email,omitempty"`
+	NoUsername              string `json:"no-username,omitempty"`
+}
+
+type ScreenResetPasswordEmail struct {
+	PageTitle           string `json:"pageTitle,omitempty"`
+	Title               string `json:"title,omitempty"`
+	EmailDescription    string `json:"emailDescription,omitempty"`
+	ResendLinkText      string `json:"resendLinkText,omitempty"`
+	//Documented but not supported
+	//ResendText          string `json:"resendText,omitempty"`
+	UsernameDescription string `json:"usernameDescription,omitempty"`
+}
+
+type ScreenResetPassword struct {
+	PageTitle                  string `json:"pageTitle,omitempty"`
+	Title                      string `json:"title,omitempty"`
+	Description                string `json:"description,omitempty"`
+	ButtonText                 string `json:"buttonText,omitempty"`
+	PasswordPlaceholder        string `json:"passwordPlaceholder,omitempty"`
+	ReEnterPasswordPlaceholder string `json:"reEnterpasswordPlaceholder,omitempty"`
+	PasswordSecurityText       string `json:"passwordSecurityText,omitempty"`
+	Auth0UsersExpiredTicket    string `json:"auth0-users-expired-ticket,omitempty"`
+	CustomScriptErrorCode      string `json:"custom-script-error-code,omitempty"`
+	Auth0UsersUsedTicket       string `json:"auth0-users-used-ticket,omitempty"`
+	Auth0UsersValidation       string `json:"auth0-users-validation,omitempty"`
+	NoReEnterPassword          string `json:"no-re-enter-password,omitempty"`
+}
+
+type ScreenResetPasswordSuccess struct {
+	PageTitle   string `json:"pageTitle,omitempty"`
+	EventTitle  string `json:"eventTitle,omitempty"`
+	Description string `json:"description,omitempty"`
+	ButtonText  string `json:"buttonText,omitempty"`
+}
+
+type ScreenResetPasswordError struct {
+	PageTitle               string `json:"pageTitle,omitempty"`
+	BackToLoginLinkText     string `json:"backToLoginLinkText,omitempty"`
+	DescriptionExpired      string `json:"descriptionExpired,omitempty"`
+	DescriptionGeneric      string `json:"descriptionGeneric,omitempty"`
+	DescriptionUsed         string `json:"descriptionUsed,omitempty"`
+	EventTitleExpired       string `json:"eventTitleExpired,omitempty"`
+	EventTitleUsed          string `json:"eventTitleUsed,omitempty"`
+	Auth0UsersExpiredTicket string `json:"auth0-users-expired-ticket,omitempty"`
+	CustomScriptErrorCode   string `json:"custom-script-error-code,omitempty"`
+	Auth0UsersUsedTicket    string `json:"auth0-users-used-ticket,omitempty"`
+	Auth0UsersValidation    string `json:"auth0-users-validation,omitempty"`
+	ResetPasswordError      string `json:"reset-password-error,omitempty"`
+}
+
+type PromptResetPassword struct {
+	ResetPasswordRequest ScreenResetPasswordRequest `json:"reset-password-request,omitempty"`
+	ResetPasswordEmail ScreenResetPasswordEmail `json:"reset-password-email,omitempty"`
+	ResetPassword ScreenResetPassword `json:"reset-password"`
+	ResetPasswordSuccess ScreenResetPasswordSuccess `json:"reset-password-success"`
+	ResetPasswordError ScreenResetPasswordError `json:"reset-password-error"`
+}
+
+// ReadResetPassword reads reset-password custom text
+//
+// See: https://auth0.com/docs/api/management/v2#!/Prompts/get_custom_text_by_language
+func (m *CustomTextManager) ReadResetPassword(language string, opts ...RequestOption) (p *PromptResetPassword, err error) {
+	err = m.Request("GET", m.URI("prompts", "reset-password", "custom-text", language), &p, opts...)
+	return
+}
+
+// SetResetPassword sets reset-password custom text
+//
+// See: https://auth0.com/docs/api/management/v2#!/Prompts/put_custom_text_by_language
+func (m *CustomTextManager) SetResetPassword(language string, p *PromptResetPassword, opts ...RequestOption) error {
+	return m.Request("PUT", m.URI("prompts", "reset-password", "custom-text", language), p, opts...)
+}
+
+// prompt: signup
+// See: https://auth0.com/docs/universal-login/prompt-signup
+
+type ScreenSignup struct {
+	PageTitle                        string `json:"pageTitle,omitempty"`
+	Title                            string `json:"title,omitempty"`
+	Description                      string `json:"description,omitempty"`
+	SeparatorText                    string `json:"separatorText,omitempty"`
+	ButtonText                       string `json:"buttonText,omitempty"`
+	EmailPlaceholder                 string `json:"emailPlaceholder,omitempty"`
+	FederatedConnectionButtonText    string `json:"federatedConnectionButtonText,omitempty"`
+	LoginActionLinkText              string `json:"loginActionLinkText,omitempty"`
+	LoginActionText                  string `json:"loginActionText,omitempty"`
+	PasswordPlaceholder              string `json:"passwordPlaceholder,omitempty"`
+	PasswordSecurityText             string `json:"passwordSecurityText,omitempty"`
+	UsernamePlaceholder              string `json:"usernamePlaceholder,omitempty"`
+	EmailInUse                       string `json:"email-in-use,omitempty"`
+	InvalidEmailFormat               string `json:"invalid-email-format,omitempty"`
+	PasswordTooWeak                  string `json:"password-too-common,omitempty"`
+	PasswordTooCommon                string `json:"password-too-weak,omitempty"`
+	PasswordPreviouslyUsed           string `json:"password-previously-used,omitempty"`
+	PasswordMismatch                 string `json:"password-mismatch,omitempty"`
+	InvalidUsername                  string `json:"invalid-username,omitempty"`
+	InvalidUsernameMaxLength         string `json:"invalid-username-max-length,omitempty"`
+	InvalidUsernameMinLength         string `json:"invalid-username-min-length,omitempty"`
+	InvalidUsernameInvalidCharacters string `json:"invalid-username-invalid-characters,omitempty"`
+	InvalidUsernameEmailNotAllowed   string `json:"invalid-username-email-not-allowed,omitempty"`
+	UsernameTaken                    string `json:"username-taken,omitempty"`
+	CustomScriptErrorCode            string `json:"custom-script-error-code,omitempty"`
+	Auth0UsersValidation             string `json:"auth0-users-validation,omitempty"`
+	InvalidConnection                string `json:"invalid-connection,omitempty"`
+	IpBlocked                        string `json:"ip-blocked,omitempty"`
+	IpSignupBlocked                  string `json:"ip-signup-blocked,omitempty"`
+	NoDbConnection                   string `json:"no-db-connection,omitempty"`
+	NoEmail                          string `json:"no-email,omitempty"`
+	NoPasswordd                       string `json:"no-password,omitempty"`
+	NoReEnterPassword                string `json:"no-re-enter-password,omitempty"`
+	NoUsername                       string `json:"no-username,omitempty"`
+}
+
+type PromptSignup struct {
+	Signup ScreenSignup `json:"signup"`
+}
+
+// ReadSignup reads signup custom text
+//
+// See: https://auth0.com/docs/api/management/v2#!/Prompts/get_custom_text_by_language
+func (m *CustomTextManager) ReadSignup(language string, opts ...RequestOption) (p *PromptSignup, err error) {
+	err = m.Request("GET", m.URI("prompts", "signup", "custom-text", language), &p, opts...)
+	return
+}
+
+// SetSignup sets signup custom text
+//
+// See: https://auth0.com/docs/api/management/v2#!/Prompts/put_custom_text_by_language
+func (m *CustomTextManager) SetSignup(language string, p *PromptSignup, opts ...RequestOption) error {
+	return m.Request("PUT", m.URI("prompts", "signup", "custom-text", language), p, opts...)
+}
+
+// prompt: signup-id
+// See: https://auth0.com/docs/universal-login/prompt-signup-id
+
+type ScreenSignupId struct {
+	PageTitle                        string `json:"pageTitle,omitempty"`
+	Title                            string `json:"title,omitempty"`
+	Description                      string `json:"description,omitempty"`
+	SeparatorText                    string `json:"separatorText,omitempty"`
+	ButtonText                       string `json:"buttonText,omitempty"`
+	EmailPlaceholder                 string `json:"emailPlaceholder,omitempty"`
+	FederatedConnectionButtonText    string `json:"federatedConnectionButtonText,omitempty"`
+	LoginActionLinkText              string `json:"loginActionLinkText,omitempty"`
+	LoginActionText                  string `json:"loginActionText,omitempty"`
+	PasswordPlaceholder              string `json:"passwordPlaceholder,omitempty"`
+	PasswordSecurityText             string `json:"passwordSecurityText,omitempty"`
+	UsernamePlaceholder              string `json:"usernamePlaceholder,omitempty"`
+	LogoAltText                      string `json:"logoAltText,omitempty"`
+	EmailInUse                       string `json:"email-in-use,omitempty"`
+	InvalidEmailFormat               string `json:"invalid-email-format,omitempty"`
+	PasswordTooWeak                  string `json:"password-too-common,omitempty"`
+	PasswordTooCommon                string `json:"password-too-weak,omitempty"`
+	PasswordPreviouslyUsed           string `json:"password-previously-used,omitempty"`
+	PasswordMismatch                 string `json:"password-mismatch,omitempty"`
+	InvalidUsername                  string `json:"invalid-username,omitempty"`
+	InvalidUsernameMaxLength         string `json:"invalid-username-max-length,omitempty"`
+	InvalidUsernameMinLength         string `json:"invalid-username-min-length,omitempty"`
+	InvalidUsernameInvalidCharacters string `json:"invalid-username-invalid-characters,omitempty"`
+	InvalidUsernameEmailNotAllowed   string `json:"invalid-username-email-not-allowed,omitempty"`
+	UsernameTaken                    string `json:"username-taken,omitempty"`
+	CustomScriptErrorCode            string `json:"custom-script-error-code,omitempty"`
+	Auth0UsersValidation             string `json:"auth0-users-validation,omitempty"`
+	InvalidConnection                string `json:"invalid-connection,omitempty"`
+	IpBlocked                        string `json:"ip-blocked,omitempty"`
+	IpSignupBlocked                  string `json:"ip-signup-blocked,omitempty"`
+	NoDbConnection                   string `json:"no-db-connection,omitempty"`
+	NoEmail                          string `json:"no-email,omitempty"`
+	NoPassword                       string `json:"no-password,omitempty"`
+	NoReEnterPassword                string `json:"no-re-enter-password,omitempty"`
+	NoUsername                       string `json:"no-username,omitempty"`
+}
+
+type PromptSignupId struct {
+	SignupId ScreenSignupId `json:"signup-id"`
+}
+
+// ReadSignupId reads signup-id custom text
+//
+// See: https://auth0.com/docs/api/management/v2#!/Prompts/get_custom_text_by_language
+func (m *CustomTextManager) ReadSignupId(language string, opts ...RequestOption) (p *PromptSignupId, err error) {
+	err = m.Request("GET", m.URI("prompts", "signup-id", "custom-text", language), &p, opts...)
+	return
+}
+
+// SetSignupId sets signup-id custom text
+//
+// See: https://auth0.com/docs/api/management/v2#!/Prompts/put_custom_text_by_language
+func (m *CustomTextManager) SetSignupId(language string, p *PromptSignupId, opts ...RequestOption) error {
+	return m.Request("PUT", m.URI("prompts", "signup-id", "custom-text", language), p, opts...)
+}
+
+// prompt: signup-password
+// See: https://auth0.com/docs/universal-login/prompt-signup-password
+
+type ScreenSignupPassword struct {
+	PageTitle                        string `json:"pageTitle,omitempty"`
+	Title                            string `json:"title,omitempty"`
+	Description                      string `json:"description,omitempty"`
+	SeparatorText                    string `json:"separatorText,omitempty"`
+	ButtonText                       string `json:"buttonText,omitempty"`
+	EmailPlaceholder                 string `json:"emailPlaceholder,omitempty"`
+	FederatedConnectionButtonText    string `json:"federatedConnectionButtonText,omitempty"`
+	LoginActionLinkText              string `json:"loginActionLinkText,omitempty"`
+	LoginActionText                  string `json:"loginActionText,omitempty"`
+	//Documented but not supported
+	//LoginLinkText                    string `json:"loginLinkText,omitempty"`
+	InvitationTitle                  string `json:"invitationTitle,omitempty"`
+	InvitationDescription            string `json:"invitationDescription,omitempty"`
+	PasswordPlaceholder              string `json:"passwordPlaceholder,omitempty"`
+	PasswordSecurityText             string `json:"passwordSecurityText,omitempty"`
+	UsernamePlaceholder              string `json:"usernamePlaceholder,omitempty"`
+	EmailInUse                       string `json:"email-in-use,omitempty"`
+	InvalidEmailFormat               string `json:"invalid-email-format,omitempty"`
+	PasswordTooWeak                  string `json:"password-too-common,omitempty"`
+	PasswordTooCommon                string `json:"password-too-weak,omitempty"`
+	PasswordPreviouslyUsed           string `json:"password-previously-used,omitempty"`
+	PasswordMismatch                 string `json:"password-mismatch,omitempty"`
+	InvalidUsername                  string `json:"invalid-username,omitempty"`
+	InvalidUsernameMaxLength         string `json:"invalid-username-max-length,omitempty"`
+	InvalidUsernameMinLength         string `json:"invalid-username-min-length,omitempty"`
+	InvalidUsernameInvalidCharacters string `json:"invalid-username-invalid-characters,omitempty"`
+	InvalidUsernameEmailNotAllowed   string `json:"invalid-username-email-not-allowed,omitempty"`
+	UsernameTaken                    string `json:"username-taken,omitempty"`
+	CustomScriptErrorCode            string `json:"custom-script-error-code,omitempty"`
+	Auth0UsersValidation             string `json:"auth0-users-validation,omitempty"`
+	InvalidConnection                string `json:"invalid-connection,omitempty"`
+	IpBlocked                        string `json:"ip-blocked,omitempty"`
+	IpSignupBlocked                  string `json:"ip-signup-blocked,omitempty"`
+	NoDbConnection                   string `json:"no-db-connection,omitempty"`
+	NoEmail                          string `json:"no-email,omitempty"`
+	NoPassword                       string `json:"no-password,omitempty"`
+	NoReEnterPassword                string `json:"no-re-enter-password,omitempty"`
+	NoUsername                       string `json:"no-username,omitempty"`
+	LogoAltText                      string `json:"logoAltText,omitempty"`
+}
+
+type PromptSignupPassword struct {
+	SignupPassword ScreenSignupPassword `json:"signup-password"`
+}
+
+// ReadSignupPassword reads signup-password custom text
+//
+// See: https://auth0.com/docs/api/management/v2#!/Prompts/get_custom_text_by_language
+func (m *CustomTextManager) ReadSignupPassword(language string, opts ...RequestOption) (p *PromptSignupPassword, err error) {
+	err = m.Request("GET", m.URI("prompts", "signup-password", "custom-text", language), &p, opts...)
+	return
+}
+
+// SetSignupPassword sets signup-password custom text
+//
+// See: https://auth0.com/docs/api/management/v2#!/Prompts/put_custom_text_by_language
+func (m *CustomTextManager) SetSignupPassword(language string, p *PromptSignupPassword, opts ...RequestOption) error {
+	return m.Request("PUT", m.URI("prompts", "signup-password", "custom-text", language), p, opts...)
 }

--- a/management/prompt.go
+++ b/management/prompt.go
@@ -65,7 +65,7 @@ type ScreenConsent struct {
 }
 
 type PromptConsent struct {
-	Consent ScreenConsent `json:"consent"`
+	Consent *ScreenConsent `json:"consent,omitempty"`
 }
 
 // ReadConsent reads consent custom text
@@ -120,10 +120,10 @@ type ScreenDeviceCodeConfirmation struct {
 }
 
 type PromptDeviceFlow struct {
-	DeviceCodeActivation        ScreenDeviceCodeActivation        `json:"device-code-activation,omitempty"`
-	DeviceCodeActivationAllowed ScreenDeviceCodeActivationAllowed `json:"device-code-activation-allowed,omitempty"`
-	DeviceCodeActivationDenied  ScreenDeviceCodeActivationDenied  `json:"device-code-activation-denied,omitempty"`
-	DeviceCodeConfirmation      ScreenDeviceCodeConfirmation      `json:"device-code-confirmation"`
+	DeviceCodeActivation        *ScreenDeviceCodeActivation        `json:"device-code-activation,omitempty"`
+	DeviceCodeActivationAllowed *ScreenDeviceCodeActivationAllowed `json:"device-code-activation-allowed,omitempty"`
+	DeviceCodeActivationDenied  *ScreenDeviceCodeActivationDenied  `json:"device-code-activation-denied,omitempty"`
+	DeviceCodeConfirmation      *ScreenDeviceCodeConfirmation      `json:"device-code-confirmation"`
 }
 
 // ReadDeviceFlow reads device-flow custom text
@@ -160,7 +160,7 @@ type ScreenEmailOtpChallenge struct {
 }
 
 type PromptEmailOtpChallenge struct {
-	EmailOtpChallenge ScreenEmailOtpChallenge `json:"email-otp-challenge"`
+	EmailOtpChallenge *ScreenEmailOtpChallenge `json:"email-otp-challenge,omitempty"`
 }
 
 // ReadEmailOtpChallenge reads email-otp-challenge custom text
@@ -197,7 +197,7 @@ type ScreenEmailVerificationResult struct {
 }
 
 type PromptEmailVerification struct {
-	EmailVerificationResult ScreenEmailVerificationResult `json:"email-verification-result"`
+	EmailVerificationResult *ScreenEmailVerificationResult `json:"email-verification-result,omitempty"`
 }
 
 // ReadEmailVerification reads email-verification custom text
@@ -227,7 +227,7 @@ type ScreenAcceptInvitation struct {
 }
 
 type PromptInvitation struct {
-	AcceptInvitation ScreenAcceptInvitation `json:"accept-invitation"`
+	AcceptInvitation *ScreenAcceptInvitation `json:"accept-invitation,omitempty"`
 }
 
 // ReadInvitation reads invitation custom text
@@ -290,7 +290,7 @@ type ScreenLogin struct {
 }
 
 type PromptLogin struct {
-	Login ScreenLogin `json:"login"`
+	Login *ScreenLogin `json:"login,omitempty"`
 }
 
 // ReadLogin reads login custom text
@@ -347,7 +347,7 @@ type ScreenLoginId struct {
 }
 
 type PromptLoginId struct {
-	LoginId ScreenLoginId `json:"login-id"`
+	LoginId *ScreenLoginId `json:"login-id,omitempty"`
 }
 
 // ReadLoginId reads login-id custom text
@@ -406,7 +406,7 @@ type ScreenLoginPassword struct {
 }
 
 type PromptLoginPassword struct {
-	LoginPassword ScreenLoginPassword `json:"login-password"`
+	LoginPassword *ScreenLoginPassword `json:"login-password,omitempty"`
 }
 
 // ReadLoginPassword reads login-password custom text
@@ -443,7 +443,7 @@ type ScreenLoginEmailVerification struct {
 }
 
 type PromptLoginEmailVerification struct {
-	LoginEmailVerification ScreenLoginEmailVerification `json:"login-email-verification"`
+	LoginEmailVerification *ScreenLoginEmailVerification `json:"login-email-verification,omitempty"`
 }
 
 // ReadLoginEmailVerification reads login-email-verification custom text
@@ -514,9 +514,9 @@ type ScreenMfaBeginEnrollOptions struct {
 }
 
 type PromptMfa struct {
-	MfaEnrollResult ScreenMfaEnrollResult `json:"mfa-enroll-result"`
-	MfaLoginOptions ScreenMfaLoginOptions `json:"mfa-login-options"`
-	MfaBeginEnrollOptions ScreenMfaBeginEnrollOptions `json:"mfa-begin-enroll-options"`
+	MfaEnrollResult       *ScreenMfaEnrollResult       `json:"mfa-enroll-result,omitempty"`
+	MfaLoginOptions       *ScreenMfaLoginOptions       `json:"mfa-login-options,omitempty"`
+	MfaBeginEnrollOptions *ScreenMfaBeginEnrollOptions `json:"mfa-begin-enroll-options,omitempty"`
 }
 
 // ReadMfa reads mfa custom text
@@ -565,8 +565,8 @@ type ScreenMfaEmailList struct {
 }
 
 type PromptMfaEmail struct {
-	MfaEmailChallenge ScreenMfaEmailChallenge `json:"mfa-email-challenge"`
-	MfaEmailList      ScreenMfaEmailList      `json:"mfa-email-list"`
+	MfaEmailChallenge *ScreenMfaEmailChallenge `json:"mfa-email-challenge,omitempty"`
+	MfaEmailList      *ScreenMfaEmailList      `json:"mfa-email-list,omitempty"`
 }
 
 // ReadMfaEmail reads mfa-email custom text
@@ -633,9 +633,9 @@ type ScreenMfaOtpEnrollmentChallenge struct {
 }
 
 type PromptMfaOtp struct {
-	MfaOtpEnrollmentQr ScreenMfaOtpEnrollmentQr `json:"mfa-otp-enrollment-qr"`
-	MfaOtpEnrollmentCode ScreenMfaOtpEnrollmentCode `json:"mfa-otp-enrollment-code"`
-	MfaOtpEnrollmentChallenge ScreenMfaOtpEnrollmentChallenge `json:"mfa-otp-challenge"`
+	MfaOtpEnrollmentQr        *ScreenMfaOtpEnrollmentQr        `json:"mfa-otp-enrollment-qr,omitempty"`
+	MfaOtpEnrollmentCode      *ScreenMfaOtpEnrollmentCode      `json:"mfa-otp-enrollment-code,omitempty"`
+	MfaOtpEnrollmentChallenge *ScreenMfaOtpEnrollmentChallenge `json:"mfa-otp-challenge,omitempty"`
 }
 
 // ReadMfaOtp reads mfa-otp custom text
@@ -697,8 +697,8 @@ type ScreenMfaPhoneEnrollment struct {
 }
 
 type PromptMfaPhone struct {
-	MfaPhoneChallenge ScreenMfaPhoneChallenge `json:"mfa-phone-challenge"`
-	MfaPhoneEnrollment ScreenMfaPhoneEnrollment `json:"mfa-phone-enrollment"`
+	MfaPhoneChallenge  *ScreenMfaPhoneChallenge  `json:"mfa-phone-challenge,omitempty"`
+	MfaPhoneEnrollment *ScreenMfaPhoneEnrollment `json:"mfa-phone-enrollment,omitempty"`
 }
 
 // ReadMfaPhone reads mfa-phone custom text
@@ -768,10 +768,10 @@ type ScreenMfaPushList struct {
 }
 
 type PromptMfaPush struct {
-	MfaPushWelcome ScreenMfaPushWelcome `json:"mfa-push-welcome"`
-	MfaPushEnrollmentQr ScreenMfaPushEnrollmentQr `json:"mfa-push-enrollment-qr"`
-	MfaPushChallengePush ScreenMfaPushChallengePush `json:"mfa-push-challenge-push"`
-	MfaPushList ScreenMfaPushList `json:"mfa-push-list"`
+	MfaPushWelcome       *ScreenMfaPushWelcome       `json:"mfa-push-welcome,omitempty"`
+	MfaPushEnrollmentQr  *ScreenMfaPushEnrollmentQr  `json:"mfa-push-enrollment-qr,omitempty"`
+	MfaPushChallengePush *ScreenMfaPushChallengePush `json:"mfa-push-challenge-push,omitempty"`
+	MfaPushList          *ScreenMfaPushList          `json:"mfa-push-list,omitempty"`
 }
 
 // ReadMfaPush reads mfa-push custom text
@@ -820,8 +820,8 @@ type ScreenMfaRecoveryCodeChallenge struct {
 }
 
 type PromptMfaRecoveryCode struct {
-	MfaRecoveryCodeEnrollment ScreenMfaRecoveryCodeEnrollment `json:"mfa-recovery-code-enrollment"`
-	MfaRecoveryCodeChallenge ScreenMfaRecoveryCodeChallenge `json:"mfa-recovery-code-challenge"`
+	MfaRecoveryCodeEnrollment *ScreenMfaRecoveryCodeEnrollment `json:"mfa-recovery-code-enrollment,omitempty"`
+	MfaRecoveryCodeChallenge  *ScreenMfaRecoveryCodeChallenge  `json:"mfa-recovery-code-challenge,omitempty"`
 }
 
 // ReadMfaRecoveryCode reads mfa-recovery-code custom text
@@ -896,10 +896,10 @@ type ScreenMfaSmsList struct {
 }
 
 type PromptMfaSms struct {
-	MfaCountryCodes  ScreenMfaCountryCodes  `json:"mfa-country-codes"`
-	MfaSmsEnrollment ScreenMfaSmsEnrollment `json:"mfa-sms-enrollment"`
-	MfaSmsChallenge  ScreenMfaSmsChallenge  `json:"mfa-sms-challenge"`
-	MfaSmsList       ScreenMfaSmsList       `json:"mfa-sms-list"`
+	MfaCountryCodes  *ScreenMfaCountryCodes  `json:"mfa-country-codes,omitempty"`
+	MfaSmsEnrollment *ScreenMfaSmsEnrollment `json:"mfa-sms-enrollment,omitempty"`
+	MfaSmsChallenge  *ScreenMfaSmsChallenge  `json:"mfa-sms-challenge,omitempty"`
+	MfaSmsList       *ScreenMfaSmsList       `json:"mfa-sms-list,omitempty"`
 }
 
 // ReadMfaSms reads mfa-sms custom text
@@ -963,8 +963,8 @@ type ScreenMfaVoiceChallenge struct {
 }
 
 type PromptMfaVoice struct {
-	MfaVoiceEnrollment ScreenMfaVoiceEnrollment `json:"mfa-voice-enrollment"`
-	MfaVoiceChallenge  ScreenMfaVoiceChallenge  `json:"mfa-voice-challenge"`
+	MfaVoiceEnrollment *ScreenMfaVoiceEnrollment `json:"mfa-voice-enrollment,omitempty"`
+	MfaVoiceChallenge  *ScreenMfaVoiceChallenge  `json:"mfa-voice-challenge,omitempty"`
 }
 
 // ReadMfaVoice reads mfa-voice custom text
@@ -997,7 +997,7 @@ type ScreenOrganizationSelection struct {
 }
 
 type PromptOrganizations struct {
-	OrganizationSelection ScreenOrganizationSelection `json:"organization-selection"`
+	OrganizationSelection *ScreenOrganizationSelection `json:"organization-selection,omitempty"`
 }
 
 // ReadOrganizations reads organizations custom text
@@ -1087,11 +1087,11 @@ type ScreenResetPasswordError struct {
 }
 
 type PromptResetPassword struct {
-	ResetPasswordRequest ScreenResetPasswordRequest `json:"reset-password-request,omitempty"`
-	ResetPasswordEmail ScreenResetPasswordEmail `json:"reset-password-email,omitempty"`
-	ResetPassword ScreenResetPassword `json:"reset-password"`
-	ResetPasswordSuccess ScreenResetPasswordSuccess `json:"reset-password-success"`
-	ResetPasswordError ScreenResetPasswordError `json:"reset-password-error"`
+	ResetPasswordRequest *ScreenResetPasswordRequest `json:"reset-password-request,omitempty"`
+	ResetPasswordEmail   *ScreenResetPasswordEmail   `json:"reset-password-email,omitempty"`
+	ResetPassword        *ScreenResetPassword        `json:"reset-password,omitempty"`
+	ResetPasswordSuccess *ScreenResetPasswordSuccess `json:"reset-password-success,omitempty"`
+	ResetPasswordError   *ScreenResetPasswordError   `json:"reset-password-error,omitempty"`
 }
 
 // ReadResetPassword reads reset-password custom text
@@ -1144,13 +1144,13 @@ type ScreenSignup struct {
 	IpSignupBlocked                  string `json:"ip-signup-blocked,omitempty"`
 	NoDbConnection                   string `json:"no-db-connection,omitempty"`
 	NoEmail                          string `json:"no-email,omitempty"`
-	NoPasswordd                       string `json:"no-password,omitempty"`
+	NoPassword                       string `json:"no-password,omitempty"`
 	NoReEnterPassword                string `json:"no-re-enter-password,omitempty"`
 	NoUsername                       string `json:"no-username,omitempty"`
 }
 
 type PromptSignup struct {
-	Signup ScreenSignup `json:"signup"`
+	Signup *ScreenSignup `json:"signup,omitempty"`
 }
 
 // ReadSignup reads signup custom text
@@ -1210,7 +1210,7 @@ type ScreenSignupId struct {
 }
 
 type PromptSignupId struct {
-	SignupId ScreenSignupId `json:"signup-id"`
+	SignupId *ScreenSignupId `json:"signup-id,omitempty"`
 }
 
 // ReadSignupId reads signup-id custom text
@@ -1274,7 +1274,7 @@ type ScreenSignupPassword struct {
 }
 
 type PromptSignupPassword struct {
-	SignupPassword ScreenSignupPassword `json:"signup-password"`
+	SignupPassword *ScreenSignupPassword `json:"signup-password,omitempty"`
 }
 
 // ReadSignupPassword reads signup-password custom text

--- a/management/prompt_test.go
+++ b/management/prompt_test.go
@@ -1,6 +1,7 @@
 package management
 
 import (
+	"fmt"
 	"gopkg.in/auth0.v5"
 	"gopkg.in/auth0.v5/internal/testing/expect"
 	"testing"
@@ -48,4 +49,1471 @@ func TestPrompt(t *testing.T) {
 	}
 	expect.Expect(t, ps.UniversalLoginExperience, "classic")
 	expect.Expect(t, ps.IdentifierFirst, auth0.Bool(false))
+}
+
+// CustomText tests
+//
+// instructions:
+// install go: https://golang.org/doc/install
+// $ cd auth0/management
+// $ go test -run CustomText
+
+// Language to use with tests
+const Language = "en"
+
+func TestConsentCustomText(t *testing.T) {
+	StartVal, err := m.CustomText.ReadConsent(Language)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Cleanup(func() {
+		err = m.CustomText.SetConsent(Language, StartVal)
+		if err != nil {
+			// fails if StartVal is empty object
+			fmt.Printf("Warning, Set-StartVal failed: %q", err)
+		}
+		ReturnVal, err := m.CustomText.ReadConsent(Language)
+		if err != nil {
+			t.Fatal(err)
+		}
+		expect.Expect(t, ReturnVal, StartVal)
+	})
+
+	SetVal := PromptConsent{
+		Consent: ScreenConsent{
+			PageTitle:              "PageTitle",
+			Title:                  "Title",
+			MessageMultipleTenants: "MessageMultipleTenants",
+			AudiencePickerAltText:  "AudiencePickerAltText",
+			MessageSingleTenant:    "MessageSingleTenant",
+			AcceptButtonText:       "AcceptButtonText",
+			DeclineButtonText:      "DeclineButtonText",
+			InvalidAction:          "InvalidAction",
+			InvalidAudience:        "InvalidAudience",
+			InvalidScope:           "InvalidScope",
+		},
+	}
+
+	err = m.CustomText.SetConsent(Language, &SetVal)
+	if err != nil {
+		t.Error(err)
+	}
+
+	ReturnVal, err := m.CustomText.ReadConsent(Language)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expect.Expect(t, *ReturnVal, SetVal)
+}
+
+func TestDeviceFlowCustomText(t *testing.T) {
+	StartVal, err := m.CustomText.ReadDeviceFlow(Language)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Cleanup(func() {
+		err = m.CustomText.SetDeviceFlow(Language, StartVal)
+		if err != nil {
+			// cleanup fails if StartVal is empty object
+			fmt.Printf("Warning, Set-StartVal failed: %q", err)
+		} else {
+			ReturnVal, err := m.CustomText.ReadDeviceFlow(Language)
+			if err != nil {
+				t.Fatal(err)
+			}
+			expect.Expect(t, ReturnVal, StartVal)
+		}
+	})
+
+	SetVal := PromptDeviceFlow{
+		DeviceCodeActivation: ScreenDeviceCodeActivation{
+			PageTitle:          "PageTitle",
+			ButtonText:         "ButtonText",
+			Description:        "Description",
+			Placeholder:        "Placeholder",
+			Title:              "Title",
+			InvalidExpiredCode: "InvalidExpiredCode",
+			NoCode:             "NoCode",
+			InvalidCode:        "InvalidCode",
+		},
+		DeviceCodeActivationAllowed: ScreenDeviceCodeActivationAllowed{
+			PageTitle:   "PageTitle",
+			Description: "Description",
+			EventTitle:  "EventTitle",
+		},
+		DeviceCodeActivationDenied: ScreenDeviceCodeActivationDenied{
+			PageTitle:   "PageTitle",
+			Description: "Description",
+			EventTitle:  "EventTitle",
+		},
+		DeviceCodeConfirmation: ScreenDeviceCodeConfirmation{
+			PageTitle:         "PageTitle",
+			Description:       "Description",
+			InputCodeLabel:    "InputCodeLabel",
+			Title:             "Title",
+			ConfirmButtonText: "ConfirmButtonText",
+			CancelButtonText:  "CancelButtonText",
+			ConfirmationText:  "ConfirmationText",
+		},
+	}
+
+	err = m.CustomText.SetDeviceFlow(Language, &SetVal)
+	if err != nil {
+		t.Error(err)
+	}
+
+	ReturnVal, err := m.CustomText.ReadDeviceFlow(Language)
+	if err != nil {
+		t.Error(err)
+	}
+	expect.Expect(t, *ReturnVal, SetVal)
+}
+
+func TestEmailOtpChallengeCustomText(t *testing.T) {
+	StartVal, err := m.CustomText.ReadEmailOtpChallenge(Language)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Cleanup(func() {
+		err = m.CustomText.SetEmailOtpChallenge(Language, StartVal)
+		if err != nil {
+			// cleanup fails if StartVal is empty object
+			fmt.Printf("Warning, Set-StartVal failed: %q", err)
+		} else {
+			ReturnVal, err := m.CustomText.ReadEmailOtpChallenge(Language)
+			if err != nil {
+				t.Fatal(err)
+			}
+			expect.Expect(t, ReturnVal, StartVal)
+		}
+	})
+
+	SetVal := PromptEmailOtpChallenge{
+		EmailOtpChallenge: ScreenEmailOtpChallenge{
+			PageTitle:            "PageTitle",
+			ButtonText:           "ButtonText",
+			Description:          "Description",
+			Placeholder:          "Placeholder",
+			ResendActionText:     "ResendActionText",
+			ResendText:           "ResendText",
+			Title:                "Title",
+			InvalidOtpCodeFormat: "InvalidOtpCodeFormat",
+			InvalidCode:          "InvalidCode",
+			InvalidExpiredCode:   "InvalidExpiredCode",
+			AuthenticatorError:   "AuthenticatorError",
+			TooManyEmail:         "TooManyEmail",
+		},
+	}
+
+	err = m.CustomText.SetEmailOtpChallenge(Language, &SetVal)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ReturnVal, err := m.CustomText.ReadEmailOtpChallenge(Language)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expect.Expect(t, *ReturnVal, SetVal)
+}
+
+func TestEmailVerificationCustomText(t *testing.T) {
+	StartVal, err := m.CustomText.ReadEmailVerification(Language)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Cleanup(func() {
+		err = m.CustomText.SetEmailVerification(Language, StartVal)
+		if err != nil {
+			// cleanup fails if StartVal is empty object
+			fmt.Printf("Warning, Set-StartVal failed: %q", err)
+		} else {
+			ReturnVal, err := m.CustomText.ReadEmailVerification(Language)
+			if err != nil {
+				t.Fatal(err)
+			}
+			expect.Expect(t, ReturnVal, StartVal)
+		}
+	})
+
+	SetVal := PromptEmailVerification{
+		EmailVerificationResult: ScreenEmailVerificationResult{
+			PageTitle:                       "PageTitle",
+			VerifiedTitle:                   "VerifiedTitle",
+			ErrorTitle:                      "ErrorTitle",
+			VerifiedDescription:             "VerifiedDescription",
+			AlreadyVerifiedDescription:      "AlreadyVerifiedDescription",
+			InvalidAccountOrCodeDescription: "InvalidAccountOrCodeDescription",
+			UnknownErrorDescription:         "UnknownErrorDescription",
+			ButtonText:                      "ButtonText",
+			Auth0UsersExpiredTicket:         "Auth0UsersExpiredTicket",
+			CustomScriptErrorCode:           "CustomScriptErrorCode",
+			Auth0UsersUsedTicket:            "Auth0UsersUsedTicket",
+			Auth0UsersValidation:            "Auth0UsersValidation",
+		},
+	}
+
+	err = m.CustomText.SetEmailVerification(Language, &SetVal)
+	if err != nil {
+		t.Error(err)
+	}
+
+	ReturnVal, err := m.CustomText.ReadEmailVerification(Language)
+	if err != nil {
+		t.Error(err)
+	}
+	expect.Expect(t, *ReturnVal, SetVal)
+}
+
+func TestInvitationCustomText(t *testing.T) {
+	StartVal, err := m.CustomText.ReadInvitation(Language)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Cleanup(func() {
+		err = m.CustomText.SetInvitation(Language, StartVal)
+		if err != nil {
+			// cleanup fails if StartVal is empty object
+			fmt.Printf("Warning, Set-StartVal failed: %q", err)
+		} else {
+			ReturnVal, err := m.CustomText.ReadInvitation(Language)
+			if err != nil {
+				t.Fatal(err)
+			}
+			expect.Expect(t, ReturnVal, StartVal)
+		}
+	})
+
+	SetVal := PromptInvitation{
+		AcceptInvitation: ScreenAcceptInvitation{
+			PageTitle:   "PageTitle",
+			Title:       "Title",
+			Description: "Description",
+			ButtonText:  "ButtonText",
+			LogoAltText: "LogoAltText",
+		},
+	}
+
+	err = m.CustomText.SetInvitation(Language, &SetVal)
+	if err != nil {
+		t.Error(err)
+	}
+
+	ReturnVal, err := m.CustomText.ReadInvitation(Language)
+	if err != nil {
+		t.Error(err)
+	}
+	expect.Expect(t, *ReturnVal, SetVal)
+}
+
+func TestLoginCustomText(t *testing.T) {
+	StartVal, err := m.CustomText.ReadLogin(Language)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Cleanup(func() {
+		err = m.CustomText.SetLogin(Language, StartVal)
+		if err != nil {
+			// cleanup fails if StartVal is empty object
+			fmt.Printf("Warning, Set-StartVal failed: %q", err)
+		} else {
+			ReturnVal, err := m.CustomText.ReadLogin(Language)
+			if err != nil {
+				t.Fatal(err)
+			}
+			expect.Expect(t, ReturnVal, StartVal)
+		}
+	})
+
+	SetVal := PromptLogin{
+		Login: ScreenLogin{
+			PageTitle:                     "PageTitle",
+			Title:                         "Title",
+			Description:                   "Description",
+			SeparatorText:                 "SeparatorText",
+			ButtonText:                    "ButtonText",
+			FederatedConnectionButtonText: "FederatedConnectionButtonText",
+			SignupActionLinkText:          "SignupActionLinkText",
+			SignupActionText:              "SignupActionTextc",
+			ForgotPasswordText:            "ForgotPasswordText",
+			PasswordPlaceholder:           "PasswordPlaceholder",
+			UsernamePlaceholder:           "UsernamePlaceholder",
+			//In online documentation but not supported
+			//CaptchaCodePlaceholder: "CaptchaCodePlaceholder",
+			//CaptchaMatchExprPlaceholder: "CaptchaMatchExprPlaceholder",
+			EmailPlaceholder:      "EmailPlaceholder",
+			EditEmailText:         "EditEmailText",
+			AlertListTitle:        "AlertListTitle",
+			InvitationTitle:       "InvitationTitle",
+			InvitationDescription: "InvitationDescription",
+			WrongCredentials:      "WrongCredentials",
+			//In online documentation but not supported
+			//WrongCaptcha: "WrongCaptcha",
+			InvalidCode:           "InvalidCode",
+			InvalidExpiredCode:    "InvalidExpiredCode",
+			InvalidEmailFormat:    "InvalidEmailFormat",
+			WrongEmailCredentials: "WrongEmailCredentials",
+			CustomScriptErrorCode: "CustomScriptErrorCode",
+			Auth0UsersValidation:  "Auth0UsersValidation",
+			AuthenticationFailure: "AuthenticationFailure",
+			InvalidConnection:     "InvalidConnection",
+			IpBlocked:             "IpBlocked",
+			NoDbConnection:        "NoDbConnection",
+			PasswordBreached:      "PasswordBreached",
+			UserBlocked:           "UserBlocked",
+			SameUserLogin:         "SameUserLogin",
+			NoEmail:               "NoEmail",
+			NoPassword:            "NoPassword",
+			NoUsername:            "NoUsername",
+		},
+	}
+
+	err = m.CustomText.SetLogin(Language, &SetVal)
+	if err != nil {
+		t.Error(err)
+	}
+
+	ReturnVal, err := m.CustomText.ReadLogin(Language)
+	if err != nil {
+		t.Error(err)
+	}
+	expect.Expect(t, *ReturnVal, SetVal)
+}
+
+func TestLoginIdCustomText(t *testing.T) {
+	StartVal, err := m.CustomText.ReadLoginId(Language)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Cleanup(func() {
+		err = m.CustomText.SetLoginId(Language, StartVal)
+		if err != nil {
+			// cleanup fails if StartVal is empty object
+			fmt.Printf("Warning, Set-StartVal failed: %q", err)
+		} else {
+			ReturnVal, err := m.CustomText.ReadLoginId(Language)
+			if err != nil {
+				t.Fatal(err)
+			}
+			expect.Expect(t, ReturnVal, StartVal)
+		}
+	})
+
+	SetVal := PromptLoginId{
+		LoginId: ScreenLoginId{
+			PageTitle:                     "PageTitle",
+			Title:                         "Title",
+			Description:                   "Description",
+			SeparatorText:                 "SeparatorText",
+			ButtonText:                    "ButtonText",
+			FederatedConnectionButtonText: "FederatedConnectionButtonText",
+			SignupActionLinkText:          "SignupActionLinkText",
+			SignupActionText:              "SignupActionTextc",
+			PasswordPlaceholder:           "PasswordPlaceholder",
+			UsernamePlaceholder:           "UsernamePlaceholder",
+			EmailPlaceholder:              "EmailPlaceholder",
+			EditEmailText:                 "EditEmailText",
+			AlertListTitle:                "AlertListTitle",
+			LogoAltText:                   "LogoAltText",
+			WrongCredentials:              "WrongCredentials",
+			InvalidCode:                   "InvalidCode",
+			InvalidExpiredCode:            "InvalidExpiredCode",
+			InvalidEmailFormat:            "InvalidEmailFormat",
+			WrongEmailCredentials:         "WrongEmailCredentials",
+			CustomScriptErrorCode:         "CustomScriptErrorCode",
+			Auth0UsersValidation:          "Auth0UsersValidation",
+			AuthenticationFailure:         "AuthenticationFailure",
+			InvalidConnection:             "InvalidConnection",
+			IpBlocked:                     "IpBlocked",
+			NoDbConnection:                "NoDbConnection",
+			NoHrdConnection:               "NoHrdConnection",
+			PasswordBreached:              "PasswordBreached",
+			UserBlocked:                   "UserBlocked",
+			SameUserLogin:                 "SameUserLogin",
+			NoEmail:                       "NoEmail",
+			NoPassword:                    "NoPassword",
+			NoUsername:                    "NoUsername",
+		},
+	}
+
+	err = m.CustomText.SetLoginId(Language, &SetVal)
+	if err != nil {
+		t.Error(err)
+	}
+
+	ReturnVal, err := m.CustomText.ReadLoginId(Language)
+	if err != nil {
+		t.Error(err)
+	}
+	expect.Expect(t, *ReturnVal, SetVal)
+}
+
+func TestLoginPasswordCustomText(t *testing.T) {
+	StartVal, err := m.CustomText.ReadLoginPassword(Language)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Cleanup(func() {
+		err = m.CustomText.SetLoginPassword(Language, StartVal)
+		if err != nil {
+			// cleanup fails if StartVal is empty object
+			fmt.Printf("Warning, Set-StartVal failed: %q", err)
+		} else {
+			ReturnVal, err := m.CustomText.ReadLoginPassword(Language)
+			if err != nil {
+				t.Fatal(err)
+			}
+			expect.Expect(t, ReturnVal, StartVal)
+		}
+	})
+
+	SetVal := PromptLoginPassword{
+		LoginPassword: ScreenLoginPassword{
+			PageTitle:                     "PageTitle",
+			Title:                         "Title",
+			Description:                   "Description",
+			SeparatorText:                 "SeparatorText",
+			ButtonText:                    "ButtonText",
+			FederatedConnectionButtonText: "FederatedConnectionButtonText",
+			SignupActionLinkText:          "SignupActionLinkText",
+			SignupActionText:              "SignupActionTextc",
+			PasswordPlaceholder:           "PasswordPlaceholder",
+			UsernamePlaceholder:           "UsernamePlaceholder",
+			EmailPlaceholder:              "EmailPlaceholder",
+			EditEmailText:                 "EditEmailText",
+			AlertListTitle:                "AlertListTitle",
+			LogoAltText:                   "LogoAltText",
+			WrongCredentials:              "WrongCredentials",
+			InvalidCode:                   "InvalidCode",
+			InvalidExpiredCode:            "InvalidExpiredCode",
+			InvalidEmailFormat:            "InvalidEmailFormat",
+			WrongEmailCredentials:         "WrongEmailCredentials",
+			CustomScriptErrorCode:         "CustomScriptErrorCode",
+			Auth0UsersValidation:          "Auth0UsersValidation",
+			AuthenticationFailure:         "AuthenticationFailure",
+			InvalidConnection:             "InvalidConnection",
+			IpBlocked:                     "IpBlocked",
+			NoDbConnection:                "NoDbConnection",
+			PasswordBreached:              "PasswordBreached",
+			UserBlocked:                   "UserBlocked",
+			SameUserLogin:                 "SameUserLogin",
+			NoEmail:                       "NoEmail",
+			NoPassword:                    "NoPassword",
+			NoUsername:                    "NoUsername",
+		},
+	}
+
+	err = m.CustomText.SetLoginPassword(Language, &SetVal)
+	if err != nil {
+		t.Error(err)
+	}
+
+	ReturnVal, err := m.CustomText.ReadLoginPassword(Language)
+	if err != nil {
+		t.Error(err)
+	}
+	expect.Expect(t, *ReturnVal, SetVal)
+}
+
+func TestLoginEmailVerificationCustomText(t *testing.T) {
+	StartVal, err := m.CustomText.ReadLoginEmailVerification(Language)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Cleanup(func() {
+		err = m.CustomText.SetLoginEmailVerification(Language, StartVal)
+		if err != nil {
+			// cleanup fails if StartVal is empty object
+			fmt.Printf("Warning, Set-StartVal failed: %q", err)
+		} else {
+			ReturnVal, err := m.CustomText.ReadLoginEmailVerification(Language)
+			if err != nil {
+				t.Fatal(err)
+			}
+			expect.Expect(t, ReturnVal, StartVal)
+		}
+	})
+
+	SetVal := PromptLoginEmailVerification{
+		LoginEmailVerification: ScreenLoginEmailVerification{
+			PageTitle:            "PageTitle",
+			ButtonText:           "ButtonText",
+			Description:          "Description",
+			Placeholder:          "Placeholder",
+			ResendActionText:     "ResendActionText",
+			ResendText:           "ResendText",
+			Title:                "Title",
+			InvalidOtpCodeFormat: "InvalidOtpCodeFormat",
+			InvalidCode:          "InvalidCode",
+			InvalidExpiredCode:   "InvalidExpiredCode",
+			AuthenticatorError:   "AuthenticatorError",
+			TooManyEmail:         "TooManyEmail",
+		},
+	}
+
+	err = m.CustomText.SetLoginEmailVerification(Language, &SetVal)
+	if err != nil {
+		t.Error(err)
+	}
+
+	ReturnVal, err := m.CustomText.ReadLoginEmailVerification(Language)
+	if err != nil {
+		t.Error(err)
+	}
+	expect.Expect(t, *ReturnVal, SetVal)
+}
+
+func TestMfaCustomText(t *testing.T) {
+	StartVal, err := m.CustomText.ReadMfa(Language)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Cleanup(func() {
+		err = m.CustomText.SetMfa(Language, StartVal)
+		if err != nil {
+			// cleanup fails if StartVal is empty object
+			fmt.Printf("Warning, Set-StartVal failed: %q", err)
+		} else {
+			ReturnVal, err := m.CustomText.ReadMfa(Language)
+			if err != nil {
+				t.Fatal(err)
+			}
+			expect.Expect(t, ReturnVal, StartVal)
+		}
+	})
+
+	SetVal := PromptMfa{
+		MfaEnrollResult: ScreenMfaEnrollResult{
+			PageTitle:                  "PageTitle",
+			EnrolledTitle:              "EnrolledTitle",
+			EnrolledDescription:        "EnrolledDescription",
+			InvalidTicketTitle:         "InvalidTicketTitle",
+			InvalidTicketDescription:   "InvalidTicketDescription",
+			ExpiredTicketTitle:         "ExpiredTicketTitle",
+			ExpiredTicketDescription:   "ExpiredTicketDescription",
+			AlreadyUsedTitle:           "AlreadyUsedTitle",
+			AlreadyUsedDescription:     "AlreadyUsedDescription",
+			AlreadyEnrolledDescription: "AlreadyEnrolledDescription",
+			GenericError:               "GenericError",
+		},
+		MfaLoginOptions: ScreenMfaLoginOptions{
+			PageTitle:                          "PageTitle",
+			BackText:                           "BackText",
+			Title:                              "Title",
+			AuthenticatorNamesSMS:              "AuthenticatorNamesSMS",
+			AuthenticatorNamesPhone:            "AuthenticatorNamesPhone",
+			AuthenticatorNamesVoice:            "AuthenticatorNamesVoice",
+			AuthenticatorNamesPushNotification: "AuthenticatorNamesPushNotification",
+			AuthenticatorNamesEmail:            "AuthenticatorNamesEmail",
+			AuthenticatorNamesRecoveryCode:     "AuthenticatorNamesRecoveryCode",
+			AuthenticatorNamesDUO:              "AuthenticatorNamesDUO",
+			AuthenticatorNamesWebauthnRoaming:  "AuthenticatorNamesWebauthnRoaming",
+			//In online documentation but not supported
+			// AuthenticatorNamesWebauthnPlatform: "authenticatorNamesWebauthnPlatform",
+		},
+		MfaBeginEnrollOptions: ScreenMfaBeginEnrollOptions{
+			PageTitle:                          "PageTitle",
+			BackText:                           "BackText",
+			Title:                              "Title",
+			Description:                        "Description",
+			LogoAltText:                        "LogoAltText",
+			AuthenticatorNamesSms:              "AuthenticatorNamesSms",
+			AuthenticatorNamesVoice:            "AuthenticatorNamesVoice",
+			AuthenticatorNamesPhone:            "AuthenticatorNamesPhone",
+			AuthenticatorNamesPushNotification: "AuthenticatorNamesPushNotification",
+			AuthenticatorNamesOtp:              "AuthenticatorNamesOtp",
+			AuthenticatorNamesEmail:            "AuthenticatorNamesEmail",
+			AuthenticatorNamesRecoveryCode:     "AuthenticatorNamesRecoveryCode",
+			AuthenticatorNamesDUO:              "AuthenticatorNamesDUO",
+			AuthenticatorNamesWebauthnRoaming:  "AuthenticatorNamesWebauthnRoaming",
+			//In online documentation but not supported
+			// AuthenticatorNamesWebauthnPlatform: "authenticatorNamesWebauthnPlatform",
+		},
+	}
+
+	err = m.CustomText.SetMfa(Language, &SetVal)
+	if err != nil {
+		t.Error(err)
+	}
+
+	ReturnVal, err := m.CustomText.ReadMfa(Language)
+	if err != nil {
+		t.Error(err)
+	}
+	expect.Expect(t, *ReturnVal, SetVal)
+}
+
+func TestMfaEmailCustomText(t *testing.T) {
+	StartVal, err := m.CustomText.ReadMfaEmail(Language)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Cleanup(func() {
+		err = m.CustomText.SetMfaEmail(Language, StartVal)
+		if err != nil {
+			// cleanup fails if StartVal is empty object
+			fmt.Printf("Warning, Set-StartVal failed: %q", err)
+		} else {
+			ReturnVal, err := m.CustomText.ReadMfaEmail(Language)
+			if err != nil {
+				t.Fatal(err)
+			}
+			expect.Expect(t, ReturnVal, StartVal)
+		}
+	})
+
+	SetVal := PromptMfaEmail{
+		MfaEmailChallenge: ScreenMfaEmailChallenge{
+			PageTitle:                           "PageTitle",
+			BackText:                            "BackText",
+			ButtonText:                          "ButtonText",
+			Description:                         "Description",
+			PickAuthenticatorText:               "PickAuthenticatorText",
+			Placeholder:                         "Placeholder",
+			RememberMeText:                      "RememberMeText",
+			ResendActionText:                    "ResendActionText",
+			ResendText:                          "ResendActionText",
+			Title:                               "Title",
+			InvalidOtpCodeFormat:                "InvalidOtpCodeFormat",
+			InvalidCode:                         "InvalidCode",
+			InvalidExpiredCode:                  "InvalidExpiredCode",
+			AuthenticatorError:                  "AuthenticatorError",
+			NoTransactionInProgress:             "NoTransactionInProgress",
+			TooManyEmail:                        "TooManyEmail",
+			TransactionNotFound:                 "TransactionNotFound",
+			MfaEmailChallengeAuthenticatorError: "MfaEmailChallengeAuthenticatorError",
+		},
+		MfaEmailList: ScreenMfaEmailList{
+			PageTitle: "PageTitle",
+			BackText:  "BackText",
+			Title:     "Title",
+		},
+	}
+
+	err = m.CustomText.SetMfaEmail(Language, &SetVal)
+	if err != nil {
+		t.Error(err)
+	}
+
+	ReturnVal, err := m.CustomText.ReadMfaEmail(Language)
+	if err != nil {
+		t.Error(err)
+	}
+	expect.Expect(t, *ReturnVal, SetVal)
+}
+
+func TestMfaOtpCustomText(t *testing.T) {
+	StartVal, err := m.CustomText.ReadMfaOtp(Language)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Cleanup(func() {
+		err = m.CustomText.SetMfaOtp(Language, StartVal)
+		if err != nil {
+			// cleanup fails if StartVal is empty object
+			fmt.Printf("Warning, Set-StartVal failed: %q", err)
+		} else {
+			ReturnVal, err := m.CustomText.ReadMfaOtp(Language)
+			if err != nil {
+				t.Fatal(err)
+			}
+			expect.Expect(t, ReturnVal, StartVal)
+		}
+	})
+
+	SetVal := PromptMfaOtp{
+		MfaOtpEnrollmentQr: ScreenMfaOtpEnrollmentQr{
+			PageTitle:             "PageTitle",
+			Title:                 "Title",
+			Description:           "Description",
+			ButtonText:            "ButtonText",
+			CodeEnrollmentText:    "CodeEnrollmentText",
+			PickAuthenticatorText: "PickAuthenticatorText",
+			Placeholder:           "Placeholder",
+			//Documented but not supported
+			//SeparatorText: "SeparatorText",
+			InvalidOtpCodeFormat: "InvalidOtpCodeFormat",
+			InvalidCode:          "InvalidCode",
+			InvalidExpiredCode:   "InvalidExpiredCode",
+			TooManyFailures:      "TooManyFailures",
+			TransactionNotFound:  "TransactionNotFound",
+			UserAlreadyEnrolled:  "UserAlreadyEnrolled",
+		},
+		MfaOtpEnrollmentCode: ScreenMfaOtpEnrollmentCode{
+			PageTitle:             "PageTitle",
+			BackText:              "BackText",
+			ButtonText:            "ButtonText",
+			AltText:               "AltText",
+			CopyCodeButtonText:    "CopyCodeButtonText",
+			Description:           "Description",
+			PickAuthenticatorText: "PickAuthenticatorText",
+			Placeholder:           "Placeholder",
+			Title:                 "Title",
+			TooManyFailures:       "TooManyFailures",
+			TransactionNotFound:   "TransactionNotFound",
+		},
+		MfaOtpEnrollmentChallenge: ScreenMfaOtpEnrollmentChallenge{
+			PageTitle:             "PageTitle",
+			Title:                 "Title",
+			Description:           "Description",
+			ButtonText:            "ButtonText",
+			PickAuthenticatorText: "PickAuthenticatorText",
+			Placeholder:           "Placeholder",
+			RememberMeText:        "RememberMeText",
+			AuthenticatorError:    "AuthenticatorError",
+			TooManyFailures:       "TooManyFailures",
+			TransactionNotFound:   "TransactionNotFound",
+		},
+	}
+
+	err = m.CustomText.SetMfaOtp(Language, &SetVal)
+	if err != nil {
+		t.Error(err)
+	}
+
+	ReturnVal, err := m.CustomText.ReadMfaOtp(Language)
+	if err != nil {
+		t.Error(err)
+	}
+	expect.Expect(t, *ReturnVal, SetVal)
+}
+
+func TestMfaPhoneCustomText(t *testing.T) {
+	StartVal, err := m.CustomText.ReadMfaPhone(Language)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Cleanup(func() {
+		err = m.CustomText.SetMfaPhone(Language, StartVal)
+		if err != nil {
+			// cleanup fails if StartVal is empty object
+			fmt.Printf("Warning, Set-StartVal failed: %q", err)
+		} else {
+			ReturnVal, err := m.CustomText.ReadMfaPhone(Language)
+			if err != nil {
+				t.Fatal(err)
+			}
+			expect.Expect(t, ReturnVal, StartVal)
+		}
+	})
+
+	SetVal := PromptMfaPhone{
+		MfaPhoneChallenge: ScreenMfaPhoneChallenge{
+			PageTitle:             "PageTitle",
+			Title:                 "Title",
+			Description:           "Description",
+			ContinueButtonText:    "ContinueButtonText",
+			SmsButtonText:         "SmsButtonText",
+			VoiceButtonText:       "VoiceButtonText",
+			ChooseMessageTypeText: "ChooseMessageTypeText",
+			PickAuthenticatorText: "PickAuthenticatorText",
+			Placeholder:           "Placeholder",
+			SendSmsFailed:         "SendSmsFailed",
+			SendVoiceFailed:       "SendVoiceFailed",
+			InvalidPhoneFormat:    "InvalidPhoneFormat",
+			TooManySms:            "TooManySms",
+			TooManyVoice:          "TooManyVoice",
+			TransactionNotFound:   "TransactionNotFound",
+			NoPhone:               "NoPhone",
+		},
+		MfaPhoneEnrollment: ScreenMfaPhoneEnrollment{
+			PageTitle:             "PageTitle",
+			Title:                 "Title",
+			Description:           "Description",
+			ContinueButtonText:    "ContinueButtonText",
+			SmsButtonText:         "SmsButtonText",
+			VoiceButtonText:       "VoiceButtonText",
+			ChooseMessageTypeText: "ChooseMessageTypeText",
+			PickAuthenticatorText: "PickAuthenticatorText",
+			Placeholder:           "Placeholder",
+			SendSmsFailed:         "SendSmsFailed",
+			SendVoiceFailed:       "SendVoiceFailed",
+			InvalidPhoneFormat:    "InvalidPhoneFormat",
+			TooManySms:            "TooManySms",
+			TooManyVoice:          "TooManyVoice",
+			TransactionNotFound:   "TransactionNotFound",
+			NoPhone:               "NoPhone",
+		},
+	}
+
+	err = m.CustomText.SetMfaPhone(Language, &SetVal)
+	if err != nil {
+		t.Error(err)
+	}
+
+	ReturnVal, err := m.CustomText.ReadMfaPhone(Language)
+	if err != nil {
+		t.Error(err)
+	}
+	expect.Expect(t, *ReturnVal, SetVal)
+}
+
+func TestMfaPushCustomText(t *testing.T) {
+	StartVal, err := m.CustomText.ReadMfaPush(Language)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Cleanup(func() {
+		err = m.CustomText.SetMfaPush(Language, StartVal)
+		if err != nil {
+			// cleanup fails if StartVal is empty object
+			fmt.Printf("Warning, Set-StartVal failed: %q", err)
+		} else {
+			ReturnVal, err := m.CustomText.ReadMfaPush(Language)
+			if err != nil {
+				t.Fatal(err)
+			}
+			expect.Expect(t, ReturnVal, StartVal)
+		}
+	})
+
+	SetVal := PromptMfaPush{
+		MfaPushWelcome: ScreenMfaPushWelcome{
+			PageTitle:             "PageTitle",
+			Title:                 "Title",
+			Description:           "Description",
+			AndroidButtonText:     "AndroidButtonText",
+			ButtonText:            "ButtonText",
+			IosButtonText:         "IosButtonText",
+			PickAuthenticatorText: "PickAuthenticatorText",
+		},
+		MfaPushEnrollmentQr: ScreenMfaPushEnrollmentQr{
+			PageTitle:                    "PageTitle",
+			Title:                        "Title",
+			Description:                  "Description",
+			PickAuthenticatorText:        "PickAuthenticatorText",
+			ButtonText:                   "ButtonText",
+			EnrollmentTransactionPending: "EnrollmentTransactionPending",
+		},
+		MfaPushChallengePush: ScreenMfaPushChallengePush{
+			PageTitle:   "PageTitle",
+			Title:       "Title",
+			Description: "Description",
+			//Documented but not supported
+			//AwaitingConfirmation: "AwaitingConfirmation",
+			ButtonText:                         "ButtonText",
+			PickAuthenticatorText:              "PickAuthenticatorText",
+			RememberMeText:                     "RememberMeText",
+			ResendActionText:                   "ResendActionText",
+			ResendText:                         "ResendText",
+			EnterOtpCode:                       "EnterOtpCode",
+			SeparatorText:                      "SeparatorText",
+			ChallengeTransactionPending:        "ChallengeTransactionPending",
+			PollingIntervalExceeded:            "PollingIntervalExceeded",
+			TooManyPush:                        "TooManyPush",
+			TransactionNotFound:                "TransactionNotFound",
+			MfaPushVerifyTransactionPending:    "MfaPushVerifyTransactionPending",
+			MfaPushVerifyAuthenticatorError:    "MfaPushVerifyAuthenticatorError",
+			MfaPushChallengeAuthenticatorError: "MfaPushChallengeAuthenticatorError",
+			TransactionRejected:                "TransactionRejected",
+		},
+		MfaPushList: ScreenMfaPushList{
+			PageTitle: "PageTitle",
+			BackText:  "BackText",
+			Title:     "Title",
+		},
+	}
+
+	err = m.CustomText.SetMfaPush(Language, &SetVal)
+	if err != nil {
+		t.Error(err)
+	}
+
+	ReturnVal, err := m.CustomText.ReadMfaPush(Language)
+	if err != nil {
+		t.Error(err)
+	}
+	expect.Expect(t, *ReturnVal, SetVal)
+}
+
+func TestMfaRecoveryCodeCustomText(t *testing.T) {
+	StartVal, err := m.CustomText.ReadMfaRecoveryCode(Language)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Cleanup(func() {
+		err = m.CustomText.SetMfaRecoveryCode(Language, StartVal)
+		if err != nil {
+			// cleanup fails if StartVal is empty object
+			fmt.Printf("Warning, Set-StartVal failed: %q", err)
+		} else {
+			ReturnVal, err := m.CustomText.ReadMfaRecoveryCode(Language)
+			if err != nil {
+				t.Fatal(err)
+			}
+			expect.Expect(t, ReturnVal, StartVal)
+		}
+	})
+
+	SetVal := PromptMfaRecoveryCode{
+		MfaRecoveryCodeEnrollment: ScreenMfaRecoveryCodeEnrollment{
+			PageTitle:          "PageTitle",
+			Title:              "Title",
+			Description:        "Description",
+			AltText:            "AltText",
+			ButtonText:         "ButtonText",
+			CheckboxText:       "CheckboxText",
+			CopyCodeButtonText: "CopyCodeButtonText",
+			NoConfirmation:     "NoConfirmation",
+		},
+		MfaRecoveryCodeChallenge: ScreenMfaRecoveryCodeChallenge{
+			PageTitle:             "PageTitle",
+			Title:                 "Title",
+			Description:           "Description",
+			ButtonText:            "ButtonText",
+			PickAuthenticatorText: "PickAuthenticatorText",
+			Placeholder:           "Placeholder",
+			InvalidCode:           "InvalidCode",
+			InvalidCodeFormat:     "InvalidCodeFormat",
+			InvalidExpiredCode:    "InvalidExpiredCode",
+			AuthenticatorError:    "AuthenticatorError",
+			NoConfirmation:        "NoConfirmation",
+			TooManyFailures:       "TooManyFailures",
+			TransactionNotFound:   "TransactionNotFound",
+		},
+	}
+
+	err = m.CustomText.SetMfaRecoveryCode(Language, &SetVal)
+	if err != nil {
+		t.Error(err)
+	}
+
+	ReturnVal, err := m.CustomText.ReadMfaRecoveryCode(Language)
+	if err != nil {
+		t.Error(err)
+	}
+	expect.Expect(t, *ReturnVal, SetVal)
+}
+
+func TestMfaSmsCustomText(t *testing.T) {
+	StartVal, err := m.CustomText.ReadMfaSms(Language)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Cleanup(func() {
+		err = m.CustomText.SetMfaSms(Language, StartVal)
+		if err != nil {
+			// cleanup fails if StartVal is empty object
+			fmt.Printf("Warning, Set-StartVal failed: %q", err)
+		} else {
+			ReturnVal, err := m.CustomText.ReadMfaSms(Language)
+			if err != nil {
+				t.Fatal(err)
+			}
+			expect.Expect(t, ReturnVal, StartVal)
+		}
+	})
+
+	SetVal := PromptMfaSms{
+		MfaCountryCodes: ScreenMfaCountryCodes{
+			PageTitle: "PageTitle",
+			BackText:  "BackText",
+			Title:     "Title",
+		},
+		MfaSmsEnrollment: ScreenMfaSmsEnrollment{
+			PageTitle:             "PageTitle",
+			Title:                 "Title",
+			Description:           "Description",
+			ButtonText:            "ButtonText",
+			PickAuthenticatorText: "PickAuthenticatorText",
+			Placeholder:           "Placeholder",
+			SendSmsFailed:         "SendSmsFailed",
+			InvalidPhoneFormat:    "InvalidPhoneFormat",
+			InvalidPhone:          "InvalidPhone",
+			TooManySms:            "TooManySms",
+			TransactionNotFound:   "TransactionNotFound",
+			NoPhone:               "NoPhone",
+		},
+		MfaSmsChallenge: ScreenMfaSmsChallenge{
+			PageTitle:                            "PageTitle",
+			Title:                                "Title",
+			Description:                          "Description",
+			ButtonText:                           "ButtonText",
+			EditText:                             "EditText",
+			PickAuthenticatorText:                "PickAuthenticatorText",
+			Placeholder:                          "Placeholder",
+			RememberMeText:                       "RememberMeText",
+			ResendActionText:                     "ResendActionText",
+			ResendText:                           "ResendText",
+			ResendVoiceActionSeparatorTextBefore: "ResendVoiceActionSeparatorTextBefore",
+			ResendVoiceActionText:                "ResendVoiceActionText",
+			ResendVoiceActionSeparatorTextAfter:  "ResendVoiceActionSeparatorTextAfter",
+			InvalidOtpCodeFormat:                 "InvalidOtpCodeFormat",
+			InvalidCode:                          "InvalidCode",
+			InvalidExpiredCode:                   "InvalidExpiredCode",
+			SendSmsFailed:                        "SendSmsFailed",
+			AuthenticatorError:                   "AuthenticatorError",
+			SmsAuthenticatorError:                "SmsAuthenticatorError",
+			NoTransactionInProgress:              "NoTransactionInProgress",
+			TooManyFailures:                      "TooManyFailures",
+			TooManySms:                           "TooManySms",
+			TransactionNotFound:                  "TransactionNotFound",
+		},
+		MfaSmsList: ScreenMfaSmsList{
+			PageTitle: "PageTitle",
+			BackText:  "BackText",
+			Title:     "Title",
+		},
+	}
+
+	err = m.CustomText.SetMfaSms(Language, &SetVal)
+	if err != nil {
+		t.Error(err)
+	}
+
+	ReturnVal, err := m.CustomText.ReadMfaSms(Language)
+	if err != nil {
+		t.Error(err)
+	}
+	expect.Expect(t, *ReturnVal, SetVal)
+}
+
+func TestMfaVoiceCustomText(t *testing.T) {
+	StartVal, err := m.CustomText.ReadMfaVoice(Language)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Cleanup(func() {
+		err = m.CustomText.SetMfaVoice(Language, StartVal)
+		if err != nil {
+			// cleanup fails if StartVal is empty object
+			fmt.Printf("Warning, Set-StartVal failed: %q", err)
+		} else {
+			ReturnVal, err := m.CustomText.ReadMfaVoice(Language)
+			if err != nil {
+				t.Fatal(err)
+			}
+			expect.Expect(t, ReturnVal, StartVal)
+		}
+	})
+
+	SetVal := PromptMfaVoice{
+		MfaVoiceEnrollment: ScreenMfaVoiceEnrollment{
+			PageTitle:             "PageTitle",
+			Title:                 "Title",
+			Description:           "Description",
+			ButtonText:            "ButtonText",
+			PickAuthenticatorText: "PickAuthenticatorText",
+			Placeholder:           "Placeholder",
+			SendSmsFailed:         "SendSmsFailed",
+			InvalidPhoneFormat:    "InvalidPhoneFormat",
+			InvalidPhone:          "InvalidPhone",
+			TooManySms:            "TooManySms",
+			TransactionNotFound:   "TransactionNotFound",
+			NoPhone:               "NoPhone",
+		},
+		MfaVoiceChallenge: ScreenMfaVoiceChallenge{
+			PageTitle:                          "PageTitle",
+			Title:                              "Title",
+			Description:                        "Description",
+			ButtonText:                         "ButtonText",
+			EditText:                           "EditText",
+			PickAuthenticatorText:              "PickAuthenticatorText",
+			Placeholder:                        "Placeholder",
+			RememberMeText:                     "RememberMeText",
+			ResendActionText:                   "ResendActionText",
+			ResendText:                         "ResendText",
+			ResendSmsActionSeparatorTextBefore: "ResendSmsActionSeparatorTextBefore",
+			ResendSmsActionText:                "ResendSmsActionText",
+			ResendSmsActionSeparatorTextAfter:  "ResendSmsActionSeparatorTextAfter",
+			InvalidOtpCodeFormat:               "InvalidOtpCodeFormat",
+			InvalidCode:                        "InvalidCode",
+			InvalidExpiredCode:                 "InvalidExpiredCode",
+			SendVoiceFailed:                    "SendVoiceFailed",
+			AuthenticatorError:                 "AuthenticatorError",
+			VoiceAuthenticatorError:            "VoiceAuthenticatorError",
+			NoTransactionInProgress:            "NoTransactionInProgress",
+			TooManyFailures:                    "TooManyFailures",
+			TooManyVoice:                       "TooManyVoice",
+			TransactionNotFound:                "TransactionNotFound",
+		},
+	}
+
+	err = m.CustomText.SetMfaVoice(Language, &SetVal)
+	if err != nil {
+		t.Error(err)
+	}
+
+	ReturnVal, err := m.CustomText.ReadMfaVoice(Language)
+	if err != nil {
+		t.Error(err)
+	}
+	expect.Expect(t, *ReturnVal, SetVal)
+}
+
+func TestOrganizationsCustomText(t *testing.T) {
+	StartVal, err := m.CustomText.ReadOrganizations(Language)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Cleanup(func() {
+		err = m.CustomText.SetOrganizations(Language, StartVal)
+		if err != nil {
+			// cleanup fails if StartVal is empty object
+			fmt.Printf("Warning, Set-StartVal failed: %q", err)
+		} else {
+			ReturnVal, err := m.CustomText.ReadOrganizations(Language)
+			if err != nil {
+				t.Fatal(err)
+			}
+			expect.Expect(t, ReturnVal, StartVal)
+		}
+	})
+
+	SetVal := PromptOrganizations{
+		OrganizationSelection: ScreenOrganizationSelection{
+			PageTitle:   "PageTitle",
+			Title:       "Title",
+			Description: "Description",
+			ButtonText:  "ButtonText",
+			Placeholder: "Placeholder",
+			//Documented but not supported
+			//ErrorInvalidOrganization: "ErrorInvalidOrganization",
+			LogoAltText: "LogoAltText",
+		},
+	}
+
+	err = m.CustomText.SetOrganizations(Language, &SetVal)
+	if err != nil {
+		t.Error(err)
+	}
+
+	ReturnVal, err := m.CustomText.ReadOrganizations(Language)
+	if err != nil {
+		t.Error(err)
+	}
+	expect.Expect(t, *ReturnVal, SetVal)
+}
+
+func TestResetPasswordCustomText(t *testing.T) {
+	StartVal, err := m.CustomText.ReadResetPassword(Language)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Cleanup(func() {
+		err = m.CustomText.SetResetPassword(Language, StartVal)
+		if err != nil {
+			// cleanup fails if StartVal is empty object
+			fmt.Printf("Warning, Set-StartVal failed: %q", err)
+		} else {
+			ReturnVal, err := m.CustomText.ReadResetPassword(Language)
+			if err != nil {
+				t.Fatal(err)
+			}
+			expect.Expect(t, ReturnVal, StartVal)
+		}
+	})
+
+	SetVal := PromptResetPassword{
+		ResetPasswordRequest: ScreenResetPasswordRequest{
+			PageTitle:               "PageTitle",
+			Title:                   "Title",
+			BackToLoginLinkText:     "BackToLoginLinkText",
+			ButtonText:              "ButtonText",
+			DescriptionEmail:        "DescriptionEmail",
+			DescriptionUsername:     "DescriptionUsername",
+			PlaceholderEmail:        "PlaceholderEmail",
+			PlaceholderUsername:     "PlaceholderUsername",
+			InvalidEmailFormat:      "InvalidEmailFormat",
+			Auth0UsersExpiredTicket: "Auth0UsersExpiredTicket",
+			CustomScriptErrorCode:   "CustomScriptErrorCode",
+			Auth0UsersUsedTicket:    "Auth0UsersUsedTicket",
+			ResetPasswordError:      "ResetPasswordError",
+			TooManyEmail:            "TooManyEmail",
+			TooManyRequests:         "TooManyRequests",
+			NoEmail:                 "NoEmail",
+			NoUsername:              "NoUsername",
+		},
+		ResetPasswordEmail: ScreenResetPasswordEmail{
+			PageTitle:        "PageTitle",
+			Title:            "Title",
+			EmailDescription: "EmailDescription",
+			ResendLinkText:   "ResendLinkText",
+			//Documented but not supported
+			//ResendText:              "ResendText",
+			UsernameDescription: "UsernameDescription",
+		},
+		ResetPassword: ScreenResetPassword{
+			PageTitle:                  "PageTitle",
+			Title:                      "Title",
+			Description:                "Description",
+			ButtonText:                 "ButtonText",
+			PasswordPlaceholder:        "PasswordPlaceholder",
+			ReEnterPasswordPlaceholder: "ReEnterPasswordPlaceholder",
+			PasswordSecurityText:       "PasswordSecurityText",
+			Auth0UsersExpiredTicket:    "Auth0UsersExpiredTicket",
+			CustomScriptErrorCode:      "CustomScriptErrorCode",
+			Auth0UsersUsedTicket:       "Auth0UsersUsedTicket",
+			Auth0UsersValidation:       "Auth0UsersValidation",
+			NoReEnterPassword:          "NoReEnterPassword",
+		},
+		ResetPasswordSuccess: ScreenResetPasswordSuccess{
+			PageTitle:   "PageTitle",
+			EventTitle:  "EventTitle",
+			Description: "Description",
+			ButtonText:  "ButtonText",
+		},
+		ResetPasswordError: ScreenResetPasswordError{
+			PageTitle:               "PageTitle",
+			BackToLoginLinkText:     "BackToLoginLinkText",
+			DescriptionExpired:      "DescriptionExpired",
+			DescriptionGeneric:      "DescriptionGeneric",
+			DescriptionUsed:         "DescriptionUsed",
+			EventTitleExpired:       "EventTitleExpired",
+			EventTitleUsed:          "EventTitleUsed",
+			Auth0UsersExpiredTicket: "Auth0UsersExpiredTicket",
+			CustomScriptErrorCode:   "CustomScriptErrorCode",
+			Auth0UsersUsedTicket:    "Auth0UsersUsedTicket",
+			Auth0UsersValidation:    "Auth0UsersValidation",
+			ResetPasswordError:      "ResetPasswordError",
+		},
+	}
+
+	err = m.CustomText.SetResetPassword(Language, &SetVal)
+	if err != nil {
+		t.Error(err)
+	}
+
+	ReturnVal, err := m.CustomText.ReadResetPassword(Language)
+	if err != nil {
+		t.Error(err)
+	}
+	expect.Expect(t, *ReturnVal, SetVal)
+}
+
+func TestSignupCustomText(t *testing.T) {
+	StartVal, err := m.CustomText.ReadSignup(Language)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Cleanup(func() {
+		err = m.CustomText.SetSignup(Language, StartVal)
+		if err != nil {
+			// cleanup fails if StartVal is empty object
+			fmt.Printf("Warning, Set-StartVal failed: %q", err)
+		} else {
+			ReturnVal, err := m.CustomText.ReadSignup(Language)
+			if err != nil {
+				t.Fatal(err)
+			}
+			expect.Expect(t, ReturnVal, StartVal)
+		}
+	})
+
+	SetVal := PromptSignup{
+		Signup: ScreenSignup{
+			PageTitle:                        "PageTitle",
+			Title:                            "Title",
+			Description:                      "Description",
+			SeparatorText:                    "SeparatorText",
+			ButtonText:                       "ButtonText",
+			EmailPlaceholder:                 "EmailPlaceholder",
+			FederatedConnectionButtonText:    "FederatedConnectionButtonText",
+			LoginActionLinkText:              "LoginActionLinkText",
+			LoginActionText:                  "LoginActionText",
+			PasswordPlaceholder:              "PasswordPlaceholder",
+			UsernamePlaceholder:              "UsernamePlaceholder",
+			EmailInUse:                       "EmailInUse",
+			InvalidEmailFormat:               "InvalidEmailFormat",
+			PasswordTooWeak:                  "PasswordTooWeak",
+			PasswordTooCommon:                "PasswordTooCommon",
+			PasswordPreviouslyUsed:           "PasswordPreviouslyUsed",
+			PasswordMismatch:                 "PasswordMismatch",
+			InvalidUsername:                  "InvalidUsername",
+			InvalidUsernameMaxLength:         "InvalidUsernameMaxLength",
+			InvalidUsernameMinLength:         "InvalidUsernameMinLength",
+			InvalidUsernameInvalidCharacters: "InvalidUsernameInvalidCharacters",
+			InvalidUsernameEmailNotAllowed:   "InvalidUsernameEmailNotAllowed",
+			UsernameTaken:                    "UsernameTaken",
+			CustomScriptErrorCode:            "CustomScriptErrorCode",
+			Auth0UsersValidation:             "Auth0UsersValidation",
+			InvalidConnection:                "InvalidConnection",
+			IpBlocked:                        "IpBlocked",
+			IpSignupBlocked:                  "IpSignupBlocked",
+			NoDbConnection:                   "NoDbConnection",
+			NoEmail:                          "NoEmail",
+			NoPasswordd:                      "NoPasswordd",
+			NoReEnterPassword:                "NoReEnterPassword",
+			NoUsername:                       "NoUsername",
+		},
+	}
+
+	err = m.CustomText.SetSignup(Language, &SetVal)
+	if err != nil {
+		t.Error(err)
+	}
+
+	ReturnVal, err := m.CustomText.ReadSignup(Language)
+	if err != nil {
+		t.Error(err)
+	}
+	expect.Expect(t, *ReturnVal, SetVal)
+}
+
+func TestSignupIdCustomText(t *testing.T) {
+	StartVal, err := m.CustomText.ReadSignupId(Language)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Cleanup(func() {
+		err = m.CustomText.SetSignupId(Language, StartVal)
+		if err != nil {
+			// cleanup fails if StartVal is empty object
+			fmt.Printf("Warning, Set-StartVal failed: %q", err)
+		} else {
+			ReturnVal, err := m.CustomText.ReadSignupId(Language)
+			if err != nil {
+				t.Fatal(err)
+			}
+			expect.Expect(t, ReturnVal, StartVal)
+		}
+	})
+
+	SetVal := PromptSignupId{
+		SignupId: ScreenSignupId{
+			PageTitle:                        "PageTitle",
+			Title:                            "Title",
+			Description:                      "Description",
+			SeparatorText:                    "SeparatorText",
+			ButtonText:                       "ButtonText",
+			EmailPlaceholder:                 "EmailPlaceholder",
+			FederatedConnectionButtonText:    "FederatedConnectionButtonText",
+			LoginActionLinkText:              "LoginActionLinkText",
+			LoginActionText:                  "LoginActionText",
+			PasswordPlaceholder:              "PasswordPlaceholder",
+			PasswordSecurityText:             "PasswordSecurityText",
+			UsernamePlaceholder:              "UsernamePlaceholder",
+			LogoAltText:                      "LogoAltText",
+			EmailInUse:                       "EmailInUse",
+			InvalidEmailFormat:               "InvalidEmailFormat",
+			PasswordTooWeak:                  "PasswordTooWeak",
+			PasswordTooCommon:                "PasswordTooCommon",
+			PasswordPreviouslyUsed:           "PasswordPreviouslyUsed",
+			PasswordMismatch:                 "PasswordMismatch",
+			InvalidUsername:                  "InvalidUsername",
+			InvalidUsernameMaxLength:         "InvalidUsernameMaxLength",
+			InvalidUsernameMinLength:         "InvalidUsernameMinLength",
+			InvalidUsernameInvalidCharacters: "InvalidUsernameInvalidCharacters",
+			InvalidUsernameEmailNotAllowed:   "InvalidUsernameEmailNotAllowed",
+			UsernameTaken:                    "UsernameTaken",
+			CustomScriptErrorCode:            "CustomScriptErrorCode",
+			Auth0UsersValidation:             "Auth0UsersValidation",
+			InvalidConnection:                "InvalidConnection",
+			IpBlocked:                        "IpBlocked",
+			IpSignupBlocked:                  "IpSignupBlocked",
+			NoDbConnection:                   "NoDbConnection",
+			NoEmail:                          "NoEmail",
+			NoPassword:                       "NoPassword",
+			NoReEnterPassword:                "NoReEnterPassword",
+			NoUsername:                       "NoUsername",
+		},
+	}
+
+	err = m.CustomText.SetSignupId(Language, &SetVal)
+	if err != nil {
+		t.Error(err)
+	}
+
+	ReturnVal, err := m.CustomText.ReadSignupId(Language)
+	if err != nil {
+		t.Error(err)
+	}
+	expect.Expect(t, *ReturnVal, SetVal)
+}
+
+func TestSignupPasswordCustomText(t *testing.T) {
+	StartVal, err := m.CustomText.ReadSignupPassword(Language)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Cleanup(func() {
+		err = m.CustomText.SetSignupPassword(Language, StartVal)
+		if err != nil {
+			// cleanup fails if StartVal is empty object
+			fmt.Printf("Warning, Set-StartVal failed: %q", err)
+		} else {
+			ReturnVal, err := m.CustomText.ReadSignupPassword(Language)
+			if err != nil {
+				t.Fatal(err)
+			}
+			expect.Expect(t, ReturnVal, StartVal)
+		}
+	})
+
+	SetVal := PromptSignupPassword{
+		SignupPassword: ScreenSignupPassword{
+			PageTitle:                     "PageTitle",
+			Title:                         "Title",
+			Description:                   "Description",
+			SeparatorText:                 "SeparatorText",
+			ButtonText:                    "ButtonText",
+			EmailPlaceholder:              "EmailPlaceholder",
+			FederatedConnectionButtonText: "FederatedConnectionButtonText",
+			LoginActionLinkText:           "LoginActionLinkText",
+			LoginActionText:               "LoginActionText",
+			//Documented but not supported
+			//LoginLinkText: "LoginLinkText",
+			InvitationTitle:                  "InvitationTitle",
+			InvitationDescription:            "InvitationDescription",
+			PasswordPlaceholder:              "PasswordPlaceholder",
+			PasswordSecurityText:             "PasswordSecurityText",
+			UsernamePlaceholder:              "UsernamePlaceholder",
+			EmailInUse:                       "EmailInUse",
+			InvalidEmailFormat:               "InvalidEmailFormat",
+			PasswordTooWeak:                  "PasswordTooWeak",
+			PasswordTooCommon:                "PasswordTooCommon",
+			PasswordPreviouslyUsed:           "PasswordPreviouslyUsed",
+			PasswordMismatch:                 "PasswordMismatch",
+			InvalidUsername:                  "InvalidUsername",
+			InvalidUsernameMaxLength:         "InvalidUsernameMaxLength",
+			InvalidUsernameMinLength:         "InvalidUsernameMinLength",
+			InvalidUsernameInvalidCharacters: "InvalidUsernameInvalidCharacters",
+			InvalidUsernameEmailNotAllowed:   "InvalidUsernameEmailNotAllowed",
+			UsernameTaken:                    "UsernameTaken",
+			CustomScriptErrorCode:            "CustomScriptErrorCode",
+			Auth0UsersValidation:             "Auth0UsersValidation",
+			InvalidConnection:                "InvalidConnection",
+			IpBlocked:                        "IpBlocked",
+			IpSignupBlocked:                  "IpSignupBlocked",
+			NoDbConnection:                   "NoDbConnection",
+			NoEmail:                          "NoEmail",
+			NoPassword:                       "NoPassword",
+			NoReEnterPassword:                "NoReEnterPassword",
+			NoUsername:                       "NoUsername",
+			LogoAltText:                      "LogoAltText",
+		},
+	}
+
+	err = m.CustomText.SetSignupPassword(Language, &SetVal)
+	if err != nil {
+		t.Error(err)
+	}
+
+	ReturnVal, err := m.CustomText.ReadSignupPassword(Language)
+	if err != nil {
+		t.Error(err)
+	}
+	expect.Expect(t, *ReturnVal, SetVal)
 }

--- a/management/prompt_test.go
+++ b/management/prompt_test.go
@@ -1,7 +1,6 @@
 package management
 
 import (
-	"fmt"
 	"gopkg.in/auth0.v5"
 	"gopkg.in/auth0.v5/internal/testing/expect"
 	"testing"
@@ -70,8 +69,7 @@ func TestConsentCustomText(t *testing.T) {
 	t.Cleanup(func() {
 		err = m.CustomText.SetConsent(Language, StartVal)
 		if err != nil {
-			// fails if StartVal is empty object
-			fmt.Printf("Warning, Set-StartVal failed: %q", err)
+			t.Fatal(err)
 		}
 		ReturnVal, err := m.CustomText.ReadConsent(Language)
 		if err != nil {
@@ -81,7 +79,7 @@ func TestConsentCustomText(t *testing.T) {
 	})
 
 	SetVal := PromptConsent{
-		Consent: ScreenConsent{
+		Consent: &ScreenConsent{
 			PageTitle:              "PageTitle",
 			Title:                  "Title",
 			MessageMultipleTenants: "MessageMultipleTenants",
@@ -116,19 +114,17 @@ func TestDeviceFlowCustomText(t *testing.T) {
 	t.Cleanup(func() {
 		err = m.CustomText.SetDeviceFlow(Language, StartVal)
 		if err != nil {
-			// cleanup fails if StartVal is empty object
-			fmt.Printf("Warning, Set-StartVal failed: %q", err)
-		} else {
-			ReturnVal, err := m.CustomText.ReadDeviceFlow(Language)
-			if err != nil {
-				t.Fatal(err)
-			}
-			expect.Expect(t, ReturnVal, StartVal)
+			t.Fatal(err)
 		}
+		ReturnVal, err := m.CustomText.ReadDeviceFlow(Language)
+		if err != nil {
+			t.Fatal(err)
+		}
+		expect.Expect(t, ReturnVal, StartVal)
 	})
 
 	SetVal := PromptDeviceFlow{
-		DeviceCodeActivation: ScreenDeviceCodeActivation{
+		DeviceCodeActivation: &ScreenDeviceCodeActivation{
 			PageTitle:          "PageTitle",
 			ButtonText:         "ButtonText",
 			Description:        "Description",
@@ -138,17 +134,17 @@ func TestDeviceFlowCustomText(t *testing.T) {
 			NoCode:             "NoCode",
 			InvalidCode:        "InvalidCode",
 		},
-		DeviceCodeActivationAllowed: ScreenDeviceCodeActivationAllowed{
+		DeviceCodeActivationAllowed: &ScreenDeviceCodeActivationAllowed{
 			PageTitle:   "PageTitle",
 			Description: "Description",
 			EventTitle:  "EventTitle",
 		},
-		DeviceCodeActivationDenied: ScreenDeviceCodeActivationDenied{
+		DeviceCodeActivationDenied: &ScreenDeviceCodeActivationDenied{
 			PageTitle:   "PageTitle",
 			Description: "Description",
 			EventTitle:  "EventTitle",
 		},
-		DeviceCodeConfirmation: ScreenDeviceCodeConfirmation{
+		DeviceCodeConfirmation: &ScreenDeviceCodeConfirmation{
 			PageTitle:         "PageTitle",
 			Description:       "Description",
 			InputCodeLabel:    "InputCodeLabel",
@@ -180,19 +176,17 @@ func TestEmailOtpChallengeCustomText(t *testing.T) {
 	t.Cleanup(func() {
 		err = m.CustomText.SetEmailOtpChallenge(Language, StartVal)
 		if err != nil {
-			// cleanup fails if StartVal is empty object
-			fmt.Printf("Warning, Set-StartVal failed: %q", err)
-		} else {
-			ReturnVal, err := m.CustomText.ReadEmailOtpChallenge(Language)
-			if err != nil {
-				t.Fatal(err)
-			}
-			expect.Expect(t, ReturnVal, StartVal)
+			t.Fatal(err)
 		}
+		ReturnVal, err := m.CustomText.ReadEmailOtpChallenge(Language)
+		if err != nil {
+			t.Fatal(err)
+		}
+		expect.Expect(t, ReturnVal, StartVal)
 	})
 
 	SetVal := PromptEmailOtpChallenge{
-		EmailOtpChallenge: ScreenEmailOtpChallenge{
+		EmailOtpChallenge: &ScreenEmailOtpChallenge{
 			PageTitle:            "PageTitle",
 			ButtonText:           "ButtonText",
 			Description:          "Description",
@@ -229,19 +223,17 @@ func TestEmailVerificationCustomText(t *testing.T) {
 	t.Cleanup(func() {
 		err = m.CustomText.SetEmailVerification(Language, StartVal)
 		if err != nil {
-			// cleanup fails if StartVal is empty object
-			fmt.Printf("Warning, Set-StartVal failed: %q", err)
-		} else {
-			ReturnVal, err := m.CustomText.ReadEmailVerification(Language)
-			if err != nil {
-				t.Fatal(err)
-			}
-			expect.Expect(t, ReturnVal, StartVal)
+			t.Fatal(err)
 		}
+		ReturnVal, err := m.CustomText.ReadEmailVerification(Language)
+		if err != nil {
+			t.Fatal(err)
+		}
+		expect.Expect(t, ReturnVal, StartVal)
 	})
 
 	SetVal := PromptEmailVerification{
-		EmailVerificationResult: ScreenEmailVerificationResult{
+		EmailVerificationResult: &ScreenEmailVerificationResult{
 			PageTitle:                       "PageTitle",
 			VerifiedTitle:                   "VerifiedTitle",
 			ErrorTitle:                      "ErrorTitle",
@@ -278,19 +270,17 @@ func TestInvitationCustomText(t *testing.T) {
 	t.Cleanup(func() {
 		err = m.CustomText.SetInvitation(Language, StartVal)
 		if err != nil {
-			// cleanup fails if StartVal is empty object
-			fmt.Printf("Warning, Set-StartVal failed: %q", err)
-		} else {
-			ReturnVal, err := m.CustomText.ReadInvitation(Language)
-			if err != nil {
-				t.Fatal(err)
-			}
-			expect.Expect(t, ReturnVal, StartVal)
+			t.Fatal(err)
 		}
+		ReturnVal, err := m.CustomText.ReadInvitation(Language)
+		if err != nil {
+			t.Fatal(err)
+		}
+		expect.Expect(t, ReturnVal, StartVal)
 	})
 
 	SetVal := PromptInvitation{
-		AcceptInvitation: ScreenAcceptInvitation{
+		AcceptInvitation: &ScreenAcceptInvitation{
 			PageTitle:   "PageTitle",
 			Title:       "Title",
 			Description: "Description",
@@ -320,19 +310,17 @@ func TestLoginCustomText(t *testing.T) {
 	t.Cleanup(func() {
 		err = m.CustomText.SetLogin(Language, StartVal)
 		if err != nil {
-			// cleanup fails if StartVal is empty object
-			fmt.Printf("Warning, Set-StartVal failed: %q", err)
-		} else {
-			ReturnVal, err := m.CustomText.ReadLogin(Language)
-			if err != nil {
-				t.Fatal(err)
-			}
-			expect.Expect(t, ReturnVal, StartVal)
+			t.Fatal(err)
 		}
+		ReturnVal, err := m.CustomText.ReadLogin(Language)
+		if err != nil {
+			t.Fatal(err)
+		}
+		expect.Expect(t, ReturnVal, StartVal)
 	})
 
 	SetVal := PromptLogin{
-		Login: ScreenLogin{
+		Login: &ScreenLogin{
 			PageTitle:                     "PageTitle",
 			Title:                         "Title",
 			Description:                   "Description",
@@ -395,19 +383,17 @@ func TestLoginIdCustomText(t *testing.T) {
 	t.Cleanup(func() {
 		err = m.CustomText.SetLoginId(Language, StartVal)
 		if err != nil {
-			// cleanup fails if StartVal is empty object
-			fmt.Printf("Warning, Set-StartVal failed: %q", err)
-		} else {
-			ReturnVal, err := m.CustomText.ReadLoginId(Language)
-			if err != nil {
-				t.Fatal(err)
-			}
-			expect.Expect(t, ReturnVal, StartVal)
+			t.Fatal(err)
 		}
+		ReturnVal, err := m.CustomText.ReadLoginId(Language)
+		if err != nil {
+			t.Fatal(err)
+		}
+		expect.Expect(t, ReturnVal, StartVal)
 	})
 
 	SetVal := PromptLoginId{
-		LoginId: ScreenLoginId{
+		LoginId: &ScreenLoginId{
 			PageTitle:                     "PageTitle",
 			Title:                         "Title",
 			Description:                   "Description",
@@ -464,19 +450,17 @@ func TestLoginPasswordCustomText(t *testing.T) {
 	t.Cleanup(func() {
 		err = m.CustomText.SetLoginPassword(Language, StartVal)
 		if err != nil {
-			// cleanup fails if StartVal is empty object
-			fmt.Printf("Warning, Set-StartVal failed: %q", err)
-		} else {
-			ReturnVal, err := m.CustomText.ReadLoginPassword(Language)
-			if err != nil {
-				t.Fatal(err)
-			}
-			expect.Expect(t, ReturnVal, StartVal)
+			t.Fatal(err)
 		}
+		ReturnVal, err := m.CustomText.ReadLoginPassword(Language)
+		if err != nil {
+			t.Fatal(err)
+		}
+		expect.Expect(t, ReturnVal, StartVal)
 	})
 
 	SetVal := PromptLoginPassword{
-		LoginPassword: ScreenLoginPassword{
+		LoginPassword: &ScreenLoginPassword{
 			PageTitle:                     "PageTitle",
 			Title:                         "Title",
 			Description:                   "Description",
@@ -532,19 +516,17 @@ func TestLoginEmailVerificationCustomText(t *testing.T) {
 	t.Cleanup(func() {
 		err = m.CustomText.SetLoginEmailVerification(Language, StartVal)
 		if err != nil {
-			// cleanup fails if StartVal is empty object
-			fmt.Printf("Warning, Set-StartVal failed: %q", err)
-		} else {
-			ReturnVal, err := m.CustomText.ReadLoginEmailVerification(Language)
-			if err != nil {
-				t.Fatal(err)
-			}
-			expect.Expect(t, ReturnVal, StartVal)
+			t.Fatal(err)
 		}
+		ReturnVal, err := m.CustomText.ReadLoginEmailVerification(Language)
+		if err != nil {
+			t.Fatal(err)
+		}
+		expect.Expect(t, ReturnVal, StartVal)
 	})
 
 	SetVal := PromptLoginEmailVerification{
-		LoginEmailVerification: ScreenLoginEmailVerification{
+		LoginEmailVerification: &ScreenLoginEmailVerification{
 			PageTitle:            "PageTitle",
 			ButtonText:           "ButtonText",
 			Description:          "Description",
@@ -581,19 +563,17 @@ func TestMfaCustomText(t *testing.T) {
 	t.Cleanup(func() {
 		err = m.CustomText.SetMfa(Language, StartVal)
 		if err != nil {
-			// cleanup fails if StartVal is empty object
-			fmt.Printf("Warning, Set-StartVal failed: %q", err)
-		} else {
-			ReturnVal, err := m.CustomText.ReadMfa(Language)
-			if err != nil {
-				t.Fatal(err)
-			}
-			expect.Expect(t, ReturnVal, StartVal)
+			t.Fatal(err)
 		}
+		ReturnVal, err := m.CustomText.ReadMfa(Language)
+		if err != nil {
+			t.Fatal(err)
+		}
+		expect.Expect(t, ReturnVal, StartVal)
 	})
 
 	SetVal := PromptMfa{
-		MfaEnrollResult: ScreenMfaEnrollResult{
+		MfaEnrollResult: &ScreenMfaEnrollResult{
 			PageTitle:                  "PageTitle",
 			EnrolledTitle:              "EnrolledTitle",
 			EnrolledDescription:        "EnrolledDescription",
@@ -606,7 +586,7 @@ func TestMfaCustomText(t *testing.T) {
 			AlreadyEnrolledDescription: "AlreadyEnrolledDescription",
 			GenericError:               "GenericError",
 		},
-		MfaLoginOptions: ScreenMfaLoginOptions{
+		MfaLoginOptions: &ScreenMfaLoginOptions{
 			PageTitle:                          "PageTitle",
 			BackText:                           "BackText",
 			Title:                              "Title",
@@ -621,7 +601,7 @@ func TestMfaCustomText(t *testing.T) {
 			//In online documentation but not supported
 			// AuthenticatorNamesWebauthnPlatform: "authenticatorNamesWebauthnPlatform",
 		},
-		MfaBeginEnrollOptions: ScreenMfaBeginEnrollOptions{
+		MfaBeginEnrollOptions: &ScreenMfaBeginEnrollOptions{
 			PageTitle:                          "PageTitle",
 			BackText:                           "BackText",
 			Title:                              "Title",
@@ -662,19 +642,17 @@ func TestMfaEmailCustomText(t *testing.T) {
 	t.Cleanup(func() {
 		err = m.CustomText.SetMfaEmail(Language, StartVal)
 		if err != nil {
-			// cleanup fails if StartVal is empty object
-			fmt.Printf("Warning, Set-StartVal failed: %q", err)
-		} else {
-			ReturnVal, err := m.CustomText.ReadMfaEmail(Language)
-			if err != nil {
-				t.Fatal(err)
-			}
-			expect.Expect(t, ReturnVal, StartVal)
+			t.Fatal(err)
 		}
+		ReturnVal, err := m.CustomText.ReadMfaEmail(Language)
+		if err != nil {
+			t.Fatal(err)
+		}
+		expect.Expect(t, ReturnVal, StartVal)
 	})
 
 	SetVal := PromptMfaEmail{
-		MfaEmailChallenge: ScreenMfaEmailChallenge{
+		MfaEmailChallenge: &ScreenMfaEmailChallenge{
 			PageTitle:                           "PageTitle",
 			BackText:                            "BackText",
 			ButtonText:                          "ButtonText",
@@ -694,7 +672,7 @@ func TestMfaEmailCustomText(t *testing.T) {
 			TransactionNotFound:                 "TransactionNotFound",
 			MfaEmailChallengeAuthenticatorError: "MfaEmailChallengeAuthenticatorError",
 		},
-		MfaEmailList: ScreenMfaEmailList{
+		MfaEmailList: &ScreenMfaEmailList{
 			PageTitle: "PageTitle",
 			BackText:  "BackText",
 			Title:     "Title",
@@ -722,19 +700,17 @@ func TestMfaOtpCustomText(t *testing.T) {
 	t.Cleanup(func() {
 		err = m.CustomText.SetMfaOtp(Language, StartVal)
 		if err != nil {
-			// cleanup fails if StartVal is empty object
-			fmt.Printf("Warning, Set-StartVal failed: %q", err)
-		} else {
-			ReturnVal, err := m.CustomText.ReadMfaOtp(Language)
-			if err != nil {
-				t.Fatal(err)
-			}
-			expect.Expect(t, ReturnVal, StartVal)
+			t.Fatal(err)
 		}
+		ReturnVal, err := m.CustomText.ReadMfaOtp(Language)
+		if err != nil {
+			t.Fatal(err)
+		}
+		expect.Expect(t, ReturnVal, StartVal)
 	})
 
 	SetVal := PromptMfaOtp{
-		MfaOtpEnrollmentQr: ScreenMfaOtpEnrollmentQr{
+		MfaOtpEnrollmentQr: &ScreenMfaOtpEnrollmentQr{
 			PageTitle:             "PageTitle",
 			Title:                 "Title",
 			Description:           "Description",
@@ -751,7 +727,7 @@ func TestMfaOtpCustomText(t *testing.T) {
 			TransactionNotFound:  "TransactionNotFound",
 			UserAlreadyEnrolled:  "UserAlreadyEnrolled",
 		},
-		MfaOtpEnrollmentCode: ScreenMfaOtpEnrollmentCode{
+		MfaOtpEnrollmentCode: &ScreenMfaOtpEnrollmentCode{
 			PageTitle:             "PageTitle",
 			BackText:              "BackText",
 			ButtonText:            "ButtonText",
@@ -764,7 +740,7 @@ func TestMfaOtpCustomText(t *testing.T) {
 			TooManyFailures:       "TooManyFailures",
 			TransactionNotFound:   "TransactionNotFound",
 		},
-		MfaOtpEnrollmentChallenge: ScreenMfaOtpEnrollmentChallenge{
+		MfaOtpEnrollmentChallenge: &ScreenMfaOtpEnrollmentChallenge{
 			PageTitle:             "PageTitle",
 			Title:                 "Title",
 			Description:           "Description",
@@ -799,19 +775,17 @@ func TestMfaPhoneCustomText(t *testing.T) {
 	t.Cleanup(func() {
 		err = m.CustomText.SetMfaPhone(Language, StartVal)
 		if err != nil {
-			// cleanup fails if StartVal is empty object
-			fmt.Printf("Warning, Set-StartVal failed: %q", err)
-		} else {
-			ReturnVal, err := m.CustomText.ReadMfaPhone(Language)
-			if err != nil {
-				t.Fatal(err)
-			}
-			expect.Expect(t, ReturnVal, StartVal)
+			t.Fatal(err)
 		}
+		ReturnVal, err := m.CustomText.ReadMfaPhone(Language)
+		if err != nil {
+			t.Fatal(err)
+		}
+		expect.Expect(t, ReturnVal, StartVal)
 	})
 
 	SetVal := PromptMfaPhone{
-		MfaPhoneChallenge: ScreenMfaPhoneChallenge{
+		MfaPhoneChallenge: &ScreenMfaPhoneChallenge{
 			PageTitle:             "PageTitle",
 			Title:                 "Title",
 			Description:           "Description",
@@ -829,7 +803,7 @@ func TestMfaPhoneCustomText(t *testing.T) {
 			TransactionNotFound:   "TransactionNotFound",
 			NoPhone:               "NoPhone",
 		},
-		MfaPhoneEnrollment: ScreenMfaPhoneEnrollment{
+		MfaPhoneEnrollment: &ScreenMfaPhoneEnrollment{
 			PageTitle:             "PageTitle",
 			Title:                 "Title",
 			Description:           "Description",
@@ -870,19 +844,17 @@ func TestMfaPushCustomText(t *testing.T) {
 	t.Cleanup(func() {
 		err = m.CustomText.SetMfaPush(Language, StartVal)
 		if err != nil {
-			// cleanup fails if StartVal is empty object
-			fmt.Printf("Warning, Set-StartVal failed: %q", err)
-		} else {
-			ReturnVal, err := m.CustomText.ReadMfaPush(Language)
-			if err != nil {
-				t.Fatal(err)
-			}
-			expect.Expect(t, ReturnVal, StartVal)
+			t.Fatal(err)
 		}
+		ReturnVal, err := m.CustomText.ReadMfaPush(Language)
+		if err != nil {
+			t.Fatal(err)
+		}
+		expect.Expect(t, ReturnVal, StartVal)
 	})
 
 	SetVal := PromptMfaPush{
-		MfaPushWelcome: ScreenMfaPushWelcome{
+		MfaPushWelcome: &ScreenMfaPushWelcome{
 			PageTitle:             "PageTitle",
 			Title:                 "Title",
 			Description:           "Description",
@@ -891,7 +863,7 @@ func TestMfaPushCustomText(t *testing.T) {
 			IosButtonText:         "IosButtonText",
 			PickAuthenticatorText: "PickAuthenticatorText",
 		},
-		MfaPushEnrollmentQr: ScreenMfaPushEnrollmentQr{
+		MfaPushEnrollmentQr: &ScreenMfaPushEnrollmentQr{
 			PageTitle:                    "PageTitle",
 			Title:                        "Title",
 			Description:                  "Description",
@@ -899,7 +871,7 @@ func TestMfaPushCustomText(t *testing.T) {
 			ButtonText:                   "ButtonText",
 			EnrollmentTransactionPending: "EnrollmentTransactionPending",
 		},
-		MfaPushChallengePush: ScreenMfaPushChallengePush{
+		MfaPushChallengePush: &ScreenMfaPushChallengePush{
 			PageTitle:   "PageTitle",
 			Title:       "Title",
 			Description: "Description",
@@ -921,7 +893,7 @@ func TestMfaPushCustomText(t *testing.T) {
 			MfaPushChallengeAuthenticatorError: "MfaPushChallengeAuthenticatorError",
 			TransactionRejected:                "TransactionRejected",
 		},
-		MfaPushList: ScreenMfaPushList{
+		MfaPushList: &ScreenMfaPushList{
 			PageTitle: "PageTitle",
 			BackText:  "BackText",
 			Title:     "Title",
@@ -949,19 +921,17 @@ func TestMfaRecoveryCodeCustomText(t *testing.T) {
 	t.Cleanup(func() {
 		err = m.CustomText.SetMfaRecoveryCode(Language, StartVal)
 		if err != nil {
-			// cleanup fails if StartVal is empty object
-			fmt.Printf("Warning, Set-StartVal failed: %q", err)
-		} else {
-			ReturnVal, err := m.CustomText.ReadMfaRecoveryCode(Language)
-			if err != nil {
-				t.Fatal(err)
-			}
-			expect.Expect(t, ReturnVal, StartVal)
+			t.Fatal(err)
 		}
+		ReturnVal, err := m.CustomText.ReadMfaRecoveryCode(Language)
+		if err != nil {
+			t.Fatal(err)
+		}
+		expect.Expect(t, ReturnVal, StartVal)
 	})
 
 	SetVal := PromptMfaRecoveryCode{
-		MfaRecoveryCodeEnrollment: ScreenMfaRecoveryCodeEnrollment{
+		MfaRecoveryCodeEnrollment: &ScreenMfaRecoveryCodeEnrollment{
 			PageTitle:          "PageTitle",
 			Title:              "Title",
 			Description:        "Description",
@@ -971,7 +941,7 @@ func TestMfaRecoveryCodeCustomText(t *testing.T) {
 			CopyCodeButtonText: "CopyCodeButtonText",
 			NoConfirmation:     "NoConfirmation",
 		},
-		MfaRecoveryCodeChallenge: ScreenMfaRecoveryCodeChallenge{
+		MfaRecoveryCodeChallenge: &ScreenMfaRecoveryCodeChallenge{
 			PageTitle:             "PageTitle",
 			Title:                 "Title",
 			Description:           "Description",
@@ -1009,24 +979,22 @@ func TestMfaSmsCustomText(t *testing.T) {
 	t.Cleanup(func() {
 		err = m.CustomText.SetMfaSms(Language, StartVal)
 		if err != nil {
-			// cleanup fails if StartVal is empty object
-			fmt.Printf("Warning, Set-StartVal failed: %q", err)
-		} else {
-			ReturnVal, err := m.CustomText.ReadMfaSms(Language)
-			if err != nil {
-				t.Fatal(err)
-			}
-			expect.Expect(t, ReturnVal, StartVal)
+			t.Fatal(err)
 		}
+		ReturnVal, err := m.CustomText.ReadMfaSms(Language)
+		if err != nil {
+			t.Fatal(err)
+		}
+		expect.Expect(t, ReturnVal, StartVal)
 	})
 
 	SetVal := PromptMfaSms{
-		MfaCountryCodes: ScreenMfaCountryCodes{
+		MfaCountryCodes: &ScreenMfaCountryCodes{
 			PageTitle: "PageTitle",
 			BackText:  "BackText",
 			Title:     "Title",
 		},
-		MfaSmsEnrollment: ScreenMfaSmsEnrollment{
+		MfaSmsEnrollment: &ScreenMfaSmsEnrollment{
 			PageTitle:             "PageTitle",
 			Title:                 "Title",
 			Description:           "Description",
@@ -1040,7 +1008,7 @@ func TestMfaSmsCustomText(t *testing.T) {
 			TransactionNotFound:   "TransactionNotFound",
 			NoPhone:               "NoPhone",
 		},
-		MfaSmsChallenge: ScreenMfaSmsChallenge{
+		MfaSmsChallenge: &ScreenMfaSmsChallenge{
 			PageTitle:                            "PageTitle",
 			Title:                                "Title",
 			Description:                          "Description",
@@ -1065,7 +1033,7 @@ func TestMfaSmsCustomText(t *testing.T) {
 			TooManySms:                           "TooManySms",
 			TransactionNotFound:                  "TransactionNotFound",
 		},
-		MfaSmsList: ScreenMfaSmsList{
+		MfaSmsList: &ScreenMfaSmsList{
 			PageTitle: "PageTitle",
 			BackText:  "BackText",
 			Title:     "Title",
@@ -1093,19 +1061,17 @@ func TestMfaVoiceCustomText(t *testing.T) {
 	t.Cleanup(func() {
 		err = m.CustomText.SetMfaVoice(Language, StartVal)
 		if err != nil {
-			// cleanup fails if StartVal is empty object
-			fmt.Printf("Warning, Set-StartVal failed: %q", err)
-		} else {
-			ReturnVal, err := m.CustomText.ReadMfaVoice(Language)
-			if err != nil {
-				t.Fatal(err)
-			}
-			expect.Expect(t, ReturnVal, StartVal)
+			t.Fatal(err)
 		}
+		ReturnVal, err := m.CustomText.ReadMfaVoice(Language)
+		if err != nil {
+			t.Fatal(err)
+		}
+		expect.Expect(t, ReturnVal, StartVal)
 	})
 
 	SetVal := PromptMfaVoice{
-		MfaVoiceEnrollment: ScreenMfaVoiceEnrollment{
+		MfaVoiceEnrollment: &ScreenMfaVoiceEnrollment{
 			PageTitle:             "PageTitle",
 			Title:                 "Title",
 			Description:           "Description",
@@ -1119,7 +1085,7 @@ func TestMfaVoiceCustomText(t *testing.T) {
 			TransactionNotFound:   "TransactionNotFound",
 			NoPhone:               "NoPhone",
 		},
-		MfaVoiceChallenge: ScreenMfaVoiceChallenge{
+		MfaVoiceChallenge: &ScreenMfaVoiceChallenge{
 			PageTitle:                          "PageTitle",
 			Title:                              "Title",
 			Description:                        "Description",
@@ -1167,19 +1133,17 @@ func TestOrganizationsCustomText(t *testing.T) {
 	t.Cleanup(func() {
 		err = m.CustomText.SetOrganizations(Language, StartVal)
 		if err != nil {
-			// cleanup fails if StartVal is empty object
-			fmt.Printf("Warning, Set-StartVal failed: %q", err)
-		} else {
-			ReturnVal, err := m.CustomText.ReadOrganizations(Language)
-			if err != nil {
-				t.Fatal(err)
-			}
-			expect.Expect(t, ReturnVal, StartVal)
+			t.Fatal(err)
 		}
+		ReturnVal, err := m.CustomText.ReadOrganizations(Language)
+		if err != nil {
+			t.Fatal(err)
+		}
+		expect.Expect(t, ReturnVal, StartVal)
 	})
 
 	SetVal := PromptOrganizations{
-		OrganizationSelection: ScreenOrganizationSelection{
+		OrganizationSelection: &ScreenOrganizationSelection{
 			PageTitle:   "PageTitle",
 			Title:       "Title",
 			Description: "Description",
@@ -1212,19 +1176,17 @@ func TestResetPasswordCustomText(t *testing.T) {
 	t.Cleanup(func() {
 		err = m.CustomText.SetResetPassword(Language, StartVal)
 		if err != nil {
-			// cleanup fails if StartVal is empty object
-			fmt.Printf("Warning, Set-StartVal failed: %q", err)
-		} else {
-			ReturnVal, err := m.CustomText.ReadResetPassword(Language)
-			if err != nil {
-				t.Fatal(err)
-			}
-			expect.Expect(t, ReturnVal, StartVal)
+			t.Fatal(err)
 		}
+		ReturnVal, err := m.CustomText.ReadResetPassword(Language)
+		if err != nil {
+			t.Fatal(err)
+		}
+		expect.Expect(t, ReturnVal, StartVal)
 	})
 
 	SetVal := PromptResetPassword{
-		ResetPasswordRequest: ScreenResetPasswordRequest{
+		ResetPasswordRequest: &ScreenResetPasswordRequest{
 			PageTitle:               "PageTitle",
 			Title:                   "Title",
 			BackToLoginLinkText:     "BackToLoginLinkText",
@@ -1243,7 +1205,7 @@ func TestResetPasswordCustomText(t *testing.T) {
 			NoEmail:                 "NoEmail",
 			NoUsername:              "NoUsername",
 		},
-		ResetPasswordEmail: ScreenResetPasswordEmail{
+		ResetPasswordEmail: &ScreenResetPasswordEmail{
 			PageTitle:        "PageTitle",
 			Title:            "Title",
 			EmailDescription: "EmailDescription",
@@ -1252,7 +1214,7 @@ func TestResetPasswordCustomText(t *testing.T) {
 			//ResendText:              "ResendText",
 			UsernameDescription: "UsernameDescription",
 		},
-		ResetPassword: ScreenResetPassword{
+		ResetPassword: &ScreenResetPassword{
 			PageTitle:                  "PageTitle",
 			Title:                      "Title",
 			Description:                "Description",
@@ -1266,13 +1228,13 @@ func TestResetPasswordCustomText(t *testing.T) {
 			Auth0UsersValidation:       "Auth0UsersValidation",
 			NoReEnterPassword:          "NoReEnterPassword",
 		},
-		ResetPasswordSuccess: ScreenResetPasswordSuccess{
+		ResetPasswordSuccess: &ScreenResetPasswordSuccess{
 			PageTitle:   "PageTitle",
 			EventTitle:  "EventTitle",
 			Description: "Description",
 			ButtonText:  "ButtonText",
 		},
-		ResetPasswordError: ScreenResetPasswordError{
+		ResetPasswordError: &ScreenResetPasswordError{
 			PageTitle:               "PageTitle",
 			BackToLoginLinkText:     "BackToLoginLinkText",
 			DescriptionExpired:      "DescriptionExpired",
@@ -1309,19 +1271,17 @@ func TestSignupCustomText(t *testing.T) {
 	t.Cleanup(func() {
 		err = m.CustomText.SetSignup(Language, StartVal)
 		if err != nil {
-			// cleanup fails if StartVal is empty object
-			fmt.Printf("Warning, Set-StartVal failed: %q", err)
-		} else {
-			ReturnVal, err := m.CustomText.ReadSignup(Language)
-			if err != nil {
-				t.Fatal(err)
-			}
-			expect.Expect(t, ReturnVal, StartVal)
+			t.Fatal(err)
 		}
+		ReturnVal, err := m.CustomText.ReadSignup(Language)
+		if err != nil {
+			t.Fatal(err)
+		}
+		expect.Expect(t, ReturnVal, StartVal)
 	})
 
 	SetVal := PromptSignup{
-		Signup: ScreenSignup{
+		Signup: &ScreenSignup{
 			PageTitle:                        "PageTitle",
 			Title:                            "Title",
 			Description:                      "Description",
@@ -1352,7 +1312,7 @@ func TestSignupCustomText(t *testing.T) {
 			IpSignupBlocked:                  "IpSignupBlocked",
 			NoDbConnection:                   "NoDbConnection",
 			NoEmail:                          "NoEmail",
-			NoPasswordd:                      "NoPasswordd",
+			NoPassword:                       "NoPassword",
 			NoReEnterPassword:                "NoReEnterPassword",
 			NoUsername:                       "NoUsername",
 		},
@@ -1379,19 +1339,17 @@ func TestSignupIdCustomText(t *testing.T) {
 	t.Cleanup(func() {
 		err = m.CustomText.SetSignupId(Language, StartVal)
 		if err != nil {
-			// cleanup fails if StartVal is empty object
-			fmt.Printf("Warning, Set-StartVal failed: %q", err)
-		} else {
-			ReturnVal, err := m.CustomText.ReadSignupId(Language)
-			if err != nil {
-				t.Fatal(err)
-			}
-			expect.Expect(t, ReturnVal, StartVal)
+			t.Fatal(err)
 		}
+		ReturnVal, err := m.CustomText.ReadSignupId(Language)
+		if err != nil {
+			t.Fatal(err)
+		}
+		expect.Expect(t, ReturnVal, StartVal)
 	})
 
 	SetVal := PromptSignupId{
-		SignupId: ScreenSignupId{
+		SignupId: &ScreenSignupId{
 			PageTitle:                        "PageTitle",
 			Title:                            "Title",
 			Description:                      "Description",
@@ -1451,19 +1409,17 @@ func TestSignupPasswordCustomText(t *testing.T) {
 	t.Cleanup(func() {
 		err = m.CustomText.SetSignupPassword(Language, StartVal)
 		if err != nil {
-			// cleanup fails if StartVal is empty object
-			fmt.Printf("Warning, Set-StartVal failed: %q", err)
-		} else {
-			ReturnVal, err := m.CustomText.ReadSignupPassword(Language)
-			if err != nil {
-				t.Fatal(err)
-			}
-			expect.Expect(t, ReturnVal, StartVal)
+			t.Fatal(err)
 		}
+		ReturnVal, err := m.CustomText.ReadSignupPassword(Language)
+		if err != nil {
+			t.Fatal(err)
+		}
+		expect.Expect(t, ReturnVal, StartVal)
 	})
 
 	SetVal := PromptSignupPassword{
-		SignupPassword: ScreenSignupPassword{
+		SignupPassword: &ScreenSignupPassword{
 			PageTitle:                     "PageTitle",
 			Title:                         "Title",
 			Description:                   "Description",


### PR DESCRIPTION
Add support for the https://auth0.com/docs/api/management/v2#!/Prompts/get_custom_text_by_language and https://auth0.com/docs/api/management/v2#!/Prompts/put_custom_text_by_language endpoints in Auth0.

The Get<Prompt>CustomText and Set<Prompt>CustomText methods call the corresponding GET and PUT /api/v2/prompts/{prompt}/custom-text/{language} and endpoints, where <Prompt> is the Camel Case version of the {prompt} id. For example, SetLoginIdCustomText("en") calls /api/v2/login-id/custom_text/en endpoint with the english ("en") language.

The APIs provide unit tests for each Get<Prompt>CustomText and Set<Prompt>CustomText pair using the English language as follows:

- Read StartVal using the Get<Prompt>CustomText method
- Initializes a Cleanup callback to restore StartVal when the test exits.
- Initialize SetVal using a value for each data member in the struct
- Set StartVal using the Set<Prompt>CustomText method
- Read ReturnVal using the Read<Prompt>CustomText method
- Assert that ReturnVal and SetVal are equivalent
- Execute the Cleanup method

The implementation is based on the prompt definitions in https://auth0.com/docs/universal-login/new-experience/text-customization-new-universal-login. When a documented struct data member is not found in the implementation, the struct data member has been commented with the notation "//Documented but not supported".

### Testing

1. install go: https://golang.org/doc/install
2. $ cd auth0/management
3. $ go test -run CustomText

### Proposed Changes

* Change 1
* Change 2

Fixes #0000

#### Acceptance Test Output

```
$ go test ./... -v -run TestUser

...
```

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->