### PR TITLE
Add update method to custom domain manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ The following Auth0 resources are supported:
 - [x] [Jobs](https://auth0.com/docs/api/management/v2#!/Jobs/get_jobs_by_id)
 - [x] [Stats](https://auth0.com/docs/api/management/v2#!/Stats/get_active_users)
 - [x] [Tenants](https://auth0.com/docs/api/management/v2#!/Tenants/get_settings)
-- [ ] [Anomaly](https://auth0.com/docs/api/management/v2#!/Anomaly/get_ips_by_id)
+- [X] [Anomaly](https://auth0.com/docs/api/management/v2#!/Anomaly/get_ips_by_id)
 - [x] [Tickets](https://auth0.com/docs/api/management/v2#!/Tickets/post_email_verification)
 - [x] [Signing Keys](https://auth0.com/docs/api/management/v2#!/Keys/get_signing_keys)
 

--- a/management/custom_domain.go
+++ b/management/custom_domain.go
@@ -24,6 +24,12 @@ type CustomDomain struct {
 	VerificationMethod *string `json:"verification_method,omitempty"`
 
 	Verification *CustomDomainVerification `json:"verification,omitempty"`
+
+	// The TLS version policy. Can be either "compatible" or "recommended".
+	TLSPolicy *string `json:"tls_policy,omitempty"`
+
+	// The HTTP header to fetch the client's IP address
+	CustomClientIPHeader *string `json:"custom_client_ip_header,omitempty"`
 }
 
 type CustomDomainVerification struct {
@@ -48,6 +54,13 @@ func newCustomDomainManager(m *Management) *CustomDomainManager {
 // See: https://auth0.com/docs/api/management/v2#!/Custom_Domains/post_custom_domains
 func (m *CustomDomainManager) Create(c *CustomDomain, opts ...RequestOption) (err error) {
 	return m.Request("POST", m.URI("custom-domains"), c, opts...)
+}
+
+// Update a custom domain.
+//
+// See: https://auth0.com/docs/api/management/v2#!/Custom_Domains/patch_custom_domains_by_id
+func (m *CustomDomainManager) Update(id string, c *CustomDomain, opts ...RequestOption) (err error) {
+	return m.Request("PATCH", m.URI("custom-domains", id), c, opts...)
 }
 
 // Retrieve a custom domain configuration and status.

--- a/management/custom_domain_test.go
+++ b/management/custom_domain_test.go
@@ -34,7 +34,6 @@ func TestCustomDomain(t *testing.T) {
 
 	t.Run("Update", func(t *testing.T) {
 		c.TLSPolicy = auth0.String("compatible")
-		c.CustomClientIPHeader = auth0.String("X-Connecting-IP")
 
 		err = m.CustomDomain.Update(c.GetID(), c)
 		if err != nil {

--- a/management/custom_domain_test.go
+++ b/management/custom_domain_test.go
@@ -11,15 +11,32 @@ import (
 func TestCustomDomain(t *testing.T) {
 
 	c := &CustomDomain{
-		Domain:             auth0.Stringf("%d.auth.uat.alexkappa.com", time.Now().UTC().Unix()),
-		Type:               auth0.String("auth0_managed_certs"),
-		VerificationMethod: auth0.String("txt"),
+		Domain:               auth0.Stringf("%d.auth.uat.alexkappa.com", time.Now().UTC().Unix()),
+		Type:                 auth0.String("auth0_managed_certs"),
+		VerificationMethod:   auth0.String("txt"),
+		TLSPolicy:            auth0.String("recommended"),
+		CustomClientIPHeader: auth0.String("cf-connecting-ip"),
 	}
 
 	var err error
 
 	t.Run("Create", func(t *testing.T) {
 		err = m.CustomDomain.Create(c)
+		if err != nil {
+			if err, ok := err.(Error); ok && err.Status() == http.StatusForbidden {
+				t.Skip(err)
+			} else {
+				t.Error(err)
+			}
+		}
+		t.Logf("%v\n", c)
+	})
+
+	t.Run("Update", func(t *testing.T) {
+		c.TLSPolicy = auth0.String("compatible")
+		c.CustomClientIPHeader = auth0.String("X-Connecting-IP")
+
+		err = m.CustomDomain.Update(c.GetID(), c)
 		if err != nil {
 			if err, ok := err.(Error); ok && err.Status() == http.StatusForbidden {
 				t.Skip(err)

--- a/management/management.gen.go
+++ b/management/management.gen.go
@@ -3407,6 +3407,22 @@ func (c *CustomDomainVerification) String() string {
 	return Stringify(c)
 }
 
+// GetTLSPolicy returns the TLSPolicy field if it's non-nil, zero value otherwise.
+func (c *CustomDomain) GetTLSPolicy() string {
+	if c == nil || c.TLSPolicy == nil {
+		return ""
+	}
+	return *c.TLSPolicy
+}
+
+// GetCustomClientIPHeader returns the CustomClientIPHeader field if it's non-nil, zero value otherwise.
+func (c *CustomDomain) GetCustomClientIPHeader() string {
+	if c == nil || c.CustomClientIPHeader == nil {
+		return ""
+	}
+	return *c.CustomClientIPHeader
+}
+
 // GetCreatedAt returns the CreatedAt field if it's non-nil, zero value otherwise.
 func (d *DailyStat) GetCreatedAt() time.Time {
 	if d == nil || d.CreatedAt == nil {

--- a/management/management.gen.go
+++ b/management/management.gen.go
@@ -3341,6 +3341,14 @@ func (c *CreateEnrollmentTicket) String() string {
 	return Stringify(c)
 }
 
+// GetCustomClientIPHeader returns the CustomClientIPHeader field if it's non-nil, zero value otherwise.
+func (c *CustomDomain) GetCustomClientIPHeader() string {
+	if c == nil || c.CustomClientIPHeader == nil {
+		return ""
+	}
+	return *c.CustomClientIPHeader
+}
+
 // GetDomain returns the Domain field if it's non-nil, zero value otherwise.
 func (c *CustomDomain) GetDomain() string {
 	if c == nil || c.Domain == nil {
@@ -3371,6 +3379,14 @@ func (c *CustomDomain) GetStatus() string {
 		return ""
 	}
 	return *c.Status
+}
+
+// GetTLSPolicy returns the TLSPolicy field if it's non-nil, zero value otherwise.
+func (c *CustomDomain) GetTLSPolicy() string {
+	if c == nil || c.TLSPolicy == nil {
+		return ""
+	}
+	return *c.TLSPolicy
 }
 
 // GetType returns the Type field if it's non-nil, zero value otherwise.
@@ -3405,22 +3421,6 @@ func (c *CustomDomain) String() string {
 // String returns a string representation of CustomDomainVerification.
 func (c *CustomDomainVerification) String() string {
 	return Stringify(c)
-}
-
-// GetTLSPolicy returns the TLSPolicy field if it's non-nil, zero value otherwise.
-func (c *CustomDomain) GetTLSPolicy() string {
-	if c == nil || c.TLSPolicy == nil {
-		return ""
-	}
-	return *c.TLSPolicy
-}
-
-// GetCustomClientIPHeader returns the CustomClientIPHeader field if it's non-nil, zero value otherwise.
-func (c *CustomDomain) GetCustomClientIPHeader() string {
-	if c == nil || c.CustomClientIPHeader == nil {
-		return ""
-	}
-	return *c.CustomClientIPHeader
 }
 
 // GetCreatedAt returns the CreatedAt field if it's non-nil, zero value otherwise.


### PR DESCRIPTION
### Proposed Changes

This PR adds the [update](https://auth0.com/docs/api/management/v2#!/Custom_Domains/patch_custom_domains_by_id) method to the custom domain manager, along with the 2 properties that can be updated:
- TLS policy
- Custom Client IP header

This has been tested manually on a modified Auth0 CLI.

<img width="877" alt="Screen Shot 2021-06-15 at 16 20 54" src="https://user-images.githubusercontent.com/5055789/122132644-971da380-ce11-11eb-949e-0abe74242171.png">

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->