### PR TITLE
Added support for custom prompts

### DIFF
--- a/management/management.gen.go
+++ b/management/management.gen.go
@@ -3373,6 +3373,11 @@ func (c *CustomDomain) GetCustomClientIPHeader() string {
 	return *c.CustomClientIPHeader
 }
 
+// String returns a string representation of ConsentScreens.
+func (c *ConsentScreens) String() string {
+	return Stringify(c)
+}
+
 // GetDomain returns the Domain field if it's non-nil, zero value otherwise.
 func (c *CustomDomain) GetDomain() string {
 	if c == nil || c.Domain == nil {
@@ -3500,6 +3505,11 @@ func (d *DailyStat) String() string {
 	return Stringify(d)
 }
 
+// String returns a string representation of DeviceFlowScreens.
+func (d *DeviceFlowScreens) String() string {
+	return Stringify(d)
+}
+
 // GetCredentials returns the Credentials field.
 func (e *Email) GetCredentials() *EmailCredentials {
 	if e == nil {
@@ -3619,6 +3629,11 @@ func (e *EmailCredentials) GetSMTPUser() string {
 
 // String returns a string representation of EmailCredentials.
 func (e *EmailCredentials) String() string {
+	return Stringify(e)
+}
+
+// String returns a string representation of EmailOtpChallengeScreens.
+func (e *EmailOtpChallengeScreens) String() string {
 	return Stringify(e)
 }
 
@@ -3754,6 +3769,11 @@ func (e *Enrollment) String() string {
 
 // String returns a string representation of EnrollmentTicket.
 func (e *EnrollmentTicket) String() string {
+	return Stringify(e)
+}
+
+// String returns a string representation of EmailVerificationScreens.
+func (e *EmailVerificationScreens) String() string {
 	return Stringify(e)
 }
 
@@ -4056,6 +4076,16 @@ func (l *Log) String() string {
 	return Stringify(l)
 }
 
+// String returns a string representation of LoginEmailVerificationScreens.
+func (l *LoginEmailVerificationScreens) String() string {
+	return Stringify(l)
+}
+
+// String returns a string representation of LoginScreens.
+func (l *LoginScreens) String() string {
+	return Stringify(l)
+}
+
 // GetID returns the ID field if it's non-nil, zero value otherwise.
 func (l *LogStream) GetID() string {
 	if l == nil || l.ID == nil {
@@ -4265,6 +4295,46 @@ func (l *LogStreamSinkSumo) GetSourceAddress() string {
 // String returns a string representation of LogStreamSinkSumo.
 func (l *LogStreamSinkSumo) String() string {
 	return Stringify(l)
+}
+
+// String returns a string representation of MfaEmailScreens.
+func (m *MfaEmailScreens) String() string {
+	return Stringify(m)
+}
+
+// String returns a string representation of MfaOtpScreens.
+func (m *MfaOtpScreens) String() string {
+	return Stringify(m)
+}
+
+// String returns a string representation of MfaPhoneScreens.
+func (m *MfaPhoneScreens) String() string {
+	return Stringify(m)
+}
+
+// String returns a string representation of MfaPushScreens.
+func (m *MfaPushScreens) String() string {
+	return Stringify(m)
+}
+
+// String returns a string representation of MfaRecoveryCodeScreens.
+func (m *MfaRecoveryCodeScreens) String() string {
+	return Stringify(m)
+}
+
+// String returns a string representation of MfaScreens.
+func (m *MfaScreens) String() string {
+	return Stringify(m)
+}
+
+// String returns a string representation of MfaSmsScreens.
+func (m *MfaSmsScreens) String() string {
+	return Stringify(m)
+}
+
+// String returns a string representation of MfaVoiceScreens.
+func (m *MfaVoiceScreens) String() string {
+	return Stringify(m)
 }
 
 // GetEnabled returns the Enabled field if it's non-nil, zero value otherwise.
@@ -4828,6 +4898,16 @@ func (p *Prompt) String() string {
 	return Stringify(p)
 }
 
+// String returns a string representation of PromptCustomText.
+func (p *PromptCustomText) String() string {
+	return Stringify(p)
+}
+
+// String returns a string representation of ResetPasswordScreens.
+func (r *ResetPasswordScreens) String() string {
+	return Stringify(r)
+}
+
 // GetAllowOfflineAccess returns the AllowOfflineAccess field if it's non-nil, zero value otherwise.
 func (r *ResourceServer) GetAllowOfflineAccess() bool {
 	if r == nil || r.AllowOfflineAccess == nil {
@@ -5158,6 +5238,11 @@ func (s *SigningKey) GetThumbprint() string {
 
 // String returns a string representation of SigningKey.
 func (s *SigningKey) String() string {
+	return Stringify(s)
+}
+
+// String returns a string representation of SignupScreens.
+func (s *SignupScreens) String() string {
 	return Stringify(s)
 }
 

--- a/management/prompt.go
+++ b/management/prompt.go
@@ -1,5 +1,28 @@
 package management
 
+import (
+	"encoding/json"
+)
+
+const (
+	PromptConsent = "consent"
+	PromptDeviceFlow = "device-flow"
+	PromptEmailOtpChallengeFlow = "email-otp-challenge"
+	PromptEmailVerificationFlow = "email-verification"
+	PromptLogin = "login"
+	PromptLoginEmailVerification = "login-email-verification"
+	PromptMfa = "mfa"
+	PromptMfaEmail = "mfa-email"
+	PromptMfaOtp = "mfa-otp"
+	PromptMfaPhone = "mfa-phone"
+	PromptMfaPush = "mfa-push"
+	PromptMfaRecoveryCode = "mfa-recovery-code"
+	PromptMfaSms = "mfa-sms"
+	PromptMfaVoice = "mfa-voice"
+	PromptResetPassword = "reset-password"
+	PromptSignup = "signup"
+)
+
 type Prompt struct {
 	// Which login experience to use. Can be `new` or `classic`.
 	UniversalLoginExperience string `json:"universal_login_experience,omitempty"`
@@ -8,12 +31,141 @@ type Prompt struct {
 	IdentifierFirst *bool `json:"identifier_first,omitempty"`
 }
 
+type PromptCustomText struct {
+	Language string `json:"-"`
+	Prompt string `json:"-"`
+	Screens interface{} `json:"-"`
+}
+
 type PromptManager struct {
 	*Management
 }
 
+type ConsentScreens struct {
+	Consent map[string]interface{} `json:"consent,omitempty"`
+}
+type DeviceFlowScreens struct {
+	DeviceCodeActivation map[string]interface{} `json:"device-code-activation,omitempty"`
+	DeviceCodeActivationAllowed map[string]interface{} `json:"device-code-activation-allowed,omitempty"`
+	DeviceCodeActivationDenied map[string]interface{} `json:"device-code-activation-denied,omitempty"`
+	DeviceCodeActivationConfirmation map[string]interface{} `json:"device-code-activation-confirmation,omitempty"`
+}
+type EmailOtpChallengeScreens struct {
+	EmailOtpChallenge map[string]interface{} `json:"email-otp-challenge,omitempty"`
+}
+type EmailVerificationScreens struct {
+	EmailVerificationResult map[string]interface{} `json:"email-verification-result,omitempty"`
+}
+type LoginScreens struct {
+	Login map[string]interface{} `json:"login,omitempty"`
+}
+type LoginEmailVerificationScreens struct {
+	LoginEmailVerification map[string]interface{} `json:"login-email-verification,omitempty"`
+}
+type MfaScreens struct {
+	MfaEnrollResult map[string]interface{} `json:"mfa-enroll-result,omitempty"`
+	MfaLoginOptions map[string]interface{} `json:"mfa-login-options,omitempty"`
+}
+type MfaEmailScreens struct {
+	MfaEmailChallenge map[string]interface{} `json:"mfa-email-challenge,omitempty"`
+	MfaEmailList map[string]interface{} `json:"mfa-email-list,omitempty"`
+}
+type MfaOtpScreens struct {
+	MfaOtpEnrollmentQr map[string]interface{} `json:"mfa-otp-enrollment-qr,omitempty"`
+	MfaOtpEnrollmentCode map[string]interface{} `json:"mfa-otp-enrollment-code,omitempty"`
+	MfaOtpChallenge map[string]interface{} `json:"mfa-otp-challenge,omitempty"`
+}
+type MfaPhoneScreens struct {
+	MfaPhoneChallenge map[string]interface{} `json:"mfa-phone-challenge,omitempty"`
+	MfaPhoneEnrollment map[string]interface{} `json:"mfa-phone-enrollment,omitempty"`
+}
+type MfaPushScreens struct {
+	MfaPushWelcome map[string]interface{} `json:"mfa-push-welcome,omitempty"`
+	MfaPushEnrollmentQr map[string]interface{} `json:"mfa-push-enrollment-qr,omitempty"`
+	MfaPushChallengePush map[string]interface{} `json:"mfa-push-challenge-push,omitempty"`
+	MfaPushChallengeCode map[string]interface{} `json:"mfa-push-challenge-code,omitempty"`
+	MfaPushList map[string]interface{} `json:"mfa-push-list,omitempty"`
+}
+type MfaRecoveryCodeScreens struct {
+	MfaRecoveryCodeEnrollment map[string]interface{} `json:"mfa-recovery-code-enrollment,omitempty"`
+	MfaRecoveryCodeChallenge map[string]interface{} `json:"mfa-recovery-code-challenge,omitempty"`
+}
+type MfaSmsScreens struct {
+	MfaCountryCodes map[string]interface{} `json:"mfa-country-codes,omitempty"`
+	MfaSmsEnrollment map[string]interface{} `json:"mfa-sms-enrollment,omitempty"`
+	MfaSmsChallenge map[string]interface{} `json:"mfa-sms-challenge,omitempty"`
+	MfaSmsList map[string]interface{} `json:"mfa-sms-list,omitempty"`
+}
+type MfaVoiceScreens struct {
+	MfaVoiceEnrollment map[string]interface{} `json:"mfa-voice-enrollment,omitempty"`
+	MfaVoiceChallenge map[string]interface{} `json:"mfa-voice-challenge,omitempty"`
+}
+type ResetPasswordScreens struct {
+	ResetPasswordRequest map[string]interface{} `json:"reset-password-request,omitempty"`
+	ResetPasswordEmail map[string]interface{} `json:"reset-password-email,omitempty"`
+	ResetPassword map[string]interface{} `json:"reset-password,omitempty"`
+	ResetPasswordError map[string]interface{} `json:"reset-password-error,omitempty"`
+}
+type SignupScreens struct {
+	Signup map[string]interface{} `json:"signup,omitempty"`
+}
+
 func newPromptManager(m *Management) *PromptManager {
 	return &PromptManager{m}
+}
+
+func (pct *PromptCustomText) MarshalJSON() ([]byte, error) {
+	return json.Marshal(pct.Screens)
+}
+
+func (pct *PromptCustomText) UnmarshalJSON(b []byte) error {
+	var v interface{}
+
+	switch pct.Prompt {
+	case PromptConsent:
+		v = &ConsentScreens{}
+	case PromptDeviceFlow:
+		v = &DeviceFlowScreens{}
+	case PromptEmailOtpChallengeFlow:
+		v = &EmailOtpChallengeScreens{}
+	case PromptEmailVerificationFlow:
+		v = &EmailVerificationScreens{}
+	case PromptLogin:
+		v = &LoginScreens{}
+	case PromptLoginEmailVerification:
+		v = &LoginEmailVerificationScreens{}
+	case PromptMfa:
+		v = &MfaScreens{}
+	case PromptMfaEmail:
+		v = &MfaEmailScreens{}
+	case PromptMfaOtp:
+		v = &MfaOtpScreens{}
+	case PromptMfaPhone:
+		v = &MfaPhoneScreens{}
+	case PromptMfaPush:
+		v = &MfaPushScreens{}
+	case PromptMfaRecoveryCode:
+		v = &MfaRecoveryCodeScreens{}
+	case PromptMfaSms:
+		v = &MfaSmsScreens{}
+	case PromptMfaVoice:
+		v = &MfaVoiceScreens{}
+	case PromptResetPassword:
+		v = &ResetPasswordScreens{}
+	case PromptSignup:
+		v = &SignupScreens{}
+	default:
+		v = make(map[string]interface{})
+	}
+
+	err := json.Unmarshal(b, &v)
+	if err != nil {
+		return err
+	}
+
+	pct.Screens = v
+
+	return nil
 }
 
 // Read retrieves prompts settings.
@@ -29,4 +181,23 @@ func (m *PromptManager) Read(opts ...RequestOption) (p *Prompt, err error) {
 // See: https://auth0.com/docs/api/management/v2#!/Prompts/patch_prompts
 func (m *PromptManager) Update(p *Prompt, opts ...RequestOption) error {
 	return m.Request("PATCH", m.URI("prompts"), p, opts...)
+}
+
+// ReadCustomText retrieve custom text for a specific prompt and language.
+//
+// See: https://auth0.com/docs/api/management/v2#!/Prompts/get_custom_text_by_language
+func (m *PromptManager) ReadCustomText(prompt string, language string, opts ...RequestOption) (pct *PromptCustomText, err error) {
+	pct = &PromptCustomText{
+		Prompt:   prompt,
+		Language: language,
+	}
+	err = m.Request("GET", m.URI("prompts", prompt, "custom-text", language), &pct, opts...)
+	return
+}
+
+// UpdateCustomText set custom text for a specific prompt. Existing texts will be overwritten.
+//
+// See: https://auth0.com/docs/api/management/v2#!/Prompts/put_custom_text_by_language
+func (m *PromptManager) UpdateCustomText(pct *PromptCustomText, opts ...RequestOption) error {
+	return m.Request("PUT", m.URI("prompts", pct.Prompt, "custom-text", pct.Language), pct, opts...)
 }

--- a/management/prompt_test.go
+++ b/management/prompt_test.go
@@ -7,7 +7,6 @@ import (
 
 	"testing"
 
-	"gopkg.in/auth0.v5/internal/testing/expect"
 )
 
 func TestPrompt(t *testing.T) {

--- a/management/prompt_test.go
+++ b/management/prompt_test.go
@@ -2,8 +2,12 @@ package management
 
 import (
 	"gopkg.in/auth0.v5"
+	"encoding/json"
 	"gopkg.in/auth0.v5/internal/testing/expect"
+
 	"testing"
+
+	"gopkg.in/auth0.v5/internal/testing/expect"
 )
 
 func TestPrompt(t *testing.T) {
@@ -48,4 +52,73 @@ func TestPrompt(t *testing.T) {
 	}
 	expect.Expect(t, ps.UniversalLoginExperience, "classic")
 	expect.Expect(t, ps.IdentifierFirst, auth0.Bool(false))
+}
+
+func TestPromptCustomText(t *testing.T) {
+
+	t.Run("ReadCustomText", func(t *testing.T) {
+		prompts := [16]string{
+			PromptConsent,
+			PromptDeviceFlow,
+			PromptEmailOtpChallengeFlow,
+			PromptEmailVerificationFlow,
+			PromptLogin,
+			PromptLoginEmailVerification,
+			PromptMfa,
+			PromptMfaEmail,
+			PromptMfaOtp,
+			PromptMfaPhone,
+			PromptMfaPush,
+			PromptMfaRecoveryCode,
+			PromptMfaSms,
+			PromptMfaVoice,
+			PromptResetPassword,
+			PromptSignup,
+		}
+		for _, prompt := range prompts {
+			pct, err := m.Prompt.ReadCustomText(prompt, "en")
+			if err != nil {
+				t.Error(err)
+			}
+			expect.Expect(t, pct.Prompt, prompt)
+			expect.Expect(t, pct.Language, "en")
+			b, err := json.Marshal(pct.Screens)
+			if err != nil {
+				t.Error(err)
+			}
+			expect.Expect(t, string(b), "{}")
+			t.Logf("%v\n", pct)
+		}
+	})
+
+	t.Run("UpdateCustomText", func(t *testing.T) {
+		defer m.Prompt.UpdateCustomText(&PromptCustomText{
+			Prompt: PromptConsent,
+			Language: "en",
+			Screens: &ConsentScreens{},
+		})
+
+		err := m.Prompt.UpdateCustomText(&PromptCustomText{
+			Prompt: PromptConsent,
+			Language: "en",
+			Screens: &ConsentScreens{
+				Consent: map[string]interface{}{ "pageTitle": "new page title" },
+			},
+		})
+		if err != nil {
+			t.Error(err)
+		}
+		pct, err := m.Prompt.ReadCustomText(PromptConsent, "en")
+		if err != nil {
+			t.Error(err)
+		}
+		expect.Expect(t, pct.Prompt, PromptConsent)
+		expect.Expect(t, pct.Language, "en")
+		b, err := json.Marshal(pct.Screens)
+		if err != nil {
+			t.Error(err)
+		}
+		expect.Expect(t, string(b), `{"consent":{"pageTitle":"new page title"}}`)
+		t.Logf("%v\n", pct)
+	})
 }


### PR DESCRIPTION
### allow customization of texts in the universal login
https://auth0.com/docs/universal-login/new-experience/text-customization-new-universal-login

The code is copied from the Pull request https://github.com/go-auth0/auth0/pull/163. I have just removed the conflicts. 
The reason is I wanted this functionality in the Terraform Provider and @gagalago has not removed the conflicts.
All the credit for this changes goes to @gagalago 

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->