### PR TITLE
Fix import syntax in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ The Auth0 Management API is meant to be used by back-end servers or trusted part
 
 ```go
 import (
-	gopkg.in/auth0.v5
-	gopkg.in/auth0.v5/management
+	"gopkg.in/auth0.v5"
+	"gopkg.in/auth0.v5/management"
 )
 ```
 


### PR DESCRIPTION
Go requires quotes around import paths. Add some quotes so the example compiles!