### PR TITLE
Adding SAML Signing key connection options supported by Auth0 API, bu…

### DIFF
--- a/management/connection.go
+++ b/management/connection.go
@@ -674,6 +674,7 @@ type ConnectionOptionsSAML struct {
 	Debug              *bool                              `json:"debug,omitempty"`
 	Expires            *string                            `json:"expires,omitempty"`
 	IdpInitiated       *ConnectionOptionsSAMLIdpInitiated `json:"idpinitiated,omitempty"`
+	SigningKey         *ConnectionOptionsSAMLSigningKey   `json:"signing_key,omitempty"`
 	SigningCert        *string                            `json:"signingCert,omitempty"`
 	Thumbprints        []interface{}                      `json:"thumbprints,omitempty"`
 	ProtocolBinding    *string                            `json:"protocolBinding,omitempty"`
@@ -705,6 +706,11 @@ type ConnectionOptionsSAMLIdpInitiated struct {
 
 	SetUserAttributes  *string   `json:"set_user_root_attributes,omitempty"`
 	NonPersistentAttrs *[]string `json:"non_persistent_attrs,omitempty"`
+}
+
+type ConnectionOptionsSAMLSigningKey struct {
+	key   *string `json:"key,omitempty"`
+	cert  *string `json:"cert,omitempty"`
 }
 
 type ConnectionOptionsGoogleApps struct {


### PR DESCRIPTION
### Proposed Changes

When setting up Auth0 connection of type SAML, it does not seem possible to specify the signing_key object.

This is supported by the API as explained here - https://auth0.com/docs/protocols/saml-protocol/saml-configuration-options/sign-and-encrypt-saml-requests#use-custom-certificate-to-sign-requests

```json
"signing_key": {
      "key": "",
      "cert": ""
}
```
Fixes

* Missing configuration

#### Acceptance Test Output

```
$ go test ./... -v -run TestUser
...
```

Ran this, the tests seem to be outdated and are not functioning as suggested in README

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->