### PR TITLE
http.Client wrapper shouldn't overwrite OAuth Transports if already set

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -134,6 +134,10 @@ func Wrap(base *http.Client, tokenSource oauth2.TokenSource, options ...Option) 
 			Source: tokenSource,
 		},
 	}
+	if tr, ok := base.Transport.(*oauth2.Transport); ok {
+		// If the base already has a TokenSource, use that instead.
+		client.Transport = tr
+	}
 	for _, option := range options {
 		option(client)
 	}


### PR DESCRIPTION
### Proposed Changes

* Change 1
* Change 2

Fixes #0000

#### Acceptance Test Output

```
$ go test ./... -v -run TestUser

...
```

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->