### PR TITLE
Fix ext_is_admin option on google-apps conn type

### DIFF
--- a/management/connection.go
+++ b/management/connection.go
@@ -737,7 +737,7 @@ type ConnectionOptionsGoogleApps struct {
 	BasicProfile    *bool `json:"basic_profile,omitempty" scope:"basic_profile"`
 	ExtendedProfile *bool `json:"ext_profile,omitempty" scope:"ext_profile"`
 	Groups          *bool `json:"ext_groups,omitempty" scope:"ext_groups"`
-	Admin           *bool `json:"ext_admin,omitempty" scope:"ext_admin"`
+	Admin           *bool `json:"ext_is_admin,omitempty" scope:"ext_is_admin"`
 	IsSuspended     *bool `json:"ext_is_suspended,omitempty" scope:"ext_is_suspended"`
 	AgreedTerms     *bool `json:"ext_agreed_terms,omitempty" scope:"ext_agreed_terms"`
 

--- a/management/connection_test.go
+++ b/management/connection_test.go
@@ -233,6 +233,7 @@ func TestConnectionOptions(t *testing.T) {
 				BasicProfile:    auth0.Bool(true),
 				ExtendedProfile: auth0.Bool(true),
 				Groups:          auth0.Bool(true),
+				Admin:           auth0.Bool(true),
 			},
 		}
 
@@ -257,8 +258,8 @@ func TestConnectionOptions(t *testing.T) {
 		expect.Expect(t, o.GetBasicProfile(), true)
 		expect.Expect(t, o.GetExtendedProfile(), true)
 		expect.Expect(t, o.GetGroups(), true)
-		expect.Expect(t, o.GetAdmin(), false)
-		expect.Expect(t, o.Scopes(), []string{"basic_profile", "ext_profile", "ext_groups"})
+		expect.Expect(t, o.GetAdmin(), true)
+		expect.Expect(t, o.Scopes(), []string{"basic_profile", "ext_profile", "ext_groups", "ext_is_admin"})
 
 		o.NonPersistentAttrs = &[]string{"gender", "ethnicity", "favorite_color"}
 		err = m.Connection.Update(g.GetID(), &Connection{


### PR DESCRIPTION
### Proposed Changes

It seems the option is actually `ext_is_admin` instead of `ext_admin` for at least google-apps conn types. 

#### Acceptance Test Output

```
$ go test ./... -v -run TestUser
=== RUN   TestConnectionOptions
--- PASS: TestConnectionOptions (2.67s)
=== RUN   TestConnectionOptions/GoogleApps
    --- PASS: TestConnectionOptions/GoogleApps (2.67s)
PASS
...
```

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->