### PR TITLE
Fix expectation in custom sms conn test

### DIFF
--- a/management/connection_test.go
+++ b/management/connection_test.go
@@ -465,7 +465,7 @@ func TestConnectionOptions(t *testing.T) {
 					Length:   auth0.Int(5),
 				},
 				BruteForceProtection: auth0.Bool(true),
-				DisableSignup:        auth0.Bool(false),
+				DisableSignup:        auth0.Bool(true),
 				Name:                 auth0.String("Test-Connection-Custom-SMS"),
 				Provider:             auth0.String("sms_gateway"),
 				GatewayUrl:           auth0.String("https://test.com/sms-gateway"),


### PR DESCRIPTION
### Proposed Changes

This fixes: https://github.com/go-auth0/auth0/runs/4142950052?check_suite_focus=true

#### Acceptance Test Output

```
$ go test ./... -v -run TestUser
=== RUN   TestConnectionOptions
--- PASS: TestConnectionOptions (1.75s)
=== RUN   TestConnectionOptions/CustomSMS
    --- PASS: TestConnectionOptions/CustomSMS (1.75s)
PASS
...
```

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->